### PR TITLE
Generation of target files, repositories.json fixes and support for ssh urls

### DIFF
--- a/taf/cli.py
+++ b/taf/cli.py
@@ -43,7 +43,7 @@ def add_target_file(repo_path, file_path, targets_key_slot, keystore,
 @click.option('--repo-path', default='repository', help='Location of the repository')
 @click.option('--targets-dir', default='targets', help='Directory where the target '
               'repositories are located')
-@click.option('--namespace', default='', help='Namespace of the target repositories')
+@click.option('--namespace', default=None, help='Namespace of the target repositories')
 def add_target_repos(repo_path, targets_dir, namespace):
   developer_tool.add_target_repos(repo_path, targets_dir, namespace)
 
@@ -108,7 +108,7 @@ def init_repo(repo_path, targets_dir, namespace, targets_rel_dir, keystore,
 @click.option('--repo-path', default='repository', help='Location of the repository')
 @click.option('--targets-dir', default='targets', help='Directory where the target '
               'repositories are located')
-@click.option('--namespace', default='', help='Namespace of the target repositories')
+@click.option('--namespace', default=None, help='Namespace of the target repositories')
 @click.option('--targets-rel-dir', default=None, help=' Directory relative to which urls '
               'of the target repositories are set, if they do not have remote set')
 @click.option('--custom', default=None, help='A dictionary containing custom '

--- a/taf/developer_tool.py
+++ b/taf/developer_tool.py
@@ -28,7 +28,7 @@ from pathlib import Path
 EXPIRATION_INTERVAL = 36500
 YUBIKEY_EXPIRATION_DATE = datetime.datetime.now() + datetime.timedelta(days=EXPIRATION_INTERVAL)
 
-def add_target_repos(repo_path, targets_directory, namespace=''):
+def add_target_repos(repo_path, targets_directory, namespace=None):
   """
   <Purpose>
     Create or update target files by reading the latest commits of the provided target repositories
@@ -42,6 +42,8 @@ def add_target_repos(repo_path, targets_directory, namespace=''):
   """
   repo_path = Path(repo_path).resolve()
   targets_directory = Path(targets_directory).resolve()
+  if namespace is None:
+    namespace = targets_directory.name
   auth_repo_targets_dir = repo_path / TARGETS_DIRECTORY_NAME
   if namespace:
     auth_repo_targets_dir = auth_repo_targets_dir / namespace
@@ -239,7 +241,7 @@ def generate_keys(keystore, roles_key_infos):
                                        password=password)
 
 
-def generate_repositories_json(repo_path, targets_directory, namespace='',
+def generate_repositories_json(repo_path, targets_directory, namespace=None,
                                targets_relative_dir=None, custom_data=None):
   """
   <Purpose>
@@ -254,19 +256,22 @@ def generate_repositories_json(repo_path, targets_directory, namespace='',
     targets_relative_dir:
       Directory relative to which urls of the target repositories are set, if they do not have remote set
   """
+
   custom_data = _read_input_dict(custom_data)
   repositories = {}
 
   repo_path = Path(repo_path).resolve()
   auth_repo_targets_dir = repo_path / TARGETS_DIRECTORY_NAME
   targets_directory = Path(targets_directory).resolve()
+  if namespace is None:
+    namespace = targets_directory.name
   for target_repo_dir in targets_directory.glob('*'):
     if not target_repo_dir.is_dir() or target_repo_dir == repo_path:
       continue
     target_repo = GitRepository(target_repo_dir)
     if not target_repo.is_git_repository:
       continue
-    target_repo_name = target_repo_dir.stem
+    target_repo_name = target_repo_dir.name
     target_repo_namespaced_name = target_repo_name if not namespace else '{}/{}'.format(
         namespace, str(target_repo_name))
     # determine url to specify in initial repositories.json

--- a/taf/git.py
+++ b/taf/git.py
@@ -306,7 +306,7 @@ def _validate_repo_name(repo_name):
                                  'dashes, but got "{}"'.format(repo_name))
 
 
-_url_re = re.compile(
+_http_fttp_url = re.compile(
     r'^(?:http|ftp)s?://'  # http:// or https://
     # domain...
     r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|'
@@ -315,10 +315,14 @@ _url_re = re.compile(
     r'(?::\d+)?'  # optional port
     r'(?:/?|[/?]\S+)$', re.IGNORECASE)
 
+_ssh_url = re.compile(r'((git|ssh|http(s)?)|(git@[\w\.]+))(:(//)?)([\w\.@\:/\-~]+)(\.git)?(/)?')
+
 
 def _validate_url(url):
   """ ensure valid URL """
-  match = _url_re.match(url)
-  if not match:
-    logger.error('Repository URL (%s) is not valid', url)
-    raise InvalidRepositoryError('Repository URL must be a valid URL, but got "{}".'.format(url))
+  for _url_re in [_http_fttp_url, _ssh_url]:
+    match = _url_re.match(url)
+    if match:
+      return
+  logger.error('Repository URL (%s) is not valid', url)
+  raise InvalidRepositoryError('Repository URL must be a valid URL, but got "{}".'.format(url))

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -2,6 +2,7 @@ from taf.git import GitRepository
 from taf.exceptions import InvalidRepositoryError
 import pytest
 
+
 def test_url_validation_valid_urls():
   urls = ['https://github.com/account/repo_name.git',
           'https://github.com/account/repo_name',
@@ -12,6 +13,7 @@ def test_url_validation_valid_urls():
   repo = GitRepository('path', urls)
   for test_url, repo_url in zip(urls, repo.repo_urls):
     assert test_url == repo_url
+
 
 def test_url_invalid_urls():
   urls = ['abc://something.com']

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,0 +1,21 @@
+from taf.git import GitRepository
+from taf.exceptions import InvalidRepositoryError
+import pytest
+
+def test_url_validation_valid_urls():
+  urls = ['https://github.com/account/repo_name.git',
+          'https://github.com/account/repo_name',
+          'http://github.com/account/repo_name.git',
+          'http://github.com/account/repo_name',
+          'git@github.com:openlawlibrary/taf.git',
+          'git@github.com:openlawlibrary/taf']
+  repo = GitRepository('path', urls)
+  for test_url, repo_url in zip(urls, repo.repo_urls):
+    assert test_url == repo_url
+
+def test_url_invalid_urls():
+  urls = ['abc://something.com']
+  with pytest.raises(InvalidRepositoryError):
+    repo = GitRepository('path', urls)
+
+

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -64,8 +64,13 @@ NO_WORKING_MIRRORS = 'Validation of authentication repository auth_repo failed d
 TIMESTAMP_EXPIRED = "Metadata 'timestamp' expired"
 REPLAYED_METADATA = 'ReplayedMetadataError'
 METADATA_CHANGED_BUT_SHOULDNT = 'Metadata file targets.json should be the same at revisions'
-settings.update_from_filesystem = True
 
+
+def setup_module(module):
+  settings.update_from_filesystem = True
+
+def teardown_module(module):
+  settings.update_from_filesystem = False
 
 @fixture(autouse=True)
 def run_around_tests(client_dir):


### PR DESCRIPTION
- If the authentication repository is in the same directory as the target directories, it is skipped. This happens both when adding target repos and when generating `repositories.json`
- Using `pathlib` instead of `os`. Support for relative paths
- Setting default `namespace` value. It should be the same as the name of the directory that contains target repositories.
- Validation of repository's urls does not fail if a url is a valid ssh url
- Added tests for validation of urls

Closes #37 
Closes #39 
Closes #44 