### PR TITLE
Remove --error-if-unauthenticated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,16 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
-- change `clients-auth-path` in `taf repo update` to optional. ([#213])
+- Remove `--error-if-unauthenticated` flag ([220])
+- Change `clients-auth-path` in `taf repo update` to optional. ([213])
 - Only clone if directory is empty ([211])
 
 ### Fixed
 
 - Fixed `_validate_urls` and local validation ([216])
 
-[215]: https://github.com/openlawlibrary/taf/pull/216
+[220]: https://github.com/openlawlibrary/taf/pull/220
+[216]: https://github.com/openlawlibrary/taf/pull/216
 [213]: https://github.com/openlawlibrary/taf/pull/213
 [211]: https://github.com/openlawlibrary/taf/pull/211
 

--- a/taf/exceptions.py
+++ b/taf/exceptions.py
@@ -147,20 +147,5 @@ class UpdateFailedError(TAFError):
     pass
 
 
-class UpdaterAdditionalCommitsError(TAFError):
-    def __init__(self, additional_commits_per_repo, message=None):
-        self.additional_commits_per_repo = additional_commits_per_repo
-        if message is None:
-            message = ""
-            for repo, branch_commits in additional_commits_per_repo.items():
-                for branch, commits in branch_commits.items():
-                    message += f"Repository {repo}: branch {branch} contains {len(commits)} additional"
-                    if len(commits) > 1:
-                        message += "commits\n"
-                    else:
-                        message += "commit\n"
-        self.message = message
-
-
 class YubikeyError(Exception):
     pass

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -191,14 +191,10 @@ def attach_to_group(group):
     @click.option("--expected-repo-type", default="either", type=click.Choice(["test", "official", "either"]),
                   help="Indicates expected authentication repository type - test or official. If type is set to either, "
                   "the updater will not check the repository's type")
-    @click.option("--error-if-unauthenticated-repos-list", multiple=True, help="Raise an error if the repository allows "
-                  "unauthentiated commits and the updater detected authenticated commits newer than local "
-                  "head commit")
     @click.option("--scripts-root-dir", default=None, help="Scripts root directory, which can be used to move scripts "
                   "out of the authentication repository for testing purposes (avoid dirty index). Scripts will be expected "
                   "to be located in scripts_root_dir/repo_name directory")
-    def update(url, clients_auth_path, clients_library_dir, default_branch, from_fs, expected_repo_type, error_if_unauthenticated_repos_list,
-               scripts_root_dir):
+    def update(url, clients_auth_path, clients_library_dir, default_branch, from_fs, expected_repo_type, scripts_root_dir):
         """
         Update and validate local authentication repository and target repositories. Remote
         authentication's repository url needs to be specified when calling this command. If the
@@ -219,11 +215,6 @@ def attach_to_group(group):
         if this flag is omitted in the mentioned case. Do not use this flag when validating a non-test
         repository as that will also result in an error.
 
-        Some repositories can contain unauthenticated commits in-between two authenticated ones. The updater
-        will check existence and order of all authenticated commits and ignore unauthenticated. To raise
-        an error if there are new unauthenticated commits (newer than the last local commit),
-        error-if-unauthenticated option can be used.
-
         Scripts root directory option can be used to move scripts out of the authentication repository for
         testing purposes (avoid dirty index). Scripts will be expected  o be located in scripts_root_dir/repo_name directory
         """
@@ -231,8 +222,7 @@ def attach_to_group(group):
             raise click.UsageError('Must specify either authentication repository path or library directory!')
 
         update_repository(url, clients_auth_path, clients_library_dir, default_branch, from_fs,
-                          UpdateType(expected_repo_type),
-                          error_if_unauthenticated_repos_list=error_if_unauthenticated_repos_list, scripts_root_dir=scripts_root_dir)
+                          UpdateType(expected_repo_type), scripts_root_dir=scripts_root_dir)
 
     @repo.command()
     @click.argument("clients-auth-path")


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Closes #204 

Cross-post commit message:

* Based on https://github.com/openlawlibrary/taf/issues/204, we proposed the solution to remove the flag altogether.
Historically, this flag was used to specify repositories for which the
updater shouldn't perform the update if there are additional unauthenticated
commits.

* Now, we perform the update and the updater returns an update reponse.
  Within that response is an `unauthenticated` commits dictionary (see
  `schemas.py` for example [1]). We delegate the error handling to the end-user, instead of the framework.

* Remove --error-if-unauthenticated flag, and exceptions that were
  raised.

[1] - law-xml updater response from [here](https://github.com/openlawlibrary/taf/blob/master/taf/tests/data/handler_inputs/valid/update/update.json)
```
"commits": {
          "master": {
              "before_pull": {
                  "commit": "1cd086ecb8e23555379611abfff94137eda0f398",
                  "custom": {
                      "build-date": "2021-12-02"
                  }
              },
              "after_pull": {
                  "commit": "1cd086ecb8e23555379611abfff94137eda0f398",
                  "custom": {
                      "build-date": "2021-12-02"
                  }
              },
              "new": [],
              "unauthenticated": [
                  "a5978b4b3bada811c9bf1fd5214b6c45e3f468b4",
                  "f496b5d247eba85a7028e5774cea65f16e786491",
                  "1e1ca36f3a58f8d01d4d63cb4b4884fa5e123cac",
                  "2a5e2fb3dceaa4c68de4edbdcbc12a98fa74c093"
              ]
          }
      }
  }
```


## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
