### PR TITLE
Simplify commit merge; exclude worktrees

### DIFF
--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -694,7 +694,7 @@ def _update_current_repository(
             if users_auth_repo.is_git_repository_root:
                 users_auth_repo.fetch(fetch_all=True)
             else:
-                users_auth_repo.clone(no_checkout=True)
+                users_auth_repo.clone()
 
         # load target repositories and validate them
         repositoriesdb.load_repositories(


### PR DESCRIPTION
* Since TAF isn't called by worktree repositories,
  simplify commit merge logic by not passing down additional_commits arg
  to `_merge_branch_commits`.

* Remove no_checkout=True argument for clone call, because we've already
  validated targets calling clone, so we can safely checkout the default
  branch now.

* Use `repository.merge_commit(commit)` instead of `repository.checkout_commit(commit)` since checking out a commit in the history leaves the commit in a detached HEAD state. Not sure whether we still need to checkout the same branch before and after merging the commit.

## Description (e.g. "Related to ...", etc.)

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
