### PR TITLE
Export historical targets data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,15 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
+- Add a command for exporting targets historical data ([133])
+
 ### Changed
+
+- `sorted_commits_and_branches_per_repositories` returns additional targets data and not just commits ([133])
 
 ### Fixed
 
+[133]: https://github.com/openlawlibrary/taf/pull/133
 
 ## [0.4.1] - 05/12/2020
 

--- a/taf/auth_repo.py
+++ b/taf/auth_repo.py
@@ -109,12 +109,12 @@ class AuthRepoMixin(TAFRepository):
         to it for every target repository:
         {
             target_repo1: {
-                branch1: [commit1, commit2, commit3],
-                branch2: [commit4, commit5]
+                branch1: [{"commit": commit1, "additional-info": {...}}, {"commit": commit2, "additional-info": {...}}, {"commit": commit3, "additional-info": {}}],
+                branch2: [{"commit": commit4, "additional-info: {...}}, {"commit": commit5, "additional_info": {}}]
             },
             target_repo2: {
-                branch1: [commit6, commit7, commit8],
-                branch2: [commit9, commit10]
+                branch1: [{"commit": commit6, "additional-info": {...}}],
+                branch2: [{"commit": commit7", "additional-info": {...}]
             }
         }
         Keep in mind that targets metadata
@@ -131,10 +131,13 @@ class AuthRepoMixin(TAFRepository):
                 if previous_commit is None or target_commit != previous_commit:
                     repositories_commits[target_path].setdefault(
                         target_branch, []
-                    ).append(target_commit)
+                    ).append({
+                        "commit": target_commit,
+                        "additional-info": target_data.get("additional-info")
+                    })
                 previous_commits[target_path] = target_commit
         taf_logger.debug(
-            "Auth repo {}: new commits per repositories according to targets.json: {}",
+            "Auth repo {}: new commits per repositories according to target files: {}",
             self.name,
             repositories_commits,
         )
@@ -175,11 +178,12 @@ class AuthRepoMixin(TAFRepository):
                         commit, get_target_path(target_path)
                     )
                     if target_content is not None:
-                        target_commit = target_content.get("commit")
-                        target_branch = target_content.get("branch", "master")
+                        target_commit = target_content.pop("commit")
+                        target_branch = target_content.pop("branch", "master")
                         targets[commit][target_path] = {
                             "branch": target_branch,
                             "commit": target_commit,
+                            "additional-info": target_content,
                         }
         return targets
 

--- a/taf/auth_repo.py
+++ b/taf/auth_repo.py
@@ -132,10 +132,12 @@ class AuthRepoMixin(TAFRepository):
                 if previous_commit is None or target_commit != previous_commit:
                     repositories_commits[target_path].setdefault(
                         target_branch, []
-                    ).append({
-                        "commit": target_commit,
-                        "additional-info": target_data.get("additional-info")
-                    })
+                    ).append(
+                        {
+                            "commit": target_commit,
+                            "additional-info": target_data.get("additional-info"),
+                        }
+                    )
                 previous_commits[target_path] = target_commit
         self._log_debug(
             f"new commits per repositories according to target files: {repositories_commits}"

--- a/taf/developer_tool.py
+++ b/taf/developer_tool.py
@@ -770,6 +770,25 @@ def export_yk_certificate(certs_dir, key):
         f.write(yk.export_piv_x509())
 
 
+def export_targets_history(repo_path, commit=None, output=None, target_repos=None):
+    auth_repo = AuthenticationRepo(repo_path)
+    commits = auth_repo.all_commits_since_commit(commit, branch="master")
+    if not len(target_repos):
+        target_repos = None
+    commits_on_branches = auth_repo.sorted_commits_and_branches_per_repositories(
+        commits, target_repos
+    )
+    commits_json = json.dumps(commits_on_branches, indent=4)
+    if output is not None and not output.endswith(".json"):
+        output += ".json"
+    if output is not None:
+        output = Path(output).resolve()
+        output.write_text(commits_json)
+        print(f"Result written to {output}")
+    else:
+        print(commits_json)
+
+
 def _get_namespace_and_root(repo_path, namespace, root_dir):
     repo_path = Path(repo_path).resolve()
     if namespace is None:

--- a/taf/developer_tool.py
+++ b/taf/developer_tool.py
@@ -779,10 +779,11 @@ def export_targets_history(repo_path, commit=None, output=None, target_repos=Non
         commits, target_repos
     )
     commits_json = json.dumps(commits_on_branches, indent=4)
-    if output is not None and not output.endswith(".json"):
-        output += ".json"
     if output is not None:
         output = Path(output).resolve()
+        if output.suffix != ".json":
+            output = output.with_suffix(".json")
+        output.parent.mkdir(parents=True, exist_ok=True)
         output.write_text(commits_json)
         print(f"Result written to {output}")
     else:

--- a/taf/git.py
+++ b/taf/git.py
@@ -804,6 +804,7 @@ class NamedGitRepository(GitRepository):
     root_dir and repo_name.
     """
         self.root_dir = root_dir
+        self.name = repo_name
         path = self._get_repo_path(root_dir, repo_name)
         super().__init__(
             path,

--- a/taf/git.py
+++ b/taf/git.py
@@ -152,7 +152,7 @@ class GitRepository:
 
     def all_commits_since_commit(self, since_commit, branch=None, reverse=True):
         """Returns a list of all commits since the specified commit on the
-        currently checked out branch
+        specified or currently checked out branch
         """
         if since_commit is None:
             return self.all_commits_on_branch(branch=branch, reverse=reverse)

--- a/taf/tools/targets/__init__.py
+++ b/taf/tools/targets/__init__.py
@@ -11,6 +11,26 @@ def attach_to_group(group):
         pass
 
     @targets.command()
+    @click.argument("repo_path")
+    @click.option("--commit", default=None, help="Starting authentication repository commit")
+    @click.option("--output", default=None, help="File to which the resulting json will be written. "
+                  "If not provided, the output will be printed to console")
+    @click.option("--repo", multiple=True, help="Target repository whose historical data "
+                  "should be collected")
+    def export_history(repo_path, commit, output, repo):
+        """Export lists of sorted commits, grouped by branches and target repositories, based
+        on target files stored in the authentication repository. If commit is specified,
+        only return changes made at that revision and all subsequent revisions. If it is not,
+        start from the initial authentication repository commit.
+        Repositories which will be taken into consideration when collecting targets historical
+        data can be defined using the repo option. If no repositories are passed in, historical
+        data will include all target repositories.
+        to a file whose location is specified using the output option, or print it to
+        console.
+        """
+        developer_tool.export_targets_history(repo_path, commit, output, repo)
+
+    @targets.command()
     @click.argument("path")
     @click.option("--keystore", default=None, help="Location of the keystore files")
     @click.option("--keys-description", help="A dictionary containing information about the "

--- a/taf/tools/yubikey/__init__.py
+++ b/taf/tools/yubikey/__init__.py
@@ -9,13 +9,13 @@ def attach_to_group(group):
         pass
 
     @yubikey.command()
-    @click.option("--path", help="File to which the exported public key will be written. "
+    @click.option("--output", help="File to which the exported public key will be written. "
                   "The result will be written to the console if path is not specified")
-    def export_pub_key(path):
+    def export_pub_key(output):
         """
         Export the inserted Yubikey's public key and save it to the specified location.
         """
-        developer_tool.export_yk_public_pem(path)
+        developer_tool.export_yk_public_pem(output)
 
     @yubikey.command()
     @click.option("--certs-dir", help="Path of the directory where the exported certificate will be saved."

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -323,6 +323,7 @@ def _update_target_repositories(
             # branch
             branch_exists = repository.branch_exists(branch, include_remotes=False)
             repo_branch_commits = repositories_branches_and_commits[path][branch]
+            repo_branch_commits = [commit_info["commit"] for commit_info in repo_branch_commits]
             if (
                 last_validated_commit is None
                 or not is_git_repository

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -322,7 +322,9 @@ def _update_target_repositories(
             # branch
             branch_exists = repository.branch_exists(branch, include_remotes=False)
             repo_branch_commits = repositories_branches_and_commits[path][branch]
-            repo_branch_commits = [commit_info["commit"] for commit_info in repo_branch_commits]
+            repo_branch_commits = [
+                commit_info["commit"] for commit_info in repo_branch_commits
+            ]
             if (
                 last_validated_commit is None
                 or not is_git_repository
@@ -387,11 +389,10 @@ def _update_target_repositories(
             for branch in repositories_branches_and_commits[path]:
                 repository.checkout_branch(branch)
                 repo_branch_commits = repositories_branches_and_commits[path][branch]
+                last_commit = repo_branch_commits[-1]["commit"]
                 if len(repo_branch_commits):
-                    taf_logger.info(
-                        "Merging {} into {}", repo_branch_commits[-1], repository.name
-                    )
-                    last_validated_commit = repo_branch_commits[-1]
+                    taf_logger.info("Merging {} into {}", last_commit, repository.name)
+                    last_validated_commit = last_commit
                     commit_to_merge = (
                         last_validated_commit
                         if not allow_unauthenticated[path]


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Implemented a command for exporting historical data of target repositories according to the authentication repository. It is possible to specify the first authentication repository commit to be taken into consideration when collecting historical data, as well as target repositories. If these parameters are not specified, history will be exported starting with the initial authentication commit and will include all target repositories.

To export history of two repositories, starting with a specific commit do the following:

`taf targets export_history auth_repo_path--repo namespace/repo1 --repo namespace/repo2` --commit sha`

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
