### PR TITLE
When exporting history, check if the specified repo exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- Check if specified target repositories exist before trying to export historical commits data ([144])
+
 ### Fixed
+
+[144]: https://github.com/openlawlibrary/taf/pull/144
 
 
 ## [0.5.2] - 07/21/2020

--- a/taf/developer_tool.py
+++ b/taf/developer_tool.py
@@ -34,6 +34,7 @@ from taf.repository_tool import (
     yubikey_signature_provider,
     is_delegated_role,
 )
+import taf.repositoriesdb as repositoriesdb
 from taf.utils import get_key_size, read_input_dict
 
 try:
@@ -747,6 +748,18 @@ def export_targets_history(repo_path, commit=None, output=None, target_repos=Non
     commits = auth_repo.all_commits_since_commit(commit, branch="master")
     if not len(target_repos):
         target_repos = None
+    else:
+        repositoriesdb.load_repositories(auth_repo)
+        invalid_targets = []
+        for target_repo in target_repos:
+            if repositoriesdb.get_repository(auth_repo, target_repo) is None:
+                invalid_targets.append(target_repo)
+        if len(invalid_targets):
+            print(
+                f"The following target repositories are not defined: {', '.join(invalid_targets)}"
+            )
+            return
+
     commits_on_branches = auth_repo.sorted_commits_and_branches_per_repositories(
         commits, target_repos
     )

--- a/taf/repositoriesdb.py
+++ b/taf/repositoriesdb.py
@@ -290,7 +290,7 @@ def get_deduplicated_repositories(auth_repo, commits):
 
 
 def get_repository(auth_repo, path, commit=None):
-    return get_repositories(auth_repo, commit)[path]
+    return get_repositories(auth_repo, commit).get(path)
 
 
 def get_repositories(auth_repo, commit=None):


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

When calling `export_history`:
`taf targets export_history law --repo namespace/law-html` 

it is checked if `namespace/law-html` is an actual target. If it is not, the command returns a warning message and is terminated without calling `sorted_commits_and_branches_per_repositories` which is slow on Windows.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
