### PR TITLE
Remove new lines from the end of files when adding targets

### DIFF
--- a/taf/utils.py
+++ b/taf/utils.py
@@ -67,18 +67,21 @@ def run(*command, **kwargs):
 
 
 def normalize_file_line_endings(file_path):
-  # replacement strings
-  WINDOWS_LINE_ENDING = b'\r\n'
-  UNIX_LINE_ENDING = b'\n'
-  with open(file_path, 'rb') as open_file:
+  with open(file_path, 'r') as open_file:
     content = open_file.read()
 
-  replaced_content = content.replace(WINDOWS_LINE_ENDING, UNIX_LINE_ENDING)
-
+  replaced_content = normalize_line_endings(content)
   if replaced_content != content:
-    with open(file_path, 'wb') as open_file:
+    with open(file_path, 'w') as open_file:
       open_file.write(replaced_content)
 
+
+def normalize_line_endings(file_content):
+
+  WINDOWS_LINE_ENDING = '\r\n'
+  UNIX_LINE_ENDING = '\n'
+  replaced_content = file_content.replace(WINDOWS_LINE_ENDING, UNIX_LINE_ENDING).rstrip(UNIX_LINE_ENDING)
+  return replaced_content
 
 def on_rm_error(_func, path, _exc_info):
   """Used by when calling rmtree to ensure that readonly files and folders

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,18 @@
+import pytest
+from taf.utils import normalize_line_endings
+
+def test_normalize_line_ending_extra_lines():
+  test_content = '''This is some text followed by two new lines
+
+
+'''
+  expected_content = 'This is some text followed by two new lines'
+  replaced_content = normalize_line_endings(test_content)
+  assert replaced_content == expected_content
+
+
+def test_normalize_line_ending_no_new_line():
+  test_content = 'This is some text without new line at the end of the file'
+  expected_content = test_content
+  replaced_content = normalize_line_endings(test_content)
+  assert replaced_content == expected_content


### PR DESCRIPTION
Because the updater relies on `git show` which seems to strip the new line at the end of the file, this ensures that all new lines are removed when adding targets. 

Closes #38 