### PR TITLE
Start update from beginning if last validated commit doesn't exist and normalize new lines fix

### DIFF
--- a/taf/updater/handlers.py
+++ b/taf/updater/handlers.py
@@ -152,7 +152,12 @@ class GitUpdater(handlers.MetadataUpdater):
       users_head_sha = None
     else:
       self.users_auth_repo.checkout_branch('master')
-      users_head_sha = self.users_auth_repo.head_commit_sha()
+      if last_validated_commit is not None:
+        users_head_sha = self.users_auth_repo.head_commit_sha()
+      else:
+        # if the user's repository exists, but there is no last_validated_commit
+        # start the update from the beginning
+        users_head_sha = None
 
     if last_validated_commit != users_head_sha:
       # TODO add a flag --force/f which, if provided, should force an automatic revert

--- a/taf/utils.py
+++ b/taf/utils.py
@@ -67,19 +67,18 @@ def run(*command, **kwargs):
 
 
 def normalize_file_line_endings(file_path):
-  with open(file_path, 'r') as open_file:
+  with open(file_path, 'rb') as open_file:
     content = open_file.read()
-
   replaced_content = normalize_line_endings(content)
   if replaced_content != content:
-    with open(file_path, 'w') as open_file:
+    with open(file_path, 'wb') as open_file:
       open_file.write(replaced_content)
 
 
 def normalize_line_endings(file_content):
 
-  WINDOWS_LINE_ENDING = '\r\n'
-  UNIX_LINE_ENDING = '\n'
+  WINDOWS_LINE_ENDING = b'\r\n'
+  UNIX_LINE_ENDING = b'\n'
   replaced_content = file_content.replace(WINDOWS_LINE_ENDING, UNIX_LINE_ENDING).rstrip(UNIX_LINE_ENDING)
   return replaced_content
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -172,10 +172,10 @@ def test_no_last_validated_commit(updater_repositories, origin_dir, client_dir):
   origin_dir = origin_dir / 'test-updater-valid'
   client_repos = _clone_and_revert_client_repositories(repositories, origin_dir,
                                                        client_dir, 3)
-  expected_error = 'Saved last validated commit None does not match the head commit'
-  # try to update without setting the last validated commit
-  _update_invalid_repos_and_check_if_remained_same(client_repos, client_dir,
-                                                   repositories, expected_error)
+
+  # update without setting the last validated commit
+  # update should start from the beginning and be successful
+  _update_and_check_commit_shas(client_repos, repositories, origin_dir, client_dir)
 
 
 def test_invalid_last_validated_commit(updater_repositories, origin_dir, client_dir):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,17 +2,17 @@ import pytest
 from taf.utils import normalize_line_endings
 
 def test_normalize_line_ending_extra_lines():
-  test_content = '''This is some text followed by two new lines
+  test_content = b'''This is some text followed by two new lines
 
 
 '''
-  expected_content = 'This is some text followed by two new lines'
+  expected_content = b'This is some text followed by two new lines'
   replaced_content = normalize_line_endings(test_content)
   assert replaced_content == expected_content
 
 
 def test_normalize_line_ending_no_new_line():
-  test_content = 'This is some text without new line at the end of the file'
+  test_content = b'This is some text without new line at the end of the file'
   expected_content = test_content
   replaced_content = normalize_line_endings(test_content)
   assert replaced_content == expected_content


### PR DESCRIPTION
- Update does not fail if last_validated_commit does not exist. It validates the repositories starting from the beginning
- Normalize line endings fix. It is necessary to read and write files as binary.
- Updated tests

Closes #46 