### PR TITLE
Convert `_unchanged_metadata`  updated_role to list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][keepachangelog],
 and this project adheres to [Semantic Versioning][semver].
 
-
 ## [Unreleased]
 
 ### Added
 
 ### Changed
 
+Update `_get_unchanged_targets_metadata` - `updated_roles` is now a list ([#246])
+
 ### Fixed
 
-
 ## [0.17.0] - 05/04/2022
-
 
 ### Added
 
@@ -34,7 +33,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
-
+[246]: https://github.com/openlawlibrary/taf/pull/246
 [240]: https://github.com/openlawlibrary/taf/pull/240
 [239]: https://github.com/openlawlibrary/taf/pull/239
 [237]: https://github.com/openlawlibrary/taf/pull/237

--- a/taf/validation.py
+++ b/taf/validation.py
@@ -12,7 +12,7 @@ def validate_branch(
     target_repos,
     branch_name,
     merge_branches,
-    updated_role,
+    updated_roles,
     should_check_capstone=True,
 ):
     """
@@ -44,11 +44,11 @@ def validate_branch(
 
     _check_lengths_of_branches(targets_and_commits, branch_name)
 
-    targets_version = None
     branch_id = None
+
     unmodified_roles_and_versions = {
         role_name: None
-        for role_name in _get_unchanged_targets_metadata(auth_repo, updated_role)
+        for role_name in _get_unchanged_targets_metadata(auth_repo, updated_roles)
     }
 
     # Get the missing commits from the top of the merge branch
@@ -62,30 +62,31 @@ def validate_branch(
                     num_of_merged_commits, branch=merge_branches[target_repo]
                 )
             )
-
-    for commit_index, auth_commit in enumerate(auth_commits):
-        # load content of the updated role's targets metadata
-        updated_targets = auth_repo.get_json(
-            auth_commit, f"{METADATA_DIRECTORY_NAME}/{updated_role}.json"
-        )
-        targets_version = _check_updated_targets_version(
-            updated_targets, updated_role, auth_commit, targets_version
-        )
-        for (
-            role_name,
-            unmodified_roles_version,
-        ) in unmodified_roles_and_versions.items():
-            unmodified_target_metadata = auth_repo.get_json(
-                auth_commit, f"{METADATA_DIRECTORY_NAME}/{role_name}.json"
+    for updated_role in updated_roles:
+        targets_version = None
+        for commit_index, auth_commit in enumerate(auth_commits):
+            # load content of the updated role's targets metadata
+            updated_targets = auth_repo.get_json(
+                auth_commit, f"{METADATA_DIRECTORY_NAME}/{updated_role}.json"
             )
-            version = _check_if_version_unmodified(
-                unmodified_target_metadata,
+            targets_version = _check_updated_targets_version(
+                updated_targets, updated_role, auth_commit, targets_version
+            )
+            for (
                 role_name,
-                auth_commit,
                 unmodified_roles_version,
-            )
-            if unmodified_roles_version is None:
-                unmodified_roles_and_versions[role_name] = version
+            ) in unmodified_roles_and_versions.items():
+                unmodified_target_metadata = auth_repo.get_json(
+                    auth_commit, f"{METADATA_DIRECTORY_NAME}/{role_name}.json"
+                )
+                version = _check_if_version_unmodified(
+                    unmodified_target_metadata,
+                    role_name,
+                    auth_commit,
+                    unmodified_roles_version,
+                )
+                if unmodified_roles_version is None:
+                    unmodified_roles_and_versions[role_name] = version
 
         branch_id = _check_branch_id(auth_repo, auth_commit, branch_id)
 
@@ -194,8 +195,8 @@ def _compare_commit_with_targets_metadata(
         )
 
 
-def _get_unchanged_targets_metadata(auth_repo, updated_role):
+def _get_unchanged_targets_metadata(auth_repo, updated_roles):
     taf_repo = Repository(auth_repo.path)
     all_roles = taf_repo.get_all_targets_roles()
-    all_roles.remove(updated_role)
+    all_roles = [*(set(all_roles) - set(updated_roles))]
     return all_roles


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)
In `validate_branch` method `_unchanged_targets_metadata `, `updated_role` param is now converted to a list of `updated_roles` which is checked against `all_roles`
## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
