### PR TITLE
Pin cryptography version and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][keepachangelog],
 and this project adheres to [Semantic Versioning][semver].
 
-
 ## [Unreleased]
 
 ### Added
@@ -15,6 +14,19 @@ and this project adheres to [Semantic Versioning][semver].
 ### Fixed
 
 
+## [0.8.0] - 02/09/2020
+
+### Added
+
+### Changed
+
+- Pin cryptography version ([162])
+
+### Fixed
+
+
+[162]: https://github.com/openlawlibrary/taf/pull/162
+
 
 ## [0.7.2] - 11/11/2020
 
@@ -22,11 +34,12 @@ and this project adheres to [Semantic Versioning][semver].
 
 - Add a command for adding new new delegated roles ([158])
 
-[158]: https://github.com/openlawlibrary/taf/pull/158
-
 ### Changed
 
 ### Fixed
+
+
+[158]: https://github.com/openlawlibrary/taf/pull/158
 
 
 ## [0.7.1] - 10/28/2020
@@ -371,7 +384,8 @@ and this project adheres to [Semantic Versioning][semver].
 [keepachangelog]: https://keepachangelog.com/en/1.0.0/
 [semver]: https://semver.org/spec/v2.0.0.html
 
-[Unreleased]: https://github.com/openlawlibrary/pygls/compare/v0.7.2...HEAD
+[Unreleased]: https://github.com/openlawlibrary/taf/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/openlawlibrary/taf/compare/v0.7.2...v.0.8.0
 [0.7.2]: https://github.com/openlawlibrary/taf/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/openlawlibrary/taf/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/openlawlibrary/taf/compare/v0.6.1...v0.7.0

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 PACKAGE_NAME = "taf"
-VERSION = "0.7.2"
+VERSION = "0.8.0"
 AUTHOR = "Open Law Library"
 AUTHOR_EMAIL = "info@openlawlib.org"
 DESCRIPTION = "Implementation of archival authentication"

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     install_requires=[
         "click==6.7",
         "colorama>=0.3.9",
-        "cryptography>=2.3.1",
+        "cryptography==3.3.1",
         "oll-tuf==0.11.2.dev9",
         "loguru==0.4.0",
     ],


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

A function used by `yubikey-manager` was deprecated in newer `cryptography` releases. Until `yubikey-manager` is updated, it is necessary to use an older `cryptography` release

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
