### PR TITLE
Logging improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- Minor logging updates ([126])
 - Updater: Partial repo factory ([125])
 - Logging formats ([120])
 - Use common role of given targets during update of targets/delegations metadata ([116])
@@ -34,6 +35,7 @@ and this project adheres to [Semantic Versioning][semver].
 - Normalize target files when creating a new repository ([117])
 
 
+[126]: https://github.com/openlawlibrary/taf/pull/126
 [125]: https://github.com/openlawlibrary/taf/pull/125
 [124]: https://github.com/openlawlibrary/taf/pull/124
 [121]: https://github.com/openlawlibrary/taf/pull/121

--- a/taf/auth_repo.py
+++ b/taf/auth_repo.py
@@ -167,24 +167,16 @@ class AuthRepoMixin(TAFRepository):
                     if target_path not in repositories_at_revision:
                         # we only care about repositories
                         continue
-                    try:
-                        target_content = self.get_json(
-                            commit, get_target_path(target_path)
-                        )
+                    target_content = self.safely_get_json(
+                        commit, get_target_path(target_path)
+                    )
+                    if target_content is not None:
                         target_commit = target_content.get("commit")
                         target_branch = target_content.get("branch", "master")
                         targets[commit][target_path] = {
                             "branch": target_branch,
                             "commit": target_commit,
                         }
-                    except json.decoder.JSONDecodeError:
-                        taf_logger.debug(
-                            "Auth repo {}: target file {} is not a valid json at revision {}",
-                            self.name,
-                            target_path,
-                            commit,
-                        )
-                        continue
         return targets
 
 

--- a/taf/git.py
+++ b/taf/git.py
@@ -114,7 +114,10 @@ class GitRepository:
                 if log_error_msg:
                     taf_logger.error(log_error_msg)
                 else:
-                    taf_logger.error(
+                    # not every git error indicates a problem
+                    # if it does, we expect that either custom error message will be provided
+                    # or that the error will be reraised
+                    taf_logger.debug(
                         "Repo {}: error occurred while executing {}:\n{}",
                         self.name,
                         command,
@@ -641,19 +644,20 @@ class GitRepository:
         try:
             return self.get_json(commit, path)
         except subprocess.CalledProcessError:
-            taf_logger.info(
+            taf_logger.debug(
                 "Auth repo {}: {} not available at revision {}",
                 self.name,
                 os.path.basename(path),
                 commit,
             )
         except json.decoder.JSONDecodeError:
-            taf_logger.info(
+            taf_logger.debug(
                 "Auth repo {}: {} not a valid json at revision {}",
                 self.name,
                 os.path.basename(path),
                 commit,
             )
+        return None
 
     def set_remote_url(self, new_url, remote="origin"):
         self._git(f"remote set-url {remote} {new_url}")

--- a/taf/log.py
+++ b/taf/log.py
@@ -16,7 +16,6 @@ console_loggers = {}
 file_loggers = {}
 
 
-
 def disable_console_logging():
     taf_logger.remove(console_loggers["log"])
     disable_tuf_console_logging()

--- a/taf/log.py
+++ b/taf/log.py
@@ -1,8 +1,10 @@
 import os
 import sys
+import logging
 from pathlib import Path
 
 import tuf.log
+import tuf.exceptions
 from loguru import logger as taf_logger
 
 import taf.settings as settings
@@ -12,6 +14,16 @@ _FILE_FORMAT_STRING = "[{time}] [{level}] [{module}:{function}@{line}]\n{message
 
 console_loggers = {}
 file_loggers = {}
+
+
+
+def disable_console_logging():
+    taf_logger.remove(console_loggers["log"])
+    disable_tuf_console_logging()
+
+
+def disable_tuf_console_logging():
+    tuf.log.set_console_log_level(logging.CRITICAL)
 
 
 def _get_log_location():
@@ -30,6 +42,10 @@ if settings.ENABLE_CONSOLE_LOGGING:
     console_loggers["log"] = taf_logger.add(
         sys.stdout, format=_CONSOLE_FORMAT_STRING, level=settings.CONSOLE_LOGGING_LEVEL
     )
+    tuf.log.set_console_log_level(settings.CONSOLE_LOGGING_LEVEL)
+else:
+    # if console logging is disable, remove tuf console logger
+    disable_tuf_console_logging()
 
 
 if settings.ENABLE_FILE_LOGGING:
@@ -46,10 +62,10 @@ if settings.ENABLE_FILE_LOGGING:
             format=_FILE_FORMAT_STRING,
             level=settings.ERROR_LOGGING_LEVEL,
         )
-
-
-def disable_console_logging(remove_error=False):
-    taf_logger.remove(console_loggers["log"])
-    if remove_error:
-        taf_logger.remove(console_loggers["error"])
-    tuf.log.remove_console_handler()
+    try:
+        tuf.log.set_filehandler_log_level(settings.FILE_LOGGING_LEVEL)
+    except tuf.exceptions.Error:
+        pass
+else:
+    # if file logging is disabled, also disable tuf file logging
+    tuf.log.disable_file_logging()

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -14,6 +14,7 @@ from taf.utils import on_rm_error
 
 disable_tuf_console_logging()
 
+
 def update_repository(
     url,
     clients_auth_path,

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -5,13 +5,14 @@ import tuf.client.updater as tuf_updater
 
 from collections import defaultdict
 from pathlib import Path
-from taf.log import taf_logger
+from taf.log import taf_logger, disable_tuf_console_logging
 import taf.repositoriesdb as repositoriesdb
 import taf.settings as settings
 from taf.exceptions import UpdateFailedError
 from taf.updater.handlers import GitUpdater
 from taf.utils import on_rm_error
 
+disable_tuf_console_logging()
 
 def update_repository(
     url,
@@ -370,6 +371,7 @@ def _update_target_repositories(
                     branch,
                 )
             except UpdateFailedError as e:
+                taf_logger.error("Updated failed due to error {}", str(e))
                 # delete all repositories that were cloned
                 for repo in cloned_repositories:
                     taf_logger.debug("Removing cloned repository {}", repo.path)


### PR DESCRIPTION
Lowered logging level in a few places. When an error occurs when executing a
git command and we neither want to reraise the error not use a customized log error message, such error is not that important. For example, a file does not exist at a revision. We often traverse through all commits and, e.g. try loading repositories.json. This file might not be available at the initial revision and that is not a problem.
Remove tuf logging when not needed
Small refactoring

## Description (e.g. "Related to ...", etc.)

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
