### PR TITLE
Clone should not always remove existing data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][keepachangelog],
 and this project adheres to [Semantic Versioning][semver].
 
-
 ## [Unreleased]
 
 ### Added
 
-
 ### Changed
 
+- Only clone if directory is empty ([211])
 
 ### Fixed
+
+[211]: https://github.com/openlawlibrary/taf/pull/211
 
 ## [0.15.0] - 02/11/2022
 

--- a/taf/git.py
+++ b/taf/git.py
@@ -1,7 +1,6 @@
 import json
 import os
 import re
-import shutil
 import subprocess
 import logging
 from collections import OrderedDict
@@ -436,8 +435,14 @@ class GitRepository:
 
     def clone(self, no_checkout=False, bare=False, **kwargs):
         self._log_info("cloning repository")
-        shutil.rmtree(self.path, True)
+
         self.path.mkdir(exist_ok=True, parents=True)
+        if len(os.listdir(self.path)) != 0:
+            raise GitError(
+                repo=self,
+                message=f"destination path {self.path} is not an empty directory.",
+            )
+
         if self.urls is None:
             raise GitError(
                 repo=self, message="cannot clone repository. No urls were specified"

--- a/taf/updater/handlers.py
+++ b/taf/updater/handlers.py
@@ -219,6 +219,7 @@ class GitUpdater(handlers.MetadataUpdater):
 
         metadata_path = Path(self.repository_directory, "metadata")
         metadata_path.mkdir(parents=True, exist_ok=True)
+        self.metadata_dir_path = metadata_path
         self.current_path = Path(metadata_path, "current")
         self.current_path.mkdir()
         self.previous_path = Path(metadata_path, "previous")
@@ -254,13 +255,12 @@ class GitUpdater(handlers.MetadataUpdater):
         directories. This should be called after the update is finished,
         either successfully or unsuccessfully.
         """
-        if self.current_path.is_dir():
-            shutil.rmtree(self.current_path)
-        if self.previous_path.is_dir():
-            shutil.rmtree(self.previous_path)
+        if self.metadata_dir_path.is_dir():
+            shutil.rmtree(self.metadata_dir_path)
         self.validation_auth_repo.cleanup()
         temp_dir = Path(self.validation_auth_repo.path, os.pardir).parent
-        shutil.rmtree(str(temp_dir), onerror=on_rm_error)
+        if temp_dir.is_dir():
+            shutil.rmtree(str(temp_dir), onerror=on_rm_error)
 
     def earliest_valid_expiration_time(self):
         # Only validate expiration time of the last commit

--- a/taf/updater/lifecycle_handlers.py
+++ b/taf/updater/lifecycle_handlers.py
@@ -122,7 +122,7 @@ def _handle_event(
         repos_and_data = _execute_scripts(repos_and_data, lifecycle_stage, event)
 
     # execute completed handler at the end
-    _print_data(repos_and_data, library_dir, lifecycle_stage)
+    # _print_data(repos_and_data, library_dir, lifecycle_stage)
     repos_and_data = _execute_scripts(repos_and_data, lifecycle_stage, Event.COMPLETED)
 
     # return formatted response if update lifecycle is done


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)
Closes #22 

We've been recursively deleting the contents of current directory before running clone. This can be concerning depending on the file system path that's being deleted. Instead, simply raise an error if the repository that's being cloned into has file contents. This is how `git clone` operates aswell.

Also: fix print_data dump that leaves trailing `persistent.json` and `data` lying around on file system when running the updater.

## How to test

Add a law repository, delete it's `.git` folder, and run the updater.


## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
