### PR TITLE
Support for skipping automatic checkout and updater fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,15 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
+- Added support for skipping automatic checkout ([179])
 
 ### Changed
 
 
 ### Fixed
 
+
+[179]: https://github.com/openlawlibrary/taf/pull/179
 
 ## [0.10.1] - 08/16/2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,15 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- Compare current head commit according to the auth repo and top commit of target repo and raise an error if they are different ([179])
+
 
 ### Fixed
+
+- Automatically remove current and previous directories if they exist before instantiating tuf repo ([179])
+- Fixed branch exists check. Avoid wrongly returning true if there is a warning ([179])
+- Fixed update of repos which can contain unauhtenticated commits - combine fetched and existing commits ([179])
+- Fixed handling of additional commits on a branch ([179])
 
 
 [179]: https://github.com/openlawlibrary/taf/pull/179

--- a/taf/git.py
+++ b/taf/git.py
@@ -350,12 +350,11 @@ class GitRepository:
                 # finally, check remote branch
                 if self.has_remote():
                     return (
-                        self._git(
+                        branch_name in self._git(
                             f"ls-remote --heads origin {branch_name}",
                             log_error_msg=f"Repo {self.name}: could check if the branch exists in the remote repository",
                             reraise_error=True,
                         )
-                        != ""
                     )
 
         return False
@@ -420,7 +419,6 @@ class GitRepository:
         self._git("clean -fd")
 
     def clone(self, no_checkout=False, bare=False, **kwargs):
-
         self._log_info("cloning repository")
         shutil.rmtree(self.path, True)
         self.path.mkdir(exist_ok=True, parents=True)

--- a/taf/git.py
+++ b/taf/git.py
@@ -349,12 +349,10 @@ class GitRepository:
 
                 # finally, check remote branch
                 if self.has_remote():
-                    return (
-                        branch_name in self._git(
-                            f"ls-remote --heads origin {branch_name}",
-                            log_error_msg=f"Repo {self.name}: could check if the branch exists in the remote repository",
-                            reraise_error=True,
-                        )
+                    return branch_name in self._git(
+                        f"ls-remote --heads origin {branch_name}",
+                        log_error_msg=f"Repo {self.name}: could check if the branch exists in the remote repository",
+                        reraise_error=True,
                     )
 
         return False
@@ -877,7 +875,7 @@ class GitRepository:
         return self._git(f"rev-parse {branch}")
 
     def _validate_repo_name(self, name):
-        """ Ensure the repo name is not malicious """
+        """Ensure the repo name is not malicious"""
         match = _repo_name_re.match(name)
         if not match:
             taf_logger.error(f"Repository name {name} is not valid")
@@ -909,7 +907,7 @@ class GitRepository:
         return repo_dir
 
     def _validate_url(self, url):
-        """ ensure valid URL """
+        """ensure valid URL"""
         for _url_re in [_http_fttp_url, _ssh_url]:
             match = _url_re.match(url)
             if match:

--- a/taf/repository_tool.py
+++ b/taf/repository_tool.py
@@ -285,6 +285,12 @@ class Repository:
         if not self.targets_path.is_dir():
             targets_existed = False
             self.targets_path.mkdir(parents=True, exist_ok=True)
+        current_dir = self.metadata_path / "current"
+        previous_dir = self.metadata_path / "previous"
+        if current_dir.is_dir():
+            shutil.rmtree(current_dir)
+        if previous_dir.is_dir():
+            shutil.rmtree(previous_dir)
         try:
             self._tuf_repository = load_repository(str(path), self.name)
         except RepositoryError:

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -826,7 +826,7 @@ def _update_target_repositories(
                     branch_commits,
                     allow_unauthenticated[path],
                     new_commits[path][branch],
-                    checkout
+                    checkout,
                 )
 
     return additional_commits_per_repo, _set_target_repositories_data(
@@ -885,7 +885,12 @@ def _get_commits(
 
 
 def _merge_branch_commits(
-    repository, branch, branch_commits, allow_unauthenticated, new_branch_commits, checkout=True
+    repository,
+    branch,
+    branch_commits,
+    allow_unauthenticated,
+    new_branch_commits,
+    checkout=True,
 ):
     """Determines which commits needs to be merged into the specified branch and
     merge it.
@@ -901,7 +906,9 @@ def _merge_branch_commits(
     _merge_commit(repository, branch, commit_to_merge, allow_unauthenticated)
 
 
-def _merge_commit(repository, branch, commit_to_merge, allow_unauthenticated=False, checkout=True):
+def _merge_commit(
+    repository, branch, commit_to_merge, allow_unauthenticated=False, checkout=True
+):
     """Merge the specified commit into the given branch and check out the branch.
     If the repository cannot contain unauthenticated commits, check out the merged commit.
     """

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -895,15 +895,13 @@ def _merge_branch_commits(
     """Determines which commits needs to be merged into the specified branch and
     merge it.
     """
-    if not checkout:
-        return
     last_commit = branch_commits[-1]["commit"]
     last_validated_commit = last_commit
     commit_to_merge = (
         last_validated_commit if not allow_unauthenticated else new_branch_commits[-1]
     )
     taf_logger.info("Merging {} into {}", commit_to_merge, repository.name)
-    _merge_commit(repository, branch, commit_to_merge, allow_unauthenticated)
+    _merge_commit(repository, branch, commit_to_merge, allow_unauthenticated, checkout)
 
 
 def _merge_commit(
@@ -912,8 +910,6 @@ def _merge_commit(
     """Merge the specified commit into the given branch and check out the branch.
     If the repository cannot contain unauthenticated commits, check out the merged commit.
     """
-    if not checkout:
-        return
     taf_logger.info("Merging commit {} into {}", commit_to_merge, repository.name)
     try:
         repository.checkout_branch(branch, raise_anyway=True)

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -785,6 +785,7 @@ def _update_target_repositories(
                 only_validate,
                 old_head,
                 branch_exists,
+                allow_unauthenticated_for_repo,
             )
             top_commits_of_branches_before_pull.setdefault(path, {})[branch] = old_head
             new_commits[path].setdefault(branch, []).extend(new_commits_on_repo_branch)
@@ -838,13 +839,13 @@ def _update_target_repositories(
 
 
 def _get_commits(
-    repository, existing_repository, branch, only_validate, old_head, branch_exists
+    repository, existing_repository, branch, only_validate, old_head, branch_exists, allow_unauthenticated_commits
 ):
     """Returns a list of newly fetched commits belonging to the specified branch."""
     if existing_repository:
         repository.fetch(branch=branch)
     if old_head is not None:
-        if not only_validate:
+        if not only_validate and not allow_unauthenticated_commits:
             # if the local branch does not exist (the branch was not checked out locally)
             # fetched commits will include already validated commits
             # check which commits are newer that the previous head commit

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -632,7 +632,6 @@ def _update_current_repository(
             _commits_ret(commits, existing_repo, False),
             UpdaterAdditionalCommitsError(additional_commits_per_repo),
             {},
-            {},
         )
 
     # commits list will always contain the previous top commit of the repository
@@ -825,6 +824,7 @@ def _update_target_repositories(
                     branch,
                     branch_commits,
                     allow_unauthenticated[path],
+                    additional_commits_per_repo.get(path, {}).get(branch),
                     new_commits[path][branch],
                     checkout,
                 )
@@ -889,13 +889,17 @@ def _merge_branch_commits(
     branch,
     branch_commits,
     allow_unauthenticated,
+    additional_commits,
     new_branch_commits,
     checkout=True,
 ):
     """Determines which commits needs to be merged into the specified branch and
     merge it.
     """
-    last_commit = branch_commits[-1]["commit"]
+    if additional_commits is not None:
+        allow_unauthenticated = False
+    last_commit = branch_commits[-1]['commit']
+
     last_validated_commit = last_commit
     commit_to_merge = (
         last_validated_commit if not allow_unauthenticated else new_branch_commits[-1]
@@ -1063,9 +1067,10 @@ def _update_target_repository(
         # pull could've been run manually
         # check where the current local head is
         branch_current_head = repository.top_commit_of_branch(branch)
-        additional_commits = additional_commits[
-            additional_commits.index(branch_current_head) + 1 :
-        ]
+        if branch_current_head in additional_commits:
+            additional_commits = additional_commits[
+                additional_commits.index(branch_current_head) + 1 :
+            ]
 
     return additional_commits
 

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -733,7 +733,7 @@ def _update_target_repositories(
             cloned_repositories.append(repository)
 
         # if no commits were published, repositories_branches_and_commits will be empty
-        # if unauthenticared commits are allow, we also want to check if there are
+        # if unauthenticared commits are allowed, we also want to check if there are
         # new commits which
         # only check the default branch
         if (
@@ -775,6 +775,18 @@ def _update_target_repositories(
                 # of the authentication repository's master branch at the time
                 # of update's invocation
                 old_head = repo_branch_commits[0]
+                if not allow_unauthenticated_for_repo:
+                    repo_old_head = repository.top_commit_of_branch(branch)
+                    if repo_old_head != old_head:
+                        taf_logger.error(
+                            "Mismatch between commits {} and {}",
+                            old_head,
+                            repo_old_head,
+                        )
+                        raise UpdateFailedError(
+                            "Mismatch between target commits specified in authentication repository"
+                            f" and target repository {repository.name} on branch {branch}"
+                        )
 
             # the repository was cloned if it didn't exist
             # if it wasn't cloned, fetch the current branch
@@ -839,7 +851,13 @@ def _update_target_repositories(
 
 
 def _get_commits(
-    repository, existing_repository, branch, only_validate, old_head, branch_exists, allow_unauthenticated_commits
+    repository,
+    existing_repository,
+    branch,
+    only_validate,
+    old_head,
+    branch_exists,
+    allow_unauthenticated_commits,
 ):
     """Returns a list of newly fetched commits belonging to the specified branch."""
     if existing_repository:
@@ -908,7 +926,7 @@ def _merge_branch_commits(
     """
     if additional_commits is not None:
         allow_unauthenticated = False
-    last_commit = branch_commits[-1]['commit']
+    last_commit = branch_commits[-1]["commit"]
 
     last_validated_commit = last_commit
     commit_to_merge = (
@@ -1067,7 +1085,7 @@ def _update_target_repository(
         )
         raise UpdateFailedError(
             "Mismatch between target commits specified in authentication repository"
-            f" and target repository {repository.name}"
+            f" and target repository {repository.name} on branch {branch}"
         )
     taf_logger.info("Successfully validated {}", repository.name)
 


### PR DESCRIPTION
- Added a flag which makes it possible to only update and validate the repositories without checking out the last validated commit
- Fixed handling of additional commits on a branch
- A minor branch exists fix
- Compare current head commit according to the auth repo and top commit of target repo

## Description (e.g. "Related to ...", etc.)

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
