### PR TITLE
Command for adding new delegated roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
+- Add a command for adding new new delegated roles ([158])
+
+[158]: https://github.com/openlawlibrary/taf/pull/158
+
 ### Changed
 
 ### Fixed

--- a/taf/tools/metadata/__init__.py
+++ b/taf/tools/metadata/__init__.py
@@ -38,7 +38,6 @@ def attach_to_group(group):
         developer_tool.add_signing_key(path, role, pub_key_path, keystore,
                                        keys_description, scheme)
 
-
     @metadata.command()
     @click.argument("path")
     @click.argument("keys-description")
@@ -47,7 +46,6 @@ def attach_to_group(group):
                   "used for signing")
     def add_roles(path, keystore, keys_description, scheme):
         developer_tool.add_roles(path, keystore, keys_description, scheme)
-
 
     @metadata.command()
     @click.argument("path")

--- a/taf/tools/metadata/__init__.py
+++ b/taf/tools/metadata/__init__.py
@@ -41,15 +41,13 @@ def attach_to_group(group):
 
     @metadata.command()
     @click.argument("path")
+    @click.argument("keys-description")
     @click.option("--keystore", default=None, help="Location of the keystore files")
-    @click.option("--keys-description", help="A dictionary containing information about the "
-                  "keys or a path to a json file which stores the needed information")
     @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme "
                   "used for signing")
     def add_roles(path, keystore, keys_description, scheme):
-        if not keys_description:
-            return
         developer_tool.add_roles(path, keystore, keys_description, scheme)
+
 
     @metadata.command()
     @click.argument("path")

--- a/taf/tools/metadata/__init__.py
+++ b/taf/tools/metadata/__init__.py
@@ -38,6 +38,19 @@ def attach_to_group(group):
         developer_tool.add_signing_key(path, role, pub_key_path, keystore,
                                        keys_description, scheme)
 
+
+    @metadata.command()
+    @click.argument("path")
+    @click.option("--keystore", default=None, help="Location of the keystore files")
+    @click.option("--keys-description", help="A dictionary containing information about the "
+                  "keys or a path to a json file which stores the needed information")
+    @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme "
+                  "used for signing")
+    def add_roles(path, keystore, keys_description, scheme):
+        if not keys_description:
+            return
+        developer_tool.add_roles(path, keystore, keys_description, scheme)
+
     @metadata.command()
     @click.argument("path")
     @click.argument("role")


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Added a command for adding new delegated targets roles.
New roles are specified using the same json input files which are used when creating a new repository, but it's not necessary
to list existing roles (unless these roles are delegated roles which are parents of other delegated roles)

This is an example of such json. It is assumed that parent of the two top roles (delegated_role1 and delegated_role2) is targets.
Parent of role1 is delegated_role2.
```
{
   "roles":{
      "delegated_role1":{
         "paths":[
            "dir1/*"
         ],
         "number":1,
         "threshold":1,
         "scheme":"rsassa-pss-sha256",
         "yubikey":true
      },
      "delegated_role2":{
         "paths":[
            "dir2/*"
         ],
         "delegations":{
            "role1":{
               "paths":[
                  "test"
               ],
               "yubikey":true
            }
         },
         "scheme":"rsassa-pss-sha256",
         "number":1,
         "threshold":1,
         "yubikey":true
      }
   },
   "keystore":"keystore"
}
```

E.g. `taf metadata add-roles law delegations_keys.json --keystore law/keystore`


## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
