### PR TITLE
add --version option to cli which prints taf's current version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
+- Add --version option to cli ([239])
 - Add TAF's repository classes and repositoriesdb's documentation ([237])
 - Add `--ff-only` to git merge ([235])
 - Added format-output flag to update repo cli ([234])
@@ -21,6 +22,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+
+[239]: https://github.com/openlawlibrary/taf/pull/239
 [237]: https://github.com/openlawlibrary/taf/pull/237
 [235]: https://github.com/openlawlibrary/taf/pull/235
 [234]: https://github.com/openlawlibrary/taf/pull/234

--- a/taf/tools/cli/taf.py
+++ b/taf/tools/cli/taf.py
@@ -7,6 +7,8 @@ import taf.tools.yubikey as yubikey_cli
 
 
 @click.group()
+@click.version_option()
+@click.pass_context
 def taf():
     """TAF Command Line Interface"""
     pass

--- a/taf/tools/cli/taf.py
+++ b/taf/tools/cli/taf.py
@@ -8,7 +8,6 @@ import taf.tools.yubikey as yubikey_cli
 
 @click.group()
 @click.version_option()
-@click.pass_context
 def taf():
     """TAF Command Line Interface"""
     pass


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Add --version option to cli which prints taf's current version. Used cli's existing support for this feature

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
