### PR TITLE
Raise a nicer error if an auth repository is not a valid TUF repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- Raise a nicer error when instantiating a TUF repository if it is invalid ([137])
+
 ### Fixed
+
+[137]: https://github.com/openlawlibrary/taf/pull/137
 
 ## [0.5.0] - 06/04/2020
 

--- a/taf/repository_tool.py
+++ b/taf/repository_tool.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import securesystemslib
 import tuf.roledb
-from securesystemslib.exceptions import Error as SSLibError
+from securesystemslib.exceptions import Error as SSLibError, RepositoryError
 from securesystemslib.interface import import_rsa_privatekey_from_file
 from securesystemslib.util import HASH_FUNCTION, get_file_details
 from tuf.exceptions import Error as TUFError
@@ -33,6 +33,7 @@ from taf.exceptions import (
     TargetsMetadataUpdateError,
     TimestampMetadataUpdateError,
     YubikeyError,
+    InvalidRepositoryError,
 )
 from taf.git import GitRepository
 from taf.utils import normalize_file_line_endings, on_rm_error
@@ -215,7 +216,10 @@ class Repository:
         # to avoid errors raised by tuf
         if not self.targets_path.is_dir():
             self.targets_path.mkdir(parents=True, exist_ok=True)
-        self._tuf_repository = load_repository(path, self.name)
+        try:
+            self._tuf_repository = load_repository(path, self.name)
+        except RepositoryError:
+            raise InvalidRepositoryError(f"{self.name} is not a valid TUF repository!")
 
     def reload_tuf_repository(self):
         """


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Raise a custom error instead of a `securesystemslib` error saying that a temp file does not exist

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
