### PR TITLE
Clear clone `no_checkout=True`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- Remove `no_checkout=True` from `clone` ([226])
 - Remove `--error-if-unauthenticated` flag ([220])
 - Change `clients-auth-path` in `taf repo update` to optional. ([213])
 - Only clone if directory is empty ([211])
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning][semver].
 - Fix updates of repos which only contain one commit ([219])
 - Fixed `_validate_urls` and local validation ([216])
 
+[226]: https://github.com/openlawlibrary/taf/pull/226
 [220]: https://github.com/openlawlibrary/taf/pull/220
 [219]: https://github.com/openlawlibrary/taf/pull/219
 [216]: https://github.com/openlawlibrary/taf/pull/216

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -694,7 +694,7 @@ def _update_current_repository(
             if users_auth_repo.is_git_repository_root:
                 users_auth_repo.fetch(fetch_all=True)
             else:
-                users_auth_repo.clone(no_checkout=True)
+                users_auth_repo.clone()
 
         # load target repositories and validate them
         repositoriesdb.load_repositories(


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Remove `no_checkout=True` argument for `clone` call, because we've already
validated targets calling clone, so we can safely checkout the default
branch now.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
