### PR TITLE
Fixed update of repositories which allow unauthenticated commits

### DIFF
--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -204,9 +204,9 @@ def _update_target_repositories(repositories, repositories_json, repositories_co
     else:
       repository.fetch(True)
 
-    if allow_unauthenticated and old_head is not None:
-      old_head =  repositories_commits[path][0]
     if old_head is not None:
+      if allow_unauthenticated:
+        old_head = repositories_commits[path][0]
       new_commits_for_repo = repository.all_fetched_commits()
       new_commits_for_repo.insert(0, old_head)
     else:

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -184,6 +184,7 @@ def _update_target_repositories(repositories, repositories_json, repositories_co
   # so that they can be removed if the update fails
   cloned_repositories = []
   for path, repository in repositories.items():
+
     if not repository.is_git_repository_root:
       old_head = None
     else:
@@ -223,11 +224,14 @@ def _update_target_repository(repository, repositories_json, old_head, target_co
   allow_unauthenticated = repositories_json['repositories'][repository.repo_name]. \
                             get('custom', {}).get('allow-unauthenticated-commits', False)
 
-  if old_head is not None:
-    new_commits = repository.all_fetched_commits()
-    new_commits.insert(0, old_head)
+  if not allow_unauthenticated:
+    if old_head is not None:
+      new_commits = repository.all_fetched_commits()
+      new_commits.insert(0, old_head)
+    else:
+      new_commits = repository.all_commits_since_commit(old_head)
   else:
-    new_commits = repository.all_commits_since_commit(old_head)
+    new_commits = repository.all_commits_since_commit(None)
 
   # A new commit might have been pushed after the update process
   # started and before fetch was called

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -100,11 +100,12 @@ def test_valid_update_existing_client_repos(test_name, num_of_commits_to_revert,
   _update_and_check_commit_shas(client_repos, repositories, origin_dir, client_dir)
 
 
-def test_no_update_necessary(updater_repositories, origin_dir, client_dir):
+@pytest.mark.parametrize('test_name', ['test-updater-valid', 'test-updater-allow-unauthenticated-commits'])
+def test_no_update_necessary(test_name, updater_repositories, origin_dir, client_dir):
   # clone the origin repositories
   # revert them to an older commit
-  repositories = updater_repositories['test-updater-valid']
-  origin_dir = origin_dir / 'test-updater-valid'
+  repositories = updater_repositories[test_name]
+  origin_dir = origin_dir / test_name
   client_repos = _clone_client_repositories(repositories, origin_dir, client_dir)
   # create valid last validated commit file
   _create_last_validated_commit(client_dir, client_repos[AUTH_REPO_REL_PATH].head_commit_sha())


### PR DESCRIPTION
The update used to fail when a repository which allows unauthenticated commits had no new commits or only commits which are not registered in the authentication repository.
Testing the case when no update is necessary and one of the target repositories allows unauthenticated commits.