### PR TITLE
Creation and setup of taf repositories enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,17 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
+- Added commands for setting up yubikeys, exporting public keys and adding new signing keys ([79])
+- Created standardized yubikey prompt ([79])
+
 ### Changed
 
 ### Fixed
 
+- Creation of new repositories made more robust ([79])
+
+
+[79]: https://github.com/openlawlibrary/taf/pull/79
 
 ## [0.1.8] - 11/12/2019
 

--- a/docs/testing_notes.md
+++ b/docs/testing_notes.md
@@ -1,0 +1,55 @@
+# Developer tool
+
+## Setting up repositories
+
+### Yubikey flow
+
+1. `taf create_repo --repo-path ./law --keys-description ./data/keys.json --commit-msg "Generated initial metadata"`
+1. `taf update_repos_from_fs --repo-path ./law --targets-dir ./data/targets --namespace test`
+1. `taf generate_repositories_json --repo-path ./law --targets-dir ./data/targets --namespace test --custom data/custom_data.json`
+1. `taf sign_targets --repo-path ./law`
+1. `taf add_signing_key --repo-path ./law --role targets`
+
+### Yubikey + Keystore flow
+
+1. `taf create_repo --repo-path ./law --keys-description ./data/keys.json --commit-msg "Generated initial metadata" --keystore ./data/keystore/`
+1. `taf update_repos_from_fs --repo-path ./law --targets-dir ./data/targets --namespace test`
+1. `taf generate_repositories_json --repo-path ./law --targets-dir ./data/targets --namespace test --custom data/custom_data.json`
+1. `taf sign_targets --repo-path ./law --keystore ./data/keystore/`
+1. `taf add_signing_key --repo-path ./law --role targets`
+
+### keys.json
+
+```
+{
+   "root": {
+     "yubikey": true,
+     "number": 3,
+     "length": 2048,
+     "threshold": 2
+   },
+   "targets": {
+      "yubikey": true,
+      "length": 2048
+   },
+   "snapshot": {},
+   "timestamp": {}
+}
+```
+
+### custom_data.json
+
+```
+{
+    "test/law-xml": {
+        "type": "xml",
+        "allow-unauthenticated-commits": true
+    },
+    "test/law-xml-codified": {
+        "type": "xml-codified"
+    },
+    "test/law-html": {
+        "type": "html"
+    }
+}
+```

--- a/taf/cli.py
+++ b/taf/cli.py
@@ -38,6 +38,14 @@ def add_target_file(repo_path, file_path, keystore, keys_description, scheme):
 
 
 @cli.command()
+@click.option('--repo-path')
+@click.option('--role')
+@click.option('--pub-key-path')
+def add_signing_key(repo_path, role, pub_key_path):
+    developer_tool.add_signing_key(repo_path, role, pub_key_path)
+
+
+@cli.command()
 @click.option('--repo-path', default='repository', help='Location of the repository')
 @click.option('--targets-dir', default='targets', help='Directory where the target '
               'repositories are located')
@@ -86,6 +94,13 @@ def build_auth_repo(repo_path, targets_dir, namespace, targets_rel_dir, keystore
               'is a test authentication repository')
 def create_repo(repo_path, keystore, keys_description, commit_msg, test):
     developer_tool.create_repository(repo_path, keystore, keys_description, commit_msg, test)
+
+
+@cli.command()
+@click.option('--path', help='File where to write the exported public key. Result will be written '
+              'to console if path is not specified')
+def export_yk_pub_key(path):
+    developer_tool.export_yk_public_pem(path)
 
 
 @cli.command()
@@ -167,6 +182,12 @@ def update(url, clients_dir, targets_dir, from_fs):
               'repository from the filesystem')
 def update_named_repo(url, clients_dir, repo_name, targets_dir, from_fs):
     update_named_repository(url, clients_dir, repo_name, targets_dir, from_fs)
+
+
+@cli.command()
+@click.option('--certs-dir', help='Path of the directory where the exported certificate will be saved')
+def setup_signing_yubikey(certs_dir):
+    developer_tool.setup_signing_yubikey(certs_dir)
 
 
 @cli.command()

--- a/taf/developer_tool.py
+++ b/taf/developer_tool.py
@@ -11,12 +11,10 @@ import securesystemslib
 import click
 import tuf.repository_tool
 import securesystemslib.exceptions
-from securesystemslib.exceptions import UnknownKeyError
 from securesystemslib.interface import (
     import_rsa_privatekey_from_file,
     import_rsa_publickey_from_file,
 )
-from tuf.keydb import get_key
 from tuf.repository_tool import (
     METADATA_DIRECTORY_NAME,
     TARGETS_DIRECTORY_NAME,
@@ -31,14 +29,13 @@ from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
 from taf.git import GitRepository
 from taf.log import get_logger
 from taf.repository_tool import Repository, load_role_key
-from taf.utils import get_pin_for
 from taf.exceptions import KeystoreError
 
 logger = get_logger(__name__)
 
 try:
     import taf.yubikey as yk
-except ImportError as e:
+except ImportError:
     logger.warning('"yubikey-manager" is not installed.')
 
 # Yubikey x509 certificate expiration interval

--- a/taf/developer_tool.py
+++ b/taf/developer_tool.py
@@ -17,19 +17,18 @@ from tuf.repository_tool import (
     create_new_repository,
     generate_and_write_rsa_keypair,
     generate_rsa_key,
-    import_rsakey_from_pem,
 )
 
 from taf.auth_repo import AuthenticationRepo
 from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
 from taf.git import GitRepository
 from taf.log import get_logger
-from taf.repository_tool import Repository, load_role_key
+from taf.repository_tool import Repository
 from taf.exceptions import KeystoreError
 from taf.keystore import (
     read_private_key_from_keystore,
     read_public_key_from_keystore,
-    key_cmd_prompt
+    key_cmd_prompt,
 )
 
 logger = get_logger(__name__)
@@ -126,7 +125,9 @@ def _load_signing_keys(
             key_name = f"{role}{num_of_signatures + 1}"
         if load_from_keystore:
             # if loading from keystore, load all keys
-            key = read_private_key_from_keystore(keystore, key_name, role_key_infos, num_of_signatures, scheme)
+            key = read_private_key_from_keystore(
+                keystore, key_name, role_key_infos, num_of_signatures, scheme
+            )
             keys.append(key)
         else:
             if num_of_signatures >= threshold:
@@ -142,7 +143,9 @@ def _load_signing_keys(
                 if is_yubikey is None:
                     is_yubikey = click.confirm(f"Sign {role} using YubiKey(s)?")
                 if is_yubikey:
-                    yk.yubikey_prompt(key_name, role, taf_repo, loaded_yubikeys=loaded_yubikeys)
+                    yk.yubikey_prompt(
+                        key_name, role, taf_repo, loaded_yubikeys=loaded_yubikeys
+                    )
                 else:
                     key = key_cmd_prompt(key_name, role, taf_repo, keys, scheme)
                     keys.append(key)
@@ -285,7 +288,7 @@ def _register_yubikey(yubikeys, role_obj, role_name, key_name, scheme, certs_dir
         )
 
         if not use_existing:
-           key = yk.setup_new_yubikey(serial_num, scheme)
+            key = yk.setup_new_yubikey(serial_num, scheme)
         export_yk_certificate(certs_dir, key)
 
         registered = True

--- a/taf/developer_tool.py
+++ b/taf/developer_tool.py
@@ -701,7 +701,8 @@ def signature_provider(key_id, cert_cn, key, data):  # pylint: disable=W0613
 
 
 def setup_signing_yubikey(certs_dir=None, scheme=DEFAULT_RSA_SIGNATURE_SCHEME):
-    _, serial_num = yk.yubikey_prompt('your new', creating_new_key=True, pin_confirm=True, pin_repeat=True)
+    _, serial_num = yk.yubikey_prompt('new Yubikey', creating_new_key=True, pin_confirm=True, pin_repeat=True,
+                                      prompt_message="Please insert the new Yubikey and press ENTER")
     _setup_new_yubikey(serial_num, certs_dir)
 
 
@@ -714,12 +715,12 @@ def _setup_new_yubikey(serial_num, certs_dir=None, scheme=DEFAULT_RSA_SIGNATURE_
     )
     scheme = DEFAULT_RSA_SIGNATURE_SCHEME
     key = import_rsakey_from_pem(pub_key_pem, scheme)
-    if cert_dir is None:
-        cert_dir = Path.home()
+    if certs_dir is None:
+        certs_dir = Path.home()
     else:
-        cert_dir = Path(cert_dir)
-    cert_dir.mkdir(parents=True, exist_ok=True)
-    cert_path = cert_dir / f"{key['keyid']}.cert"
+        certs_dir = Path(certs_dir)
+    certs_dir.mkdir(parents=True, exist_ok=True)
+    cert_path = certs_dir / f"{key['keyid']}.cert"
     print(f"Exporting certificate to {cert_path}")
     with open(cert_path, "wb") as f:
         f.write(yk.export_piv_x509())

--- a/taf/developer_tool.py
+++ b/taf/developer_tool.py
@@ -285,7 +285,8 @@ def _register_yubikey(yubikeys, role_obj, role_name, key_name, scheme, certs_dir
         )
 
         if not use_existing:
-           key = yk.setup_new_yubikey(serial_num, certs_dir, scheme)
+           key = yk.setup_new_yubikey(serial_num, scheme)
+        export_yk_certificate(certs_dir, key)
 
         registered = True
         # set Yubikey expiration date
@@ -406,6 +407,18 @@ def export_yk_public_pem(path=None):
         parent = path.parent
         parent.mkdir(parents=True, exist_ok=True)
         path.write_text(pub_key_pem)
+
+
+def export_yk_certificate(certs_dir, key):
+    if certs_dir is None:
+        certs_dir = Path.home()
+    else:
+        certs_dir = Path(certs_dir)
+    certs_dir.mkdir(parents=True, exist_ok=True)
+    cert_path = certs_dir / f"{key['keyid']}.cert"
+    print(f"Exporting certificate to {cert_path}")
+    with open(cert_path, "wb") as f:
+        f.write(yk.export_piv_x509())
 
 
 def generate_keys(keystore, roles_key_infos):
@@ -663,7 +676,8 @@ def setup_signing_yubikey(certs_dir=None, scheme=DEFAULT_RSA_SIGNATURE_SCHEME):
         pin_repeat=True,
         prompt_message="Please insert the new Yubikey and press ENTER",
     )
-    yk.setup_new_yubikey(serial_num, certs_dir)
+    key = yk.setup_new_yubikey(serial_num)
+    export_yk_certificate(certs_dir, key)
 
 
 def update_metadata_expiration_date(

--- a/taf/exceptions.py
+++ b/taf/exceptions.py
@@ -46,6 +46,7 @@ class RootMetadataUpdateError(MetadataUpdateError):
 class KeystoreError(TAFError):
     pass
 
+
 class PINMissmatchError(Exception):
     pass
 

--- a/taf/exceptions.py
+++ b/taf/exceptions.py
@@ -25,6 +25,10 @@ class InvalidRepositoryError(TAFError):
     pass
 
 
+class InvalidPINError(TAFError):
+    pass
+
+
 class MetadataUpdateError(TAFError):
     def __init__(self, metadata_role, message):
         super().__init__(

--- a/taf/exceptions.py
+++ b/taf/exceptions.py
@@ -43,6 +43,9 @@ class RootMetadataUpdateError(MetadataUpdateError):
         super().__init__("root", message)
 
 
+class KeystoreError(TAFError):
+    pass
+
 class PINMissmatchError(Exception):
     pass
 

--- a/taf/keystore.py
+++ b/taf/keystore.py
@@ -1,0 +1,101 @@
+import click
+import securesystemslib
+from pathlib import Path
+from taf.exceptions import KeystoreError
+from getpass import getpass
+from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
+from securesystemslib.interface import (
+    import_rsa_privatekey_from_file,
+    import_rsa_publickey_from_file,
+)
+from tuf.repository_tool import import_rsakey_from_pem
+
+
+def _form_private_pem(pem):
+    return f"-----BEGIN RSA PRIVATE KEY-----\n{pem}\n-----END RSA PRIVATE KEY-----"
+
+
+def key_cmd_prompt(key_name, role, taf_repo, loaded_keys=None, scheme=DEFAULT_RSA_SIGNATURE_SCHEME):
+
+    def _enter_and_check_key(key_name, role, loaded_keys, scheme):
+        pem = getpass(f"Enter {key_name} private key without its header and footer\n")
+        pem = _form_private_pem(pem)
+        try:
+            key = import_rsakey_from_pem(pem, scheme)
+        except Exception:
+            print('Invalid key')
+            return None
+        public_key = import_rsakey_from_pem(key['keyval']['public'], scheme)
+        if not taf_repo.is_valid_metadata_yubikey(role, public_key):
+            print(f"The entered key is not a valid {role} key")
+            return None
+        if loaded_keys is not None and key in loaded_keys:
+            print('Key already entered')
+            return None
+        return key
+
+    while True:
+        key =_enter_and_check_key(key_name, role, loaded_keys, scheme)
+        if key is not None:
+            return key
+
+
+def read_private_key_from_keystore(
+    keystore,
+    key_name,
+    roles_key_info=None,
+    key_num=None,
+    scheme=DEFAULT_RSA_SIGNATURE_SCHEME,
+):
+    key_path = Path(keystore, key_name)
+    if not key_path.is_file():
+        raise KeystoreError(f"{str(key_path)} does not exist")
+
+    password = None
+    if roles_key_info is not None:
+        passwords = roles_key_info.get("passwords")
+        if passwords is not None and len(passwords):
+            password = passwords[key_num]
+
+    def _read_key(path, password):
+        if password is None:
+            password = getpass(
+                f"Enter {key_name} keystore file password and press ENTER"
+            )
+        if not password:
+            password = None
+        try:
+            return import_rsa_privatekey_from_file(
+                str(Path(keystore, key_name)), password, scheme=scheme
+            )
+        except (
+            securesystemslib.exceptions.FormatError,
+            securesystemslib.exceptions.Error,
+        ) as e:
+            if "password" in str(e).lower():
+                return None
+            raise KeystoreError(e)
+        except Exception:
+            return None
+
+    while True:
+        key = _read_key(key_path, password)
+        if key is not None:
+            return key
+        if not click.confirm("Could not open keystore file. Try again?"):
+            raise KeystoreError(f"Could not open keystore file {key_path}")
+
+
+def read_public_key_from_keystore(
+    keystore, key_name, scheme=DEFAULT_RSA_SIGNATURE_SCHEME
+):
+    pub_key_path = Path(keystore, f"{key_name}.pub")
+    if not pub_key_path.is_file():
+        raise KeystoreError(f"{str(pub_key_path)} does not exist")
+    try:
+        return import_rsa_publickey_from_file(str(pub_key_path), scheme)
+    except (
+        securesystemslib.exceptions.FormatError,
+        securesystemslib.exceptions.Error,
+    ) as e:
+        raise KeystoreError(e)

--- a/taf/keystore.py
+++ b/taf/keystore.py
@@ -15,27 +15,28 @@ def _form_private_pem(pem):
     return f"-----BEGIN RSA PRIVATE KEY-----\n{pem}\n-----END RSA PRIVATE KEY-----"
 
 
-def key_cmd_prompt(key_name, role, taf_repo, loaded_keys=None, scheme=DEFAULT_RSA_SIGNATURE_SCHEME):
-
+def key_cmd_prompt(
+    key_name, role, taf_repo, loaded_keys=None, scheme=DEFAULT_RSA_SIGNATURE_SCHEME
+):
     def _enter_and_check_key(key_name, role, loaded_keys, scheme):
         pem = getpass(f"Enter {key_name} private key without its header and footer\n")
         pem = _form_private_pem(pem)
         try:
             key = import_rsakey_from_pem(pem, scheme)
         except Exception:
-            print('Invalid key')
+            print("Invalid key")
             return None
-        public_key = import_rsakey_from_pem(key['keyval']['public'], scheme)
+        public_key = import_rsakey_from_pem(key["keyval"]["public"], scheme)
         if not taf_repo.is_valid_metadata_yubikey(role, public_key):
             print(f"The entered key is not a valid {role} key")
             return None
         if loaded_keys is not None and key in loaded_keys:
-            print('Key already entered')
+            print("Key already entered")
             return None
         return key
 
     while True:
-        key =_enter_and_check_key(key_name, role, loaded_keys, scheme)
+        key = _enter_and_check_key(key_name, role, loaded_keys, scheme)
         if key is not None:
             return key
 

--- a/taf/repository_tool.py
+++ b/taf/repository_tool.py
@@ -117,13 +117,14 @@ def root_signature_provider(signature_dict, key_id, _key, _data):
     return {"keyid": key_id, "sig": hexlify(signature_dict.get(key_id)).decode()}
 
 
-def yubikey_signature_provider(name, key_id, key, data): # pylint: disable=W0613
+def yubikey_signature_provider(name, key_id, key, data):  # pylint: disable=W0613
     """
     A signatures provider which asks the user to insert a yubikey
     Useful if several yubikeys need to be used at the same time
     """
     from taf.yubikey import sign_piv_rsa_pkcs1v15, get_piv_public_key_tuf
     from binascii import hexlify
+
     data = securesystemslib.formats.encode_canonical(data).encode("utf-8")
 
     def _check_key_id(expected_key_id):
@@ -361,9 +362,9 @@ class Repository:
             if target_path.is_file():
                 self._add_target(targets_obj, str(target_path), previous_custom)
 
-
     def add_yubikey_external_signature_provider(self, role, name):
         from taf.yubikey import get_piv_public_key_tuf
+
         pub_key = get_piv_public_key_tuf()
         self._role_obj(role).add_external_signature_provider(
             pub_key, partial(yubikey_signature_provider, name, pub_key["keyid"])

--- a/taf/repository_tool.py
+++ b/taf/repository_tool.py
@@ -58,6 +58,8 @@ def load_role_key(keystore, role, password=None, scheme=DEFAULT_RSA_SIGNATURE_SC
         - securesystemslib.exceptions.FormatError: If the arguments are improperly formatted.
         - securesystemslib.exceptions.CryptoError: If path is not a valid encrypted key file.
     """
+    if password == "":
+        password = None
     key = role_keys_cache.get(role)
     if key is None:
         if password is not None:
@@ -394,6 +396,9 @@ class Repository:
         """
         role_obj = self._role_obj(role)
         return role_obj.keys
+
+    def get_role_threshold(self, role):
+        return self._role_obj(role).threshold
 
     def get_signable_metadata(self, role):
         """Return signable portion of newly generate metadata for given role.

--- a/taf/repository_tool.py
+++ b/taf/repository_tool.py
@@ -370,13 +370,6 @@ class Repository:
             if target_path.is_file():
                 self._add_target(targets_obj, str(target_path), previous_custom)
 
-    def add_yubikey_external_signature_provider(self, role, name):
-        from taf.yubikey import get_piv_public_key_tuf
-
-        pub_key = get_piv_public_key_tuf()
-        self._role_obj(role).add_external_signature_provider(
-            pub_key, partial(yubikey_signature_provider, name, pub_key["keyid"])
-        )
 
     def _get_target_repositories(self):
         repositories_path = self.targets_path / "repositories.json"

--- a/taf/repository_tool.py
+++ b/taf/repository_tool.py
@@ -2,7 +2,6 @@ import datetime
 import json
 from functools import partial
 from pathlib import Path
-from getpass import getpass
 
 import securesystemslib
 import tuf.repository_tool
@@ -58,7 +57,7 @@ def load_role_key(keystore, role, password=None, scheme=DEFAULT_RSA_SIGNATURE_SC
         - securesystemslib.exceptions.FormatError: If the arguments are improperly formatted.
         - securesystemslib.exceptions.CryptoError: If path is not a valid encrypted key file.
     """
-    if password == "":
+    if not password:
         password = None
     key = role_keys_cache.get(role)
     if key is None:
@@ -125,7 +124,6 @@ def yubikey_signature_provider(name, key_id, key, data):  # pylint: disable=W061
     Useful if several yubikeys need to be used at the same time
     """
     import taf.yubikey as yk
-    from taf.yubikey import sign_piv_rsa_pkcs1v15, get_piv_public_key_tuf, get_key_pin
     from binascii import hexlify
 
     data = securesystemslib.formats.encode_canonical(data).encode("utf-8")

--- a/taf/repository_tool.py
+++ b/taf/repository_tool.py
@@ -370,7 +370,6 @@ class Repository:
             if target_path.is_file():
                 self._add_target(targets_obj, str(target_path), previous_custom)
 
-
     def _get_target_repositories(self):
         repositories_path = self.targets_path / "repositories.json"
         if repositories_path.exists():

--- a/taf/utils.py
+++ b/taf/utils.py
@@ -160,5 +160,3 @@ def to_tuf_datetime_format(start_date, interval):
     datetime_object = start_date + datetime.timedelta(interval)
     datetime_object = datetime_object.replace(microsecond=0)
     return datetime_object.isoformat() + "Z"
-
-

--- a/taf/utils.py
+++ b/taf/utils.py
@@ -160,3 +160,5 @@ def to_tuf_datetime_format(start_date, interval):
     datetime_object = start_date + datetime.timedelta(interval)
     datetime_object = datetime_object.replace(microsecond=0)
     return datetime_object.isoformat() + "Z"
+
+

--- a/taf/yubikey.py
+++ b/taf/yubikey.py
@@ -312,7 +312,7 @@ def setup(
     )
 
 
-def setup_new_yubikey(serial_num, certs_dir=None, scheme=DEFAULT_RSA_SIGNATURE_SCHEME):
+def setup_new_yubikey(serial_num, scheme=DEFAULT_RSA_SIGNATURE_SCHEME):
     pin = get_key_pin(serial_num)
     cert_cn = input("Enter key holder's name: ")
     print("Generating key, please wait...")
@@ -321,15 +321,6 @@ def setup_new_yubikey(serial_num, certs_dir=None, scheme=DEFAULT_RSA_SIGNATURE_S
     )
     scheme = DEFAULT_RSA_SIGNATURE_SCHEME
     key = import_rsakey_from_pem(pub_key_pem, scheme)
-    if certs_dir is None:
-        certs_dir = Path.home()
-    else:
-        certs_dir = Path(certs_dir)
-    certs_dir.mkdir(parents=True, exist_ok=True)
-    cert_path = certs_dir / f"{key['keyid']}.cert"
-    print(f"Exporting certificate to {cert_path}")
-    with open(cert_path, "wb") as f:
-        f.write(export_piv_x509())
     return key
 
 

--- a/taf/yubikey.py
+++ b/taf/yubikey.py
@@ -326,11 +326,14 @@ def get_and_validate_pin(key_name, pin_confirm=True, pin_repeat=True):
 
 
 def yubikey_prompt(key_name, role=None, taf_repo=None, registering_new_key=False, creating_new_key=False,
-                   loaded_yubikeys=None, pin_confirm=True, pin_repeat=True):
+                   loaded_yubikeys=None, pin_confirm=True, pin_repeat=True, prompt_message=None):
 
     def _read_and_check_yubikey(key_name, role, taf_repo, registering_new_key, creating_new_key,
-                                loaded_yubikeys, pin_confirm, pin_repeat):
-        input(f"Please insert {key_name} YubiKey and press ENTER")
+                                loaded_yubikeys, pin_confirm, pin_repeat, prompt_message):
+
+        if prompt_message is None:
+            prompt_message = f"Please insert {key_name} YubiKey and press ENTER"
+        input(prompt_message)
         # make sure that YubiKey is inserted
         try:
             serial_num = get_serial_num()
@@ -370,6 +373,6 @@ def yubikey_prompt(key_name, role=None, taf_repo=None, registering_new_key=False
 
     while True:
         success, key, serial_num = _read_and_check_yubikey(key_name, role, taf_repo, registering_new_key, creating_new_key,
-                                                           loaded_yubikeys, pin_confirm, pin_repeat)
+                                                           loaded_yubikeys, pin_confirm, pin_repeat, prompt_message)
         if success:
             return key, serial_num

--- a/taf/yubikey.py
+++ b/taf/yubikey.py
@@ -6,7 +6,6 @@ from functools import wraps
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
-from pathlib import Path
 from tuf.repository_tool import import_rsakey_from_pem
 from ykman.descriptor import list_devices, open_device
 from ykman.piv import (
@@ -316,9 +315,7 @@ def setup_new_yubikey(serial_num, scheme=DEFAULT_RSA_SIGNATURE_SCHEME):
     pin = get_key_pin(serial_num)
     cert_cn = input("Enter key holder's name: ")
     print("Generating key, please wait...")
-    pub_key_pem = setup(pin, cert_cn, cert_exp_days=EXPIRATION_INTERVAL).decode(
-        "utf-8"
-    )
+    pub_key_pem = setup(pin, cert_cn, cert_exp_days=EXPIRATION_INTERVAL).decode("utf-8")
     scheme = DEFAULT_RSA_SIGNATURE_SCHEME
     key = import_rsakey_from_pem(pub_key_pem, scheme)
     return key

--- a/taf/yubikey.py
+++ b/taf/yubikey.py
@@ -356,7 +356,7 @@ def yubikey_prompt(
         # make sure that YubiKey is inserted
         try:
             serial_num = get_serial_num()
-        except:
+        except Exception:
             print("YubiKey not inserted")
             return False, None, None
 

--- a/taf/yubikey.py
+++ b/taf/yubikey.py
@@ -335,6 +335,7 @@ def yubikey_prompt(key_name, role=None, taf_repo=None, registering_new_key=False
         try:
             serial_num = get_serial_num()
         except:
+            print("YubiKey not inserted")
             return False, None, None
 
         # check if this key is already loaded as the provided role's key (we can use the same key
@@ -347,10 +348,10 @@ def yubikey_prompt(key_name, role=None, taf_repo=None, registering_new_key=False
         public_key = get_piv_public_key_tuf() if not creating_new_key else None
         # check if this yubikey is can be used for signing the provided role's metadata
         # if the key was already registered as that role's key
-        if not registering_new_key and role is not None and taf_repo is not None and not \
-                taf_repo.is_valid_metadata_yubikey(role, public_key):
-            print(f"The inserted YubiKey is not a valid {role} key")
-            return False, None, None
+        if not registering_new_key and role is not None and taf_repo is not None:
+            if not taf_repo.is_valid_metadata_yubikey(role, public_key):
+                print(f"The inserted YubiKey is not a valid {role} key")
+                return False, None, None
 
         if get_key_pin(serial_num) is None:
             if creating_new_key:

--- a/taf/yubikey.py
+++ b/taf/yubikey.py
@@ -318,18 +318,37 @@ def get_and_validate_pin(key_name, pin_confirm=True, pin_repeat=True):
         pin = get_pin_for(key_name, pin_confirm, pin_repeat)
         valid_pin, retries = is_valid_pin(pin)
         if not valid_pin and not retries:
-            raise InvalidPINError('No retries left. YubiKey locked.')
+            raise InvalidPINError("No retries left. YubiKey locked.")
         if not valid_pin:
-            if not click.confirm(f'Incorrect PIN. Do you want to try again? {retries} retires left.'):
-                raise InvalidPINError('PIN input cancelled')
+            if not click.confirm(
+                f"Incorrect PIN. Do you want to try again? {retries} retires left."
+            ):
+                raise InvalidPINError("PIN input cancelled")
     return pin
 
 
-def yubikey_prompt(key_name, role=None, taf_repo=None, registering_new_key=False, creating_new_key=False,
-                   loaded_yubikeys=None, pin_confirm=True, pin_repeat=True, prompt_message=None):
-
-    def _read_and_check_yubikey(key_name, role, taf_repo, registering_new_key, creating_new_key,
-                                loaded_yubikeys, pin_confirm, pin_repeat, prompt_message):
+def yubikey_prompt(
+    key_name,
+    role=None,
+    taf_repo=None,
+    registering_new_key=False,
+    creating_new_key=False,
+    loaded_yubikeys=None,
+    pin_confirm=True,
+    pin_repeat=True,
+    prompt_message=None,
+):
+    def _read_and_check_yubikey(
+        key_name,
+        role,
+        taf_repo,
+        registering_new_key,
+        creating_new_key,
+        loaded_yubikeys,
+        pin_confirm,
+        pin_repeat,
+        prompt_message,
+    ):
 
         if prompt_message is None:
             prompt_message = f"Please insert {key_name} YubiKey and press ENTER"
@@ -343,8 +362,12 @@ def yubikey_prompt(key_name, role=None, taf_repo=None, registering_new_key=False
 
         # check if this key is already loaded as the provided role's key (we can use the same key
         # to sign different metadata)
-        if loaded_yubikeys is not None and serial_num in loaded_yubikeys and role in loaded_yubikeys[serial_num]:
-            print('Key already loaded')
+        if (
+            loaded_yubikeys is not None
+            and serial_num in loaded_yubikeys
+            and role in loaded_yubikeys[serial_num]
+        ):
+            print("Key already loaded")
             return False, None, None
 
         # read the public key, unless a new key needs to be generated on the yubikey
@@ -372,7 +395,16 @@ def yubikey_prompt(key_name, role=None, taf_repo=None, registering_new_key=False
         return True, public_key, serial_num
 
     while True:
-        success, key, serial_num = _read_and_check_yubikey(key_name, role, taf_repo, registering_new_key, creating_new_key,
-                                                           loaded_yubikeys, pin_confirm, pin_repeat, prompt_message)
+        success, key, serial_num = _read_and_check_yubikey(
+            key_name,
+            role,
+            taf_repo,
+            registering_new_key,
+            creating_new_key,
+            loaded_yubikeys,
+            pin_confirm,
+            pin_repeat,
+            prompt_message,
+        )
         if success:
             return key, serial_num

--- a/taf/yubikey.py
+++ b/taf/yubikey.py
@@ -1,3 +1,4 @@
+import click
 import datetime
 from contextlib import contextmanager
 from functools import wraps
@@ -19,10 +20,23 @@ from ykman.piv import (
 from ykman.util import TRANSPORT
 
 from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
-from taf.exceptions import YubikeyError
+from taf.exceptions import YubikeyError, InvalidPINError
+from taf.utils import get_pin
 
 DEFAULT_PIN = "123456"
 DEFAULT_PUK = "12345678"
+
+
+_pins_dict = {}
+
+
+def add_key_pin(serial_num, pin):
+    global _pins_dict
+    _pins_dict[serial_num] = pin
+
+
+def get_key_pin(serial_num):
+    return _pins_dict.get(serial_num)
 
 
 def raise_yubikey_err(msg=None):
@@ -296,3 +310,63 @@ def setup(
     return pub_key.public_bytes(
         serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
     )
+
+
+def get_and_validate_pin(pin_confirm=True, pin_repeat=True):
+    valid_pin = False
+    while not valid_pin:
+        pin = get_pin(pin_confirm, pin_repeat)
+        valid_pin, retries = is_valid_pin(pin)
+        if not valid_pin and not retries:
+            raise InvalidPINError('No retries left. YubiKey locked.')
+        if not valid_pin:
+            if not click.confirm(f'Incorrect PIN. Do you want to try again? {retries} retires left.'):
+                raise InvalidPINError('PIN input cancelled')
+    return pin
+
+
+def yubikey_prompt(key_name, role, taf_repo=None, registering_new_key=False, creating_new_key=False,
+                   loaded_yubikeys=None, pin_confirm=True, pin_repeat=True):
+
+    def _read_and_check_yubikey(key_name, role, taf_repo, registering_new_key, creating_new_key,
+                                loaded_yubikeys, pin_confirm, pin_repeat):
+        input(f"Please insert {key_name} YubiKey and press ENTER")
+        # make sure that YubiKey is inserted
+        try:
+            serial_num = get_serial_num()
+        except:
+            return None
+
+        # check if this key is already loaded as the provided role's key (we can use the same key
+        # to sign different metadata)
+        if loaded_yubikeys is not None and serial_num in loaded_yubikeys and role in loaded_yubikeys[role]:
+            print('Key already loaded')
+            return None
+
+        public_key = get_piv_public_key_tuf()
+        # check if this yubikey is can be used for signing the provided role's metadata
+        # if the key was already registered as that role's key
+        if not registering_new_key and taf_repo is not None and not \
+                taf_repo.is_valid_metadata_yubikey(role, public_key):
+            print(f"The inserted YubiKey is not a valid {role} key")
+            return None
+
+        if get_key_pin(serial_num) is None:
+            if creating_new_key:
+                pin = get_pin(pin_confirm, pin_repeat)
+            else:
+                pin = get_and_validate_pin(pin_confirm, pin_repeat)
+            add_key_pin(serial_num, pin)
+
+        if loaded_yubikeys is None:
+            loaded_yubikeys = {serial_num: [role]}
+        else:
+            loaded_yubikeys.setdefault(serial_num, []).append(role)
+
+        return public_key
+
+    while True:
+        key = _read_and_check_yubikey(key_name, role, taf_repo, registering_new_key, creating_new_key,
+                                      loaded_yubikeys, pin_confirm, pin_repeat)
+        if key is not None:
+            return key


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

- Added new commands for:
  - setting up a new yubikey
  - exporting a public key from inserted yubikey
  - adding a new signing key (currently assumes that all keys are stored on yubikeys)

- Improved creation of repositories:
  - check keystore before inserting all of yubikeys
  - created standardized yubikey prompt
  -  keep retrying to access the yubikey rather than failing out with an exception (can take a few seconds for computer to recognize yubikey after inserted)
  -  store pins globallyso don't have to keep typing password.
  - made the process more robust
  - added support for mixing keys stored on yubikeys with keys from keystore files

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
