### PR TITLE
Performance and profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
-
+-  Update `targets_at_revisions` - only update a list of roles if a metadata file was added ([228])
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- Cache git and temp files ([228])
 - Remove `no_checkout=True` from `clone` ([226])
 - Remove `--error-if-unauthenticated` flag ([220])
 - Change `clients-auth-path` in `taf repo update` to optional. ([213])
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning][semver].
 - Fix updates of repos which only contain one commit ([219])
 - Fixed `_validate_urls` and local validation ([216])
 
+[228]: https://github.com/openlawlibrary/taf/pull/228
 [226]: https://github.com/openlawlibrary/taf/pull/226
 [220]: https://github.com/openlawlibrary/taf/pull/220
 [219]: https://github.com/openlawlibrary/taf/pull/219

--- a/taf/auth_repo.py
+++ b/taf/auth_repo.py
@@ -1,6 +1,5 @@
 import json
 import os
-from sys import meta_path
 import tempfile
 from collections import defaultdict
 from contextlib import contextmanager

--- a/taf/auth_repo.py
+++ b/taf/auth_repo.py
@@ -283,9 +283,11 @@ class AuthenticationRepository(GitRepository, TAFRepository):
 
             for role_name in roles_at_revision:
                 # targets metadata files corresponding to the found roles must exist
-                targets_at_revision = self.get_json(
+                targets_at_revision = self.safely_get_json(
                     commit, get_role_metadata_path(role_name)
                 )
+                if targets_at_revision is None:
+                    continue
                 targets_at_revision = targets_at_revision["signed"]["targets"]
 
                 for target_path in targets_at_revision:

--- a/taf/git.py
+++ b/taf/git.py
@@ -32,7 +32,6 @@ class GitRepository:
         default_branch="main",
         allow_unsafe=False,
         path=None,
-        allow_unsafe=False
         *args,
         **kwargs,
     ):

--- a/taf/git.py
+++ b/taf/git.py
@@ -31,6 +31,7 @@ class GitRepository:
         custom=None,
         default_branch="main",
         path=None,
+        allow_unsafe=False
         *args,
         **kwargs,
     ):
@@ -630,15 +631,15 @@ class GitRepository:
         s = self.get_file(commit, path, raw=raw)
         return json.loads(s)
 
-    def get_file(self, commit, path, raw=False):
+    def get_file(self, commit, path, raw=False, with_id=False):
         path = Path(path).as_posix()
         if raw:
             return self._git("show {}:{}", commit, path, raw=raw)
         try:
-            out = self.pygit.get_file(commit, path)
-            # if not out:
-            #     import pdb; pdb.set_trace()
-            return out
+            git_id, content = self.pygit.get_file(commit, path)
+            if with_id:
+                return git_id, content
+            return content
         except TAFError as e:
             raise e
         except Exception:

--- a/taf/pygit.py
+++ b/taf/pygit.py
@@ -15,6 +15,8 @@ class PyGitRepository:
         self.path = encapsulating_repo.path
         self.repo = pygit2.Repository(str(self.path))
 
+    _files_cache = {}
+
     def _get_child(self, parent, path_part):
         """
         Return the child object of a parent object.
@@ -75,7 +77,11 @@ class PyGitRepository:
                 message=f"fatal: Path '{path}' does not exist in '{commit}'",
             )
         else:
-            return blob.read_raw().decode()
+            git_id = blob.hex
+            if git_id not in self._files_cache:
+                content = blob.read_raw().decode()
+                self._files_cache[git_id] = content
+            return git_id, self._files_cache[git_id]
 
     def _list_files_at_revision(self, tree, path="", results=None):
         """

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -1,5 +1,4 @@
 import click
-from pathlib import Path
 import taf.developer_tool as developer_tool
 from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
 from taf.updater.updater import update_repository, validate_repository, UpdateType
@@ -225,8 +224,6 @@ def attach_to_group(group):
 
         if profile:
             import cProfile
-            import pstats
-            import io
             import atexit
 
             print("Profiling...")

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -1,4 +1,5 @@
 import click
+from pathlib import Path
 import taf.developer_tool as developer_tool
 from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
 from taf.updater.updater import update_repository, validate_repository, UpdateType
@@ -194,7 +195,8 @@ def attach_to_group(group):
     @click.option("--scripts-root-dir", default=None, help="Scripts root directory, which can be used to move scripts "
                   "out of the authentication repository for testing purposes (avoid dirty index). Scripts will be expected "
                   "to be located in scripts_root_dir/repo_name directory")
-    def update(url, clients_auth_path, clients_library_dir, default_branch, from_fs, expected_repo_type, scripts_root_dir):
+    @click.option("--profile", is_flag=True)
+    def update(url, clients_auth_path, clients_library_dir, default_branch, from_fs, expected_repo_type, scripts_root_dir, profile):
         """
         Update and validate local authentication repository and target repositories. Remote
         authentication's repository url needs to be specified when calling this command. If the
@@ -220,6 +222,24 @@ def attach_to_group(group):
         """
         if clients_auth_path is None and clients_library_dir is None:
             raise click.UsageError('Must specify either authentication repository path or library directory!')
+
+        if profile:
+            import cProfile
+            import pstats
+            import io
+            import atexit
+
+            print("Profiling...")
+            pr = cProfile.Profile()
+            pr.enable()
+
+            def exit():
+                pr.disable()
+                print("Profiling completed")
+                filename = 'updater.prof'  # You can change this if needed
+                pr.dump_stats(filename)
+
+            atexit.register(exit)
 
         update_repository(url, clients_auth_path, clients_library_dir, default_branch, from_fs,
                           UpdateType(expected_repo_type), scripts_root_dir=scripts_root_dir)

--- a/taf/updater/handlers.py
+++ b/taf/updater/handlers.py
@@ -72,6 +72,8 @@ class GitUpdater(handlers.MetadataUpdater):
     def previous_commit(self):
         return self.commits[self.current_commit_index - 1]
 
+    _temp_files_cache = {}
+
     def __init__(self, mirrors, repository_directory, repository_name):
         """
         Args:

--- a/taf/updater/handlers.py
+++ b/taf/updater/handlers.py
@@ -72,8 +72,6 @@ class GitUpdater(handlers.MetadataUpdater):
     def previous_commit(self):
         return self.commits[self.current_commit_index - 1]
 
-    _temp_files_cache = {}
-
     def __init__(self, mirrors, repository_directory, repository_name):
         """
         Args:


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

- Added timed_run decorator to updater calls which prints the total execution time
- Added profile flag to update cli. This makes it possible to easily generate .prof files.
- `targets_at_revision` performance improvement. If a new delegation is added and the new role contains targets, there
will have to be a metadata file. If no such changes are detected, we can be confident that there are no new roles. 


## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
