### PR TITLE
Updated validation of branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- Updated validation of branches ([73])
 - Move tests to the main package ([72])
 - Updated _travis_ script ([69])
 - Remove python 3.6 support ([69])
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+[73]: https://github.com/openlawlibrary/taf/pull/73
 [72]: https://github.com/openlawlibrary/taf/pull/72
 [69]: https://github.com/openlawlibrary/taf/pull/69
 


### PR DESCRIPTION
Updated validation in cases when there are more commits on authentication
repository's branch than on corresponding branches of target repositories.
The missing commits used to be populated with `None` values and validation would
only cover unmerged commits of target repositories.

However, there could initially be more commits on the authentication repository. Also, adding `None` values does not verify that those commits which are supposedly merged are valid. So, validation will now take as many commits from target repositories as there are commits on authentication repository's branch and verify that they all belonged to the appropriate branch at one point.

## Description (e.g. "Related to ...", etc.)

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
