### PR TITLE
Remove checkout commit and validate commits newer than the last_validated_commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,14 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- Remove commit checkout and checkout the latest branch for each target repository ([195])
+- If top commit of the authentication repository is not the same as the `last_validated_commit`, validate the newer commits as if they were just pulled ([195])
+
 ### Fixed
+
+
+[195]: https://github.com/openlawlibrary/taf/pull/195
+
 
 ## [0.13.1] - 10/22/2021
 
@@ -29,7 +36,7 @@ and this project adheres to [Semantic Versioning][semver].
 - Pass default branch to sorted_commits_and_branches_per_repositories ([185])
 
 
-[185] https://github.com/openlawlibrary/taf/pull/185
+[185]: https://github.com/openlawlibrary/taf/pull/185
 
 
 ## [0.13.0] - 10/20/2021
@@ -45,7 +52,7 @@ and this project adheres to [Semantic Versioning][semver].
 ### Fixed
 
 
-[184] https://github.com/openlawlibrary/taf/pull/184
+[184]: https://github.com/openlawlibrary/taf/pull/184
 
 
 ## [0.12.0] - 10/18/2021
@@ -63,7 +70,7 @@ and this project adheres to [Semantic Versioning][semver].
 - Fix validate local repo command ([183])
 
 
-[183] https://github.com/openlawlibrary/taf/pull/183
+[183]: https://github.com/openlawlibrary/taf/pull/183
 
 
 ## [0.11.2] - 09/29/2021

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ strategy:
       imageName: "ubuntu-20.04"
       pythonVersion: "3.8"
     macOS-py38:
-      imageName: "macOS-10.14"
+      imageName: "macOS-10.15"
       pythonVersion: "3.8"
     windows-64bit-py38:
       imageName: "vs2017-win2016"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ strategy:
       imageName: "ubuntu-20.04"
       pythonVersion: "3.6"
     macOS-py36:
-      imageName: "macOS-10.14"
+      imageName: "macOS-10.15"
       pythonVersion: "3.6"
     windows-64bit-py36:
       imageName: "vs2017-win2016"

--- a/taf/git.py
+++ b/taf/git.py
@@ -580,6 +580,9 @@ class GitRepository:
         self._log_debug(f"found the following commits: {commits}")
         return commits
 
+    def commit_before_commit(self, commit):
+        return self._git(f"log {commit}^ -1 --pretty=%H", log_error=True).strip()
+
     def delete_local_branch(self, branch_name, force=False):
         """Deletes local branch."""
         flag = "-D" if force else "-d"

--- a/taf/tests/test_updater.py
+++ b/taf/tests/test_updater.py
@@ -325,7 +325,6 @@ def test_older_last_validated_commit(updater_repositories, origin_dir, client_di
     )
     all_commits = client_repos[AUTH_REPO_REL_PATH].all_commits_on_branch()
     first_commit = all_commits[0]
-    last_commit = all_commits[-1]
 
     _create_last_validated_commit(client_dir, first_commit)
     # try to update without setting the last validated commit

--- a/taf/tests/test_updater.py
+++ b/taf/tests/test_updater.py
@@ -315,7 +315,7 @@ def test_no_last_validated_commit(updater_repositories, origin_dir, client_dir):
     _update_and_check_commit_shas(client_repos, repositories, origin_dir, client_dir)
 
 
-def test_invalid_last_validated_commit(updater_repositories, origin_dir, client_dir):
+def test_older_last_validated_commit(updater_repositories, origin_dir, client_dir):
     # clone the origin repositories
     # revert them to an older commit
     repositories = updater_repositories["test-updater-valid"]
@@ -326,14 +326,10 @@ def test_invalid_last_validated_commit(updater_repositories, origin_dir, client_
     all_commits = client_repos[AUTH_REPO_REL_PATH].all_commits_on_branch()
     first_commit = all_commits[0]
     last_commit = all_commits[-1]
-    expected_error = LAST_VALIDATED_COMMIT_MISMATCH.format(
-        first_commit, AUTH_REPO_REL_PATH, last_commit
-    )
+
     _create_last_validated_commit(client_dir, first_commit)
     # try to update without setting the last validated commit
-    _update_invalid_repos_and_check_if_remained_same(
-        client_repos, client_dir, repositories, expected_error
-    )
+    _update_and_check_commit_shas(client_repos, repositories, origin_dir, client_dir)
 
 
 def test_update_test_repo_no_flag(updater_repositories, origin_dir, client_dir):

--- a/taf/tools/yubikey/__init__.py
+++ b/taf/tools/yubikey/__init__.py
@@ -1,7 +1,6 @@
 import click
 import json
 import taf.developer_tool as developer_tool
-from taf.yubikey import is_valid_pin
 from taf.exceptions import YubikeyError
 
 
@@ -16,6 +15,7 @@ def attach_to_group(group):
     def check_pin(pin):
         """Checks if the specified pin is valid"""
         try:
+            from taf.yubikey import is_valid_pin
             valid, retries = is_valid_pin(pin)
             inserted = True
         except YubikeyError:

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -936,12 +936,10 @@ def _merge_branch_commits(
         last_validated_commit if not allow_unauthenticated else new_branch_commits[-1]
     )
     taf_logger.info("Merging {} into {}", commit_to_merge, repository.name)
-    _merge_commit(repository, branch, commit_to_merge, allow_unauthenticated, checkout)
+    _merge_commit(repository, branch, commit_to_merge, checkout)
 
 
-def _merge_commit(
-    repository, branch, commit_to_merge, allow_unauthenticated=False, checkout=True
-):
+def _merge_commit(repository, branch, commit_to_merge, checkout=True):
     """Merge the specified commit into the given branch and check out the branch.
     If the repository cannot contain unauthenticated commits, check out the merged commit.
     """
@@ -961,10 +959,8 @@ def _merge_commit(
 
     repository.merge_commit(commit_to_merge)
     if checkout:
-        if not allow_unauthenticated:
-            repository.checkout_commit(commit_to_merge)
-        else:
-            repository.checkout_branch(branch)
+        taf_logger.info("{}: checking out branch {}", repository.name, branch)
+        repository.checkout_branch(branch)
 
 
 def _set_target_repositories_data(


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

- Remove commit checkout - this leaves a repository in detached commit state. Instead, checkout the latest branch. This makes sense because if a branch cannot contain unauthenticated commits, the validation should fail if there are additional commits. If it can contain such commits, there is a flag to raise an error if there are additional unauthenticated commits in the remote repository which are not available locally. That means that the user needs to pull manually and check the new commits, thus making sure that they look good.
- If top commit of the authentication repository is not the same as the `last_validated_commit`, validate the newer commits as if they were just pulled. Do the same if a target repository contains commits which are newer than the ones which correspond to the authentication repository's target data.

Closes #194

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
