### PR TITLE
Add allow_unsafe flag as a response to a recent git security fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
+- Add `allow_unsafe` flag to git repo class as a response to a recent git security fix ([229])
 ### Changed
 
 - Remove `no_checkout=True` from `clone` ([226])
@@ -21,6 +22,8 @@ and this project adheres to [Semantic Versioning][semver].
 - Fix updates of repos which only contain one commit ([219])
 - Fixed `_validate_urls` and local validation ([216])
 
+
+[229]: https://github.com/openlawlibrary/taf/pull/229
 [226]: https://github.com/openlawlibrary/taf/pull/226
 [220]: https://github.com/openlawlibrary/taf/pull/220
 [219]: https://github.com/openlawlibrary/taf/pull/219

--- a/taf/auth_repo.py
+++ b/taf/auth_repo.py
@@ -31,6 +31,7 @@ class AuthenticationRepository(GitRepository, TAFRepository):
         urls=None,
         custom=None,
         default_branch="main",
+        allow_unsafe=False,
         conf_directory_root=None,
         out_of_band_authentication=None,
         hosts=None,
@@ -57,7 +58,15 @@ class AuthenticationRepository(GitRepository, TAFRepository):
           attribute.
         """
         super().__init__(
-            library_dir, name, urls, custom, default_branch, path, *args, **kwargs
+            library_dir,
+            name,
+            urls,
+            custom,
+            default_branch,
+            allow_unsafe,
+            path,
+            *args,
+            **kwargs,
         )
 
         if conf_directory_root is None:

--- a/taf/git.py
+++ b/taf/git.py
@@ -30,6 +30,7 @@ class GitRepository:
         urls=None,
         custom=None,
         default_branch="main",
+        allow_unsafe=False,
         path=None,
         *args,
         **kwargs,
@@ -84,6 +85,7 @@ class GitRepository:
         self.urls = self._validate_urls(urls)
         self.default_branch = default_branch
         self.custom = custom or {}
+        self.allow_unsafe = allow_unsafe
 
     _pygit = None
 
@@ -172,7 +174,10 @@ class GitRepository:
 
         if len(args):
             cmd = cmd.format(*args)
-        command = f"git -C {self.path} {cmd}"
+        if self.allow_unsafe:
+            command = f"git -C {self.path} -c safe.directory={self.path} {cmd}"
+        else:
+            command = f"git -C {self.path} {cmd}"
         result = None
         if log_error or log_error_msg:
             try:

--- a/taf/repositoriesdb.py
+++ b/taf/repositoriesdb.py
@@ -238,17 +238,19 @@ def load_repositories(
             urls = _get_urls(mirrors, name, repo_data)
             if name not in targets and only_load_targets:
                 continue
-
             custom = _get_custom_data(repo_data, targets.get(name))
+            allow_unsafe = False
 
             git_repo = None
             try:
                 if factory is not None:
-                    git_repo = factory(library_dir, name, urls, custom, default_branch)
+                    git_repo = factory(
+                        library_dir, name, urls, custom, default_branch, allow_unsafe
+                    )
                 else:
                     git_repo_class = _determine_repo_class(repo_classes, name)
                     git_repo = git_repo_class(
-                        library_dir, name, urls, custom, default_branch
+                        library_dir, name, urls, custom, default_branch, allow_unsafe
                     )
             except Exception as e:
                 taf_logger.error(


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

A security update made to git prevents execution of git commands if
the containing directory is owned by a different user. For example, if
repositories are owned by root and www-data tries to execute a git command.
It only affects commands executed using git cli - _git method of the git repo
class in TAF. pygit2 usage is not affected.
`allow_unsafe` flag can be set when instantiating the repositories allowing
the mentioned safety feature to be ignored. This is done by marking the
containing directory as safe. 

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
