### PR TITLE
Branch exists fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,13 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Fix branch exists git function ([82])
 - Creation of new repositories made more robust ([79])
 
 
+[82]: https://github.com/openlawlibrary/taf/pull/82
 [79]: https://github.com/openlawlibrary/taf/pull/79
+
 
 ## [0.1.8] - 11/12/2019
 

--- a/taf/git.py
+++ b/taf/git.py
@@ -212,12 +212,17 @@ class GitRepository(object):
         a remote branch exists.
         """
         branch = self._git(f"branch --list {branch_name}")
+        # this git command should return the branch's name if it exists
+        # empty string otherwise
         if branch:
             return True
         if include_remotes:
             for remote in self.remotes:
-                branch = self._git(f"branch -r --list origin/{branch_name}")
-                if branch:
+                remote_branch = self._git(f"branch -r --list {remote}/{branch_name}")
+                # this command should return the branch's name if the remote branch
+                # exists
+                # it will also return some warnings if there are problems with some refs
+                if branch_name in remote_branch:
                     return True
         return False
 


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

If there are some problems with refs, git branch -r list return
a warning, regardless of if the branch exists or not. This means that
comparing the returned string with an empty string does not always
work

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
