### PR TITLE
Move safely_get_json and fix clone_or_pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,13 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- Move safely_get_json to base git repository class ([105])
+
 ### Fixed
 
+- Fix `clone_or_pull` ([105])
+
+[105]: https://github.com/openlawlibrary/taf/pull/105
 
 ## [0.3.0] - 03/03/2020
 

--- a/taf/auth_repo.py
+++ b/taf/auth_repo.py
@@ -55,7 +55,7 @@ class AuthRepoMixin(TAFRepository):
             commit = self.head_commit_sha()
         target_path = get_target_path(target_name)
         if safely:
-            return self._safely_get_json(commit, target_path)
+            return self.safely_get_json(commit, target_path)
         else:
             return self.get_json(commit, target_path)
 
@@ -146,7 +146,7 @@ class AuthRepoMixin(TAFRepository):
         for commit in commits:
             # repositories.json might not exit, if the current commit is
             # the initial commit
-            repositories_at_revision = self._safely_get_json(
+            repositories_at_revision = self.safely_get_json(
                 commit, get_target_path("repositories.json")
             )
             if repositories_at_revision is None:
@@ -187,24 +187,6 @@ class AuthRepoMixin(TAFRepository):
                         )
                         continue
         return targets
-
-    def _safely_get_json(self, commit, path):
-        try:
-            return self.get_json(commit, path)
-        except CalledProcessError:
-            taf_logger.info(
-                "Auth repo {}: {} not available at revision {}",
-                self.name,
-                os.path.basename(path),
-                commit,
-            )
-        except json.decoder.JSONDecodeError:
-            taf_logger.info(
-                "Auth repo {}: {} not a valid json at revision {}",
-                self.name,
-                os.path.basename(path),
-                commit,
-            )
 
 
 class AuthenticationRepo(GitRepository, AuthRepoMixin):

--- a/taf/auth_repo.py
+++ b/taf/auth_repo.py
@@ -4,7 +4,6 @@ import tempfile
 from collections import defaultdict
 from contextlib import contextmanager
 from pathlib import Path
-from subprocess import CalledProcessError
 from tuf.repository_tool import METADATA_DIRECTORY_NAME
 from taf.log import taf_logger
 from taf.git import GitRepository, NamedGitRepository

--- a/taf/git.py
+++ b/taf/git.py
@@ -335,7 +335,7 @@ class GitRepository:
             try:
                 for branch in branches:
                     if only_fetch:
-                        self._git("fetch", "origin", branch)
+                        self.git('fetch', 'origin', f'{branch}:{branch}')
                     else:
                         self._git("pull", "origin", branch)
                     taf_logger.info(

--- a/taf/git.py
+++ b/taf/git.py
@@ -335,7 +335,7 @@ class GitRepository:
             try:
                 for branch in branches:
                     if only_fetch:
-                        self.git('fetch', 'origin', f'{branch}:{branch}')
+                        self.git("fetch", "origin", f"{branch}:{branch}")
                     else:
                         self._git("pull", "origin", branch)
                     taf_logger.info(

--- a/taf/git.py
+++ b/taf/git.py
@@ -609,6 +609,24 @@ class GitRepository:
     def reset_to_head(self):
         self._git("reset --hard HEAD")
 
+    def safely_get_json(self, commit, path):
+        try:
+            return self.get_json(commit, path)
+        except subprocess.CalledProcessError:
+            taf_logger.info(
+                "Auth repo {}: {} not available at revision {}",
+                self.name,
+                os.path.basename(path),
+                commit,
+            )
+        except json.decoder.JSONDecodeError:
+            taf_logger.info(
+                "Auth repo {}: {} not a valid json at revision {}",
+                self.name,
+                os.path.basename(path),
+                commit,
+            )
+
     def set_remote_url(self, new_url, remote="origin"):
         self._git(f"remote set-url {remote} {new_url}")
 


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

- Moved `safely_get_json` to the base git repository so that it can be used by any class which extends this git class - and not only authentication repositories
- A small `clone_or_pull` fix

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
