### PR TITLE
docs: allow_unsafe flag's description added to GitRepo's docstring

### DIFF
--- a/taf/git.py
+++ b/taf/git.py
@@ -46,6 +46,8 @@ class GitRepository:
           urls (list): repository's urls
           custom (dict): a dictionary containing other data
           default_branch (str): repository's default branch ("main" if not defined)
+          allow_unsafe: allow a git's security mechanism which prevents execution of git commands if
+          the containing directory is owned by a different user to be ignored
         """
         if isinstance(library_dir, str):
             library_dir = Path(library_dir)


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

`allow_unsafe` flag's description added to GitRepo's docstring

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
