### PR TITLE
Add `--ff-only` to merge commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,17 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
+- Add `--ff-only` to git merge ([235])
 - Cache loaded git files ([228])
 - Add a flag for generating performance reports of update calls and print total update execution time ([228])
 
 ### Changed
 
--  Update `targets_at_revisions` - only update a list of roles if a metadata file was added ([228])
+- Update `targets_at_revisions` - only update a list of roles if a metadata file was added ([228])
 
 ### Fixed
 
+[235]: https://github.com/openlawlibrary/taf/pull/235
 [228]: https://github.com/openlawlibrary/taf/pull/228
 
 ## [0.16.0] - 04/16/2022
@@ -25,6 +27,7 @@ and this project adheres to [Semantic Versioning][semver].
 ### Added
 
 - Add `allow_unsafe` flag to git repo class as a response to a recent git security fix ([229])
+
 ### Changed
 
 - Remove `no_checkout=True` from `clone` ([226])
@@ -36,7 +39,6 @@ and this project adheres to [Semantic Versioning][semver].
 
 - Fix updates of repos which only contain one commit ([219])
 - Fixed `_validate_urls` and local validation ([216])
-
 
 [229]: https://github.com/openlawlibrary/taf/pull/229
 [226]: https://github.com/openlawlibrary/taf/pull/226

--- a/taf/git.py
+++ b/taf/git.py
@@ -844,8 +844,9 @@ class GitRepository:
             for wt in worktrees
         }
 
-    def merge_commit(self, commit):
-        self._git("merge {}", commit, log_error=True)
+    def merge_commit(self, commit, fast_forward_only=False):
+        fast_forward_only_flag = "--ff-only" if fast_forward_only else ""
+        self._git("merge {} {}", commit, fast_forward_only_flag, log_error=True)
 
     def pull(self):
         """Pull current branch"""


### PR DESCRIPTION
* Sometimes we want to not include an additional merge commit, but only fast
  forward a git merge.

## Description (e.g. "Related to ...", etc.)

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
