### PR TITLE
Various updater fixes and enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,20 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
+- Raise an error if there are additional commits newer than the last authenticated commit if the updater is called with the check-authenticated flag ([161])
+- Added initial worktrees support to the updater ([161])
+- Added support for specifying location of the conf directory ([161])
+- Added a function for disabling fie logging ([161])
 ### Changed
+
+- Replaced authenticate-test-repo flag with an enum ([161])
 
 ### Fixed
 
+- Minor validation command fix ([161])
 
+
+[161]: https://github.com/openlawlibrary/taf/pull/161
 
 ## [0.7.2] - 11/11/2020
 
@@ -22,12 +31,13 @@ and this project adheres to [Semantic Versioning][semver].
 
 - Add a command for adding new new delegated roles ([158])
 
-[158]: https://github.com/openlawlibrary/taf/pull/158
 
 ### Changed
 
 ### Fixed
 
+
+[158]: https://github.com/openlawlibrary/taf/pull/158
 
 ## [0.7.1] - 10/28/2020
 

--- a/taf/auth_repo.py
+++ b/taf/auth_repo.py
@@ -18,6 +18,8 @@ class AuthRepoMixin(TAFRepository):
     LAST_VALIDATED_FILENAME = "last_validated_commit"
     TEST_REPO_FLAG_FILE = "test-auth-repo"
 
+    _conf_dir = None
+
     @property
     def conf_dir(self):
         """
@@ -27,10 +29,12 @@ class AuthRepoMixin(TAFRepository):
         """
         # the repository's name consists of the namespace and name (namespace/name)
         # the configuration directory should be _name
-        last_dir = os.path.basename(os.path.normpath(self.path))
-        conf_path = Path(self.path).parent / f"_{last_dir}"
-        conf_path.mkdir(parents=True, exist_ok=True)
-        return str(conf_path)
+        if self._conf_dir is None:
+            last_dir = os.path.basename(os.path.normpath(self.path))
+            conf_path = Path(self.conf_directory_root, f"_{last_dir}")
+            conf_path.mkdir(parents=True, exist_ok=True)
+            self._conf_dir = str(conf_path)
+        return self._conf_dir
 
     @property
     def certs_dir(self):
@@ -207,9 +211,13 @@ class AuthenticationRepo(GitRepository, AuthRepoMixin):
         repo_urls=None,
         additional_info=None,
         default_branch="master",
+        conf_directory_root=None,
         *args,
         **kwargs,
     ):
+        if conf_directory_root is None:
+            conf_directory_root = str(Path(path).parent)
+        self.conf_directory_root = conf_directory_root
         super().__init__(path, repo_urls, additional_info, default_branch)
 
 
@@ -221,13 +229,18 @@ class NamedAuthenticationRepo(NamedGitRepository, AuthRepoMixin):
         repo_urls=None,
         additional_info=None,
         default_branch="master",
+        conf_directory_root=None,
         *args,
         **kwargs,
     ):
+        if conf_directory_root is None:
+            conf_directory_root = str(Path(root_dir, repo_name).parent)
+        self.conf_directory_root = conf_directory_root
         super().__init__(
             root_dir=root_dir,
             repo_name=repo_name,
             repo_urls=repo_urls,
             additional_info=additional_info,
             default_branch=default_branch,
+            conf_directory_root=conf_directory_root,
         )

--- a/taf/exceptions.py
+++ b/taf/exceptions.py
@@ -131,15 +131,16 @@ class UpdateFailedError(TAFError):
 
 class UpdaterAdditionalCommits(TAFError):
     def __init__(self, additional_commits_per_repo, message=None):
-        self.repositories = list(additional_commits_per_repo.keys())
+        self.additional_commits_per_repo = additional_commits_per_repo
         if message is None:
             message = ''
-            for repo, commits in additional_commits_per_repo.items():
-                message += f"Repository {repo} contains {len(commits)} additional"
-                if len(commits) > 1:
-                    message += "commits\n"
-                else:
-                    message += "commit\n"
+            for repo, branch_commits in additional_commits_per_repo.items():
+                for branch, commits in branch_commits.items():
+                    message += f"Repository {repo}: branch {branch} contains {len(commits)} additional"
+                    if len(commits) > 1:
+                        message += "commits\n"
+                    else:
+                        message += "commit\n"
         self.message = message
 
 

--- a/taf/exceptions.py
+++ b/taf/exceptions.py
@@ -129,5 +129,19 @@ class UpdateFailedError(TAFError):
     pass
 
 
+class UpdaterAdditionalCommits(TAFError):
+    def __init__(self, additional_commits_per_repo, message=None):
+        self.repositories = list(additional_commits_per_repo.keys())
+        if message is None:
+            message = ''
+            for repo, commits in additional_commits_per_repo.items():
+                message += f"Repository {repo} contains {len(commits)} additional"
+                if len(commits) > 1:
+                    message += "commits\n"
+                else:
+                    message += "commit\n"
+        self.message = message
+
+
 class YubikeyError(Exception):
     pass

--- a/taf/exceptions.py
+++ b/taf/exceptions.py
@@ -133,7 +133,7 @@ class UpdaterAdditionalCommits(TAFError):
     def __init__(self, additional_commits_per_repo, message=None):
         self.additional_commits_per_repo = additional_commits_per_repo
         if message is None:
-            message = ''
+            message = ""
             for repo, branch_commits in additional_commits_per_repo.items():
                 for branch, commits in branch_commits.items():
                     message += f"Repository {repo}: branch {branch} contains {len(commits)} additional"

--- a/taf/exceptions.py
+++ b/taf/exceptions.py
@@ -129,7 +129,7 @@ class UpdateFailedError(TAFError):
     pass
 
 
-class UpdaterAdditionalCommits(TAFError):
+class UpdaterAdditionalCommitsError(TAFError):
     def __init__(self, additional_commits_per_repo, message=None):
         self.additional_commits_per_repo = additional_commits_per_repo
         if message is None:

--- a/taf/git.py
+++ b/taf/git.py
@@ -609,6 +609,14 @@ class GitRepository:
                 branch = ""
             self._git("fetch {} {}", remote, branch, log_error=True)
 
+    def find_worktree_path_by_branch(self, branch_name):
+        """Returns worktree path where branch is checked out."""
+        worktrees = self.list_worktrees()
+        for path, _, _branch_name in worktrees.values():
+            if _branch_name == branch_name:
+                return path
+        return None
+
     def get_current_branch(self):
         """Return current branch."""
         return self._git("rev-parse --abbrev-ref HEAD").strip()
@@ -721,6 +729,14 @@ class GitRepository:
         return [
             untracked_file for untracked_file in untracked_files if len(untracked_file)
         ]
+
+    def list_worktrees(self):
+        worktrees_list = self._git(f"worktree list")
+        worktrees = [w.split() for w in worktrees_list.splitlines() if w]
+        return {
+            Path(wt[0]): (Path(wt[0]), wt[1], wt[2].replace("[", "").replace("]", ""))
+            for wt in worktrees
+        }
 
     def merge_commit(self, commit):
         self._git("merge {}", commit, log_error=True)

--- a/taf/git.py
+++ b/taf/git.py
@@ -731,7 +731,7 @@ class GitRepository:
         ]
 
     def list_worktrees(self):
-        worktrees_list = self._git(f"worktree list")
+        worktrees_list = self._git("worktree list")
         worktrees = [w.split() for w in worktrees_list.splitlines() if w]
         return {
             Path(wt[0]): (Path(wt[0]), wt[1], wt[2].replace("[", "").replace("]", ""))

--- a/taf/git.py
+++ b/taf/git.py
@@ -732,7 +732,12 @@ class GitRepository:
 
     def list_worktrees(self):
         """
-        Returns a list containing all worktrees of the git repository
+        Returns a dictionary containing information about repository's worktrees:
+        {
+            "worktree1_path: (worktree1_path, worktree1_commit, worktree1_branch),
+            "worktree2_path: (worktree2_path, worktree2_commit, worktree2_branch),
+            ...
+        }
         """
         worktrees_list = self._git("worktree list")
         worktrees = [w.split() for w in worktrees_list.splitlines() if w]

--- a/taf/git.py
+++ b/taf/git.py
@@ -610,7 +610,7 @@ class GitRepository:
             self._git("fetch {} {}", remote, branch, log_error=True)
 
     def find_worktree_path_by_branch(self, branch_name):
-        """Returns worktree path where branch is checked out."""
+        """Returns path of the workree where the branch is checked out, or None if not checked out in any worktree"""
         worktrees = self.list_worktrees()
         for path, _, _branch_name in worktrees.values():
             if _branch_name == branch_name:
@@ -731,6 +731,9 @@ class GitRepository:
         ]
 
     def list_worktrees(self):
+        """
+        Returns a list containing all worktrees of the git repository
+        """
         worktrees_list = self._git("worktree list")
         worktrees = [w.split() for w in worktrees_list.splitlines() if w]
         return {

--- a/taf/log.py
+++ b/taf/log.py
@@ -22,6 +22,11 @@ def disable_console_logging():
     disable_tuf_console_logging()
 
 
+def disable_file_logging():
+    taf_logger.remove(file_loggers["log"])
+    disable_tuf_console_logging()
+
+
 def disable_tuf_console_logging():
     try:
         tuf.log.set_console_log_level(logging.CRITICAL)
@@ -31,7 +36,7 @@ def disable_tuf_console_logging():
 
 def disable_tuf_file_logging():
     if tuf.log.file_handler is not None:
-        tuf.log.disable_tuf_file_logging()
+        tuf.log.disable_file_logging()
     else:
         logging.getLogger("tuf").setLevel(logging.CRITICAL)
     logging.getLogger("securesystemslib_keys").setLevel(logging.CRITICAL)

--- a/taf/repository_tool.py
+++ b/taf/repository_tool.py
@@ -61,6 +61,18 @@ def get_target_path(target_name):
     return f"{TARGETS_DIRECTORY_NAME}/{target_name}"
 
 
+def is_auth_repo(repo_path):
+    try:
+        targets_path = Path(repo_path, TARGETS_DIRECTORY_NAME)
+        dir_existed = targets_path.is_dir()
+        Repository(repo_path)._repository
+        return True
+    except Exception:
+        if not dir_existed:
+            targets_path.rmdir()
+        return False
+
+
 def is_delegated_role(role):
     return role not in ("root", "targets", "snapshot", "timestamp")
 

--- a/taf/repository_tool.py
+++ b/taf/repository_tool.py
@@ -289,7 +289,7 @@ class Repository:
             self._tuf_repository = load_repository(path, self.name)
         except RepositoryError:
             if not targets_existed:
-                targets_path.rm_dir()
+                self.targets_path.rmdir()
             raise InvalidRepositoryError(f"{self.name} is not a valid TUF repository!")
 
     def reload_tuf_repository(self):

--- a/taf/repository_tool.py
+++ b/taf/repository_tool.py
@@ -66,8 +66,7 @@ def is_delegated_role(role):
 
 
 def is_auth_repo(repo_path):
-    """Check if the given path contain a valid TUF repository
-    """
+    """Check if the given path contains a valid TUF repository"""
     try:
         Repository(repo_path)._repository
         return True

--- a/taf/repository_tool.py
+++ b/taf/repository_tool.py
@@ -61,20 +61,20 @@ def get_target_path(target_name):
     return f"{TARGETS_DIRECTORY_NAME}/{target_name}"
 
 
+def is_delegated_role(role):
+    return role not in ("root", "targets", "snapshot", "timestamp")
+
+
 def is_auth_repo(repo_path):
     try:
         targets_path = Path(repo_path, TARGETS_DIRECTORY_NAME)
-        dir_existed = targets_path.is_dir()
+        targets_existed = targets_path.is_dir()
         Repository(repo_path)._repository
         return True
     except Exception:
-        if not dir_existed:
-            targets_path.rmdir()
+        if not targets_existed:
+            targets_path.rm_dir()
         return False
-
-
-def is_delegated_role(role):
-    return role not in ("root", "targets", "snapshot", "timestamp")
 
 
 def load_role_key(keystore, role, password=None, scheme=DEFAULT_RSA_SIGNATURE_SCHEME):

--- a/taf/repository_tool.py
+++ b/taf/repository_tool.py
@@ -66,14 +66,12 @@ def is_delegated_role(role):
 
 
 def is_auth_repo(repo_path):
+    """Check if the given path contain a valid TUF repository
+    """
     try:
-        targets_path = Path(repo_path, TARGETS_DIRECTORY_NAME)
-        targets_existed = targets_path.is_dir()
         Repository(repo_path)._repository
         return True
     except Exception:
-        if not targets_existed:
-            targets_path.rm_dir()
         return False
 
 
@@ -284,11 +282,15 @@ class Repository:
         """
         # before attempting to tuf repository, create empty targets directory if it does not exist
         # to avoid errors raised by tuf
+        targets_existed = True
         if not self.targets_path.is_dir():
+            targets_existed = False
             self.targets_path.mkdir(parents=True, exist_ok=True)
         try:
             self._tuf_repository = load_repository(path, self.name)
         except RepositoryError:
+            if not targets_existed:
+                targets_path.rm_dir()
             raise InvalidRepositoryError(f"{self.name} is not a valid TUF repository!")
 
     def reload_tuf_repository(self):

--- a/taf/settings.py
+++ b/taf/settings.py
@@ -6,6 +6,8 @@ import logging
 # unusable.
 temporary_directory = None
 
+conf_directory_root = None
+
 update_from_filesystem = False
 
 validate_repo_name = True

--- a/taf/tests/test_updater.py
+++ b/taf/tests/test_updater.py
@@ -98,16 +98,16 @@ def run_around_tests(client_dir):
 @pytest.mark.parametrize(
     "test_name, test_repo",
     [
-        ("test-updater-valid", False),
-        ("test-updater-additional-target-commit", False),
-        ("test-updater-valid-with-updated-expiration-dates", False),
-        ("test-updater-allow-unauthenticated-commits", False),
-        ("test-updater-test-repo", True),
-        ("test-updater-multiple-branches", False),
-        ("test-updater-delegated-roles", False),
-        ("test-updater-updated-root", False),
-        ("test-updater-updated-root-old-snapshot", False),
-        ("test-updater-updated-root-version-skipped", False),
+        ("test-updater-valid", UpdateType.OFFICIAL),
+        ("test-updater-additional-target-commit", UpdateType.OFFICIAL),
+        ("test-updater-valid-with-updated-expiration-dates", UpdateType.OFFICIAL),
+        ("test-updater-allow-unauthenticated-commits", UpdateType.OFFICIAL),
+        ("test-updater-test-repo", UpdateType.TEST),
+        ("test-updater-multiple-branches", UpdateType.OFFICIAL),
+        ("test-updater-delegated-roles", UpdateType.OFFICIAL),
+        ("test-updater-updated-root", UpdateType.OFFICIAL),
+        ("test-updater-updated-root-old-snapshot", UpdateType.OFFICIAL),
+        ("test-updater-updated-root-version-skipped", UpdateType.OFFICIAL),
     ],
 )
 def test_valid_update_no_client_repo(
@@ -121,11 +121,11 @@ def test_valid_update_no_client_repo(
 @pytest.mark.parametrize(
     "test_name, test_repo",
     [
-        ("test-updater-valid", False),
-        ("test-updater-additional-target-commit", False),
-        ("test-updater-allow-unauthenticated-commits", False),
-        ("test-updater-multiple-branches", False),
-        ("test-updater-delegated-roles", False),
+        ("test-updater-valid", UpdateType.OFFICIAL),
+        ("test-updater-additional-target-commit", UpdateType.OFFICIAL),
+        ("test-updater-allow-unauthenticated-commits", UpdateType.OFFICIAL),
+        ("test-updater-multiple-branches", UpdateType.OFFICIAL),
+        ("test-updater-delegated-roles", UpdateType.OFFICIAL),
     ],
 )
 def test_valid_update_no_auth_repo_one_target_repo_exists(
@@ -170,11 +170,11 @@ def test_valid_update_existing_client_repos(
 @pytest.mark.parametrize(
     "test_name, test_repo",
     [
-        ("test-updater-valid", False),
-        ("test-updater-allow-unauthenticated-commits", False),
-        ("test-updater-test-repo", True),
-        ("test-updater-multiple-branches", False),
-        ("test-updater-delegated-roles", False),
+        ("test-updater-valid", UpdateType.OFFICIAL),
+        ("test-updater-allow-unauthenticated-commits", UpdateType.OFFICIAL),
+        ("test-updater-test-repo", UpdateType.TEST),
+        ("test-updater-multiple-branches", UpdateType.OFFICIAL),
+        ("test-updater-delegated-roles", UpdateType.OFFICIAL),
     ],
 )
 def test_no_update_necessary(

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -190,9 +190,10 @@ def attach_to_group(group):
     @click.option("--expected-repo-type", default="either", type=click.Choice(["test", "official", "either"]),
                   help="Indicates expected authentication repository type - test or official. If type is set to either, "
                   "the updater will not check the repository's type")
-    @click.option("--check-for-unauthenticated", is_flag=True, help="Check if there are additional new commits "
-                  "if a repostiory allows unauthenicated commits")
-    def update(url, clients_auth_path, clients_root_dir, from_fs, expected_repo_type, check_for_unauthenticated):
+    @click.option("--error-if-unauthenticated", is_flag=True, help="Raise an error if the repository allows "
+                  "unauthentiated commits and the updater detected authenticated commits newer than local "
+                  "head commit")
+    def update(url, clients_auth_path, clients_root_dir, from_fs, expected_repo_type, error_if_unauthenticated):
         """
         Update and validate local authentication repository and target repositories. Remote
         authentication's repository url needs to be specified when calling this command. If the
@@ -212,10 +213,15 @@ def attach_to_group(group):
         the "test" target file), use --authenticate-test-repo flag. An error will be raised
         if this flag is omitted in the mentioned case. Do not use this flag when validating a non-test
         repository as that will also result in an error.
+
+        Some repositories can contain unauthenticated commits in-between two authenticated. The updater
+        will check if existance and order of all authenticated ones and ignore unauthenticated. To raise
+        an error if there new authenticated commits (newer than the last local commit), error-if-unauthenticated
+        can be used.
         """
         update_repository(url, clients_auth_path, clients_root_dir, from_fs,
                           UpdateType.from_name(expected_repo_type),
-                          check_for_unauthenticated=check_for_unauthenticated)
+                          error_if_unauthenticated=error_if_unauthenticated)
 
     @repo.command()
     @click.argument("clients-auth-path")

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -214,10 +214,10 @@ def attach_to_group(group):
         if this flag is omitted in the mentioned case. Do not use this flag when validating a non-test
         repository as that will also result in an error.
 
-        Some repositories can contain unauthenticated commits in-between two authenticated. The updater
-        will check if existance and order of all authenticated ones and ignore unauthenticated. To raise
-        an error if there new authenticated commits (newer than the last local commit), error-if-unauthenticated
-        can be used.
+        Some repositories can contain unauthenticated commits in-between two authenticated ones. The updater
+        will check existance and order of all authenticated commits and ignore unauthenticated. To raise
+        an error if there are new unauthenticated commits (newer than the last local commit),
+        error-if-unauthenticated option can be used.
         """
         update_repository(url, clients_auth_path, clients_root_dir, from_fs,
                           UpdateType.from_name(expected_repo_type),

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -189,7 +189,9 @@ def attach_to_group(group):
                   "repository from the filesystem")
     @click.option("--authenticate-test-repo", is_flag=True, help="Indicates that the authentication "
                   "repository is a test repository")
-    def update(url, clients_auth_path, clients_root_dir, from_fs, authenticate_test_repo):
+    @click.option("--check-for-unauthenticated", is_flag=True, help="Check if there are additional new commits "
+                  "if a repostiory allows unauthenicated commits")
+    def update(url, clients_auth_path, clients_root_dir, from_fs, authenticate_test_repo, check_for_unauthenticated):
         """
         Update and validate local authentication repository and target repositories. Remote
         authentication's repository url needs to be specified when calling this command. If the
@@ -211,7 +213,7 @@ def attach_to_group(group):
         repository as that will also result in an error.
         """
         update_repository(url, clients_auth_path, clients_root_dir, from_fs,
-                          authenticate_test_repo)
+                          authenticate_test_repo, check_for_unauthenticated=check_for_unauthenticated)
 
     @repo.command()
     @click.argument("clients-auth-path")

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -1,7 +1,7 @@
 import click
 import taf.developer_tool as developer_tool
 from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
-from taf.updater.updater import update_repository, validate_repository
+from taf.updater.updater import update_repository, validate_repository, UpdateType
 
 
 def attach_to_group(group):
@@ -187,11 +187,12 @@ def attach_to_group(group):
                   "Authentication repo is presumed to be at root-dir/namespace/auth-repo-name")
     @click.option("--from-fs", is_flag=True, default=False, help="Indicates if the we want to clone a "
                   "repository from the filesystem")
-    @click.option("--authenticate-test-repo", is_flag=True, help="Indicates that the authentication "
-                  "repository is a test repository")
+    @click.option("--expected-repo-type", type=click.Choice(["test", "official", "either"]),
+                  help="Indicates expected authentication repository type - test or official. If type is set to either, "
+                  "the updater will not check the repository's type")
     @click.option("--check-for-unauthenticated", is_flag=True, help="Check if there are additional new commits "
                   "if a repostiory allows unauthenicated commits")
-    def update(url, clients_auth_path, clients_root_dir, from_fs, authenticate_test_repo, check_for_unauthenticated):
+    def update(url, clients_auth_path, clients_root_dir, from_fs, expected_repo_type, check_for_unauthenticated):
         """
         Update and validate local authentication repository and target repositories. Remote
         authentication's repository url needs to be specified when calling this command. If the
@@ -213,7 +214,8 @@ def attach_to_group(group):
         repository as that will also result in an error.
         """
         update_repository(url, clients_auth_path, clients_root_dir, from_fs,
-                          authenticate_test_repo, check_for_unauthenticated=check_for_unauthenticated)
+                          UpdateType.from_name(expected_repo_type),
+                          check_for_unauthenticated=check_for_unauthenticated)
 
     @repo.command()
     @click.argument("clients-auth-path")

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -187,7 +187,7 @@ def attach_to_group(group):
                   "Authentication repo is presumed to be at root-dir/namespace/auth-repo-name")
     @click.option("--from-fs", is_flag=True, default=False, help="Indicates if the we want to clone a "
                   "repository from the filesystem")
-    @click.option("--expected-repo-type", type=click.Choice(["test", "official", "either"]),
+    @click.option("--expected-repo-type", default="either", type=click.Choice(["test", "official", "either"]),
                   help="Indicates expected authentication repository type - test or official. If type is set to either, "
                   "the updater will not check the repository's type")
     @click.option("--check-for-unauthenticated", is_flag=True, help="Check if there are additional new commits "

--- a/taf/updater/handlers.py
+++ b/taf/updater/handlers.py
@@ -91,9 +91,13 @@ class GitUpdater(handlers.MetadataUpdater):
         auth_url = mirrors["mirror1"]["url_prefix"]
         self.metadata_path = mirrors["mirror1"]["metadata_path"]
         self.targets_path = mirrors["mirror1"]["targets_path"]
+        conf_directory_root = settings.conf_directory_root
         if settings.validate_repo_name:
             self.users_auth_repo = NamedAuthenticationRepo(
-                repository_directory, repository_name, repo_urls=[auth_url]
+                repository_directory,
+                repository_name,
+                repo_urls=[auth_url],
+                conf_directory_root=conf_directory_root,
             )
         else:
             users_repo_path = Path(repository_directory, repository_name)
@@ -102,6 +106,7 @@ class GitUpdater(handlers.MetadataUpdater):
                 self.metadata_path,
                 self.targets_path,
                 repo_urls=[auth_url],
+                conf_directory_root=conf_directory_root,
             )
 
         self._clone_validation_repo(auth_url)
@@ -145,7 +150,7 @@ class GitUpdater(handlers.MetadataUpdater):
                 last_validated_commit
             )
         except GitError as e:
-            if "Invalid revision range" in e.output:
+            if "Invalid revision range" in str(e):
                 taf_logger.error(
                     "Commit {} is not contained by the remote repository {}.",
                     last_validated_commit,

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -458,8 +458,7 @@ def _update_target_repositories(
 def _get_commits(
     repository, existing_repository, branch, only_validate, old_head, branch_exists
 ):
-    """Returns a list of newly fetched commits belonging to the specified branch.
-    """
+    """Returns a list of newly fetched commits belonging to the specified branch."""
     if existing_repository:
         repository.fetch(branch=branch)
     if old_head is not None:
@@ -506,7 +505,7 @@ def _get_commits(
 def _merge_branch_commits(
     repository, branch, branch_commits, allow_unauthenticated, new_branch_commits
 ):
-    """ Determines which commits needs to be merged into the specified branch and
+    """Determines which commits needs to be merged into the specified branch and
     merge it.
     """
     last_commit = branch_commits[-1]["commit"]
@@ -519,7 +518,7 @@ def _merge_branch_commits(
 
 
 def _merge_commit(repository, branch, commit_to_merge, allow_unauthenticated=False):
-    """ Merge the specified commit into the given branch and check out the branch.
+    """Merge the specified commit into the given branch and check out the branch.
     If the repository cannot contain unauthenticated commits, check out the merged commit.
     """
     checkout = True

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -507,7 +507,7 @@ def _merge_branch_commits(
     repository, branch, branch_commits, allow_unauthenticated, new_branch_commits
 ):
     """ Determines which commits needs to be merged into the specified branch and
-    merged it.
+    merge it.
     """
     last_commit = branch_commits[-1]["commit"]
     last_validated_commit = last_commit
@@ -519,7 +519,8 @@ def _merge_branch_commits(
 
 
 def _merge_commit(repository, branch, commit_to_merge, allow_unauthenticated=False):
-    """ Merged the specified branch into the given branch
+    """ Merge the specified commit into the given branch and check out the branch.
+    If the repository cannot contain unauthenticated commits, check out the merged commit.
     """
     checkout = True
     try:
@@ -540,7 +541,7 @@ def _merge_commit(repository, branch, commit_to_merge, allow_unauthenticated=Fal
         if not allow_unauthenticated:
             repository.checkout_commit(commit_to_merge)
         else:
-            repository.checkout_branch(repository.default_branch)
+            repository.checkout_branch(branch)
 
 
 def _update_target_repository(

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -330,7 +330,11 @@ def _update_target_repositories(
         # if unauthenticared commits are allow, we also want to check if there are
         # new commits which
         # only check the default branch
-        if not len(repositories_branches_and_commits[path]) and allow_unauthenticated_for_repo and not only_validate:
+        if (
+            not len(repositories_branches_and_commits[path])
+            and allow_unauthenticated_for_repo
+            and not only_validate
+        ):
             repositories_branches_and_commits[path][repository.default_branch] = []
 
         for branch in repositories_branches_and_commits[path]:
@@ -407,10 +411,12 @@ def _update_target_repositories(
                     repo_branch_commits,
                     allow_unauthenticated_for_repo,
                     branch,
-                    check_for_unauthenticated
+                    check_for_unauthenticated,
                 )
                 if len(additional_commits_on_branch):
-                    additional_commits_per_repo.setdefault(repository.name, {})[branch] = additional_commits_on_branch
+                    additional_commits_per_repo.setdefault(repository.name, {})[
+                        branch
+                    ] = additional_commits_on_branch
 
             except UpdateFailedError as e:
                 taf_logger.error("Updated failed due to error {}", str(e))
@@ -446,8 +452,14 @@ def _update_target_repositories(
                         repository.checkout_branch(repository.default_branch)
     return additional_commits_per_repo
 
+
 def _update_target_repository(
-    repository, new_commits, target_commits, allow_unauthenticated, branch, check_for_unauthenticated
+    repository,
+    new_commits,
+    target_commits,
+    allow_unauthenticated,
+    branch,
+    check_for_unauthenticated,
 ):
     taf_logger.info(
         "Validating target repository {} {} branch", repository.name, branch
@@ -506,7 +518,7 @@ def _update_target_repository(
                 if commit == target_commits[-1]:
                     update_successful = True
                     if commit != new_commits[-1]:
-                        additional_commits = new_commits[new_commit_index + 1:]
+                        additional_commits = new_commits[new_commit_index + 1 :]
                     break
             if len(additional_commits):
                 taf_logger.warning(
@@ -535,9 +547,12 @@ def _update_target_repository(
         # pull could've been run manually
         # check where the current local head is
         branch_current_head = repository.top_commit_of_branch(branch)
-        additional_commits = additional_commits[additional_commits.index(branch_current_head)+1:]
+        additional_commits = additional_commits[
+            additional_commits.index(branch_current_head) + 1 :
+        ]
 
     return additional_commits
+
 
 def validate_repository(
     clients_auth_path, clients_root_dir=None, validate_from_commit=None

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -30,9 +30,6 @@ class UpdateType(enum.Enum):
             return update_type
         raise ValueError("{} is not a valid update type".format(name))
 
-    def to_name(self):
-        return UPDATE_TYPES[self.value]
-
 
 UPDATE_TYPES = {
     "test": UpdateType.TEST,


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

- Raise an error if there are additional commits newer than the last authenticated commit if the updater is called with the `check-authenticated` flag 
- A minor validation command fix
- Some improvements made to the updater's error messages
- Initial worktrees support . When merging commits, we need to check out branches which need to be updated. That cannot be done if they are checked out in a different worktree. So try to switch to that worktree and update the branch. Currently, there is no validation if that is possible or permissible. 
- Added support for specifying location of the conf directory
- Replaced authenticate-test-repo flag with an enum
- Added a function for disabling fie logging


## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
