### PR TITLE
repositoriesdb fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,16 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- Set `only_load_targets` parameter to `True` by default in `repositoriesdb` ([139])
 - Use `_load_signing_keys` in `add_signing_key` ([138])
 - Raise a nicer error when instantiating a TUF repository if it is invalid ([137])
 
 ### Fixed
 
+- Fix loading targets metadata files in `repositoriesdb` ([139])
+
+
+[139]: https://github.com/openlawlibrary/taf/pull/139
 [138]: https://github.com/openlawlibrary/taf/pull/138
 [137]: https://github.com/openlawlibrary/taf/pull/137
 

--- a/taf/repositoriesdb.py
+++ b/taf/repositoriesdb.py
@@ -114,8 +114,7 @@ def load_repositories(
 
         for path, repo_data in repositories.items():
             urls = _get_urls(mirrors, path, repo_data)
-            target = targets.get(path)
-            if target is None and only_load_targets:
+            if path not in targets and only_load_targets:
                 continue
 
             additional_info = _get_custom_data(repo_data, targets.get(path))
@@ -396,23 +395,9 @@ def _load_mirrors_json(auth_repo, commit):
 
 
 def _targets_of_roles(auth_repo, commit, roles=None):
-    all_targets = {}
+
     with auth_repo.repository_at_revision(commit):
-        if roles is None:
-            roles = auth_repo.get_all_targets_roles()
-        for role in roles:
-            try:
-                role_dict = json.loads(
-                    (auth_repo.metadata_path / f"{role}.json").read_text()
-                )
-            except Exception as e:
-                auth_repo._log_warning(
-                    f"could not load {role}.json metadata file due to {e}"
-                )
-                continue
-            targets = role_dict["signed"]["targets"]
-            all_targets.update(targets)
-    return all_targets
+        return auth_repo.get_singed_targets_with_custom_data(roles)
 
 
 def repositories_loaded(auth_repo):

--- a/taf/repositoriesdb.py
+++ b/taf/repositoriesdb.py
@@ -35,7 +35,7 @@ def load_repositories(
     repo_classes=None,
     factory=None,
     root_dir=None,
-    only_load_targets=False,
+    only_load_targets=True,
     commits=None,
     roles=None,
 ):

--- a/taf/repository_tool.py
+++ b/taf/repository_tool.py
@@ -363,6 +363,27 @@ class Repository:
             )
         )
 
+    def get_singed_targets_with_custom_data(self, roles):
+        """Return all target files signed by the specified roles and and their custom data
+        as specified in the metadata files
+
+        Args:
+        - roles whose target files will be returned
+
+        Returns:
+        - A dictionary whose keys are parts of target files relative to the targets directory
+        and values are custom data dictionaries.
+        """
+        if roles is None:
+            roles = self.get_all_targets_roles()
+        target_files = {}
+        for role in roles:
+            roles_targets = self._role_obj(role).target_files
+            for target_file, custom_data in roles_targets.items():
+                target_files.setdefault(target_file, {}).update(custom_data)
+        return target_files
+
+
     def add_metadata_key(self, role, pub_key_pem, scheme=DEFAULT_RSA_SIGNATURE_SCHEME):
         """Add metadata key of the provided role.
 


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

- Set `only_load_targets` to True by default. It makes sense to ignore repositories specified in `repositories.json` with not corresponding target files.
- Updated the way of loading targets of a role given a commit. The updater was raising an error when case when the authentication repository had to be cloned due to not being able to read `targets.json`. Since this function was previously updated to use `repository_at_revision` context manager, we can rely on TUF's objects.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
