### PR TITLE
add pytest11 endpoint only if tests are available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ and this project adheres to [Semantic Versioning][semver].
 
 
 ### Fixed
+- pytest works when taf installed via wheel ([200])
 
+[200]: https://github.com/openlawlibrary/taf/pull/200
 
 ## [0.13.3] - 11/18/2021
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import find_packages, setup
+import importlib
 
 PACKAGE_NAME = "taf"
 VERSION = "0.13.3"
@@ -42,22 +43,22 @@ tests_require = ["pytest==4.5.0", "freezegun==0.3.15", "jsonschema==3.2.0"]
 
 yubikey_require = ["yubikey-manager==3.0.0"]
 
-setup(
-    name=PACKAGE_NAME,
-    version=VERSION,
-    description=DESCRIPTION,
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url=URL,
-    author=AUTHOR,
-    author_email=AUTHOR_EMAIL,
-    keywords=KEYWORDS,
-    packages=packages,
-    cmdclass={"bdist_wheel": bdist_wheel},
-    include_package_data=True,
-    data_files=[("lib/site-packages/taf", ["./LICENSE.txt", "./README.md"])],
-    zip_safe=False,
-    install_requires=[
+kwargs = {
+    "name": PACKAGE_NAME,
+    "version": VERSION,
+    "description": DESCRIPTION,
+    "long_description": long_description,
+    "long_description_content_type": "text/markdown",
+    "url": URL,
+    "author": AUTHOR,
+    "author_email": AUTHOR_EMAIL,
+    "keywords": KEYWORDS,
+    "packages": packages,
+    "cmdclass": {"bdist_wheel"": bdist_wheel},
+    "include_package_data": True,
+    "data_files": [("lib/site-packages/taf", ["./LICENSE.txt", "./README.md"])],
+    "zip_safe": "False,
+    "install_requires": "[
         "click==7.1",
         "colorama>=0.3.9",
         "oll-tuf==0.11.2.dev9",
@@ -65,14 +66,14 @@ setup(
         "cryptography==3.2.1",
         "pyOpenSSL==20.0.1",
     ],
-    extras_require={
+    "extras_require": {
         "ci": ci_require,
         "test": tests_require,
         "dev": dev_require,
         "yubikey": yubikey_require,
     },
-    tests_require=tests_require,
-    entry_points={
+    "tests_require": tests_require,
+    "entry_points": {
         "console_scripts": [
             "taf = taf.tools.cli.taf:main",
             "olc = taf.tools.cli.olc:main",
@@ -91,4 +92,11 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: Implementation :: CPython",
     ],
-)
+}
+
+from importlib.util import find_spec
+if importlib.find_spec("taf.tests")
+if find_spec('taf.tests'):
+    kwargs['entry_points']["pytest11"] = ["taf_yubikey_utils = taf.tests.yubikey_utils"],
+
+setup(**kwargs)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import find_packages, setup
-import importlib
+from importlib.util import find_spec
 
 PACKAGE_NAME = "taf"
 VERSION = "0.13.3"
@@ -94,7 +94,6 @@ kwargs = {
     ],
 }
 
-from importlib.util import find_spec
 
 try:
     tests_exist = find_spec("taf.tests")

--- a/setup.py
+++ b/setup.py
@@ -54,11 +54,11 @@ kwargs = {
     "author_email": AUTHOR_EMAIL,
     "keywords": KEYWORDS,
     "packages": packages,
-    "cmdclass": {"bdist_wheel"": bdist_wheel},
+    "cmdclass": {"bdist_wheel": bdist_wheel},
     "include_package_data": True,
     "data_files": [("lib/site-packages/taf", ["./LICENSE.txt", "./README.md"])],
-    "zip_safe": "False,
-    "install_requires": "[
+    "zip_safe": False,
+    "install_requires": [
         "click==7.1",
         "colorama>=0.3.9",
         "oll-tuf==0.11.2.dev9",
@@ -80,7 +80,7 @@ kwargs = {
         ],
         "pytest11": ["taf_yubikey_utils = taf.tests.yubikey_utils"],
     },
-    classifiers=[
+    "classifiers": [
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",
         "Intended Audience :: Information Technology",
@@ -95,8 +95,10 @@ kwargs = {
 }
 
 from importlib.util import find_spec
-if importlib.find_spec("taf.tests")
-if find_spec('taf.tests'):
-    kwargs['entry_points']["pytest11"] = ["taf_yubikey_utils = taf.tests.yubikey_utils"],
+
+if find_spec("taf.tests"):
+    kwargs["entry_points"]["pytest11"] = (
+        ["taf_yubikey_utils = taf.tests.yubikey_utils"],
+    )
 
 setup(**kwargs)

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,11 @@ kwargs = {
 
 from importlib.util import find_spec
 
-if find_spec("taf.tests"):
+try:
+    tests_exist = find_spec("taf.tests")
+except ModuleNotFoundError:
+    tests_exist = False
+if tests_exist:
     kwargs["entry_points"]["pytest11"] = (
         ["taf_yubikey_utils = taf.tests.yubikey_utils"],
     )


### PR DESCRIPTION
taf.tests module is not available in the wheel,
but the pytest11 entrypoint requires taf.tests, and
is always called by any pytest in any environment
that has taf installed. So any call to pytest will
always fail if taf wheel is installed.

By only conditionally adding pytest11 if taf.tests
exists, the entrypoint will only be available when
installed as source.

## Description (e.g. "Related to ...", etc.)

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
