### PR TITLE
Enable exclusion of certain target repositories from the update process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
-Update `_get_unchanged_targets_metadata` - `updated_roles` is now a list ([246])
+- Enable exclusion of certain target repositories from the update process ([250])
+- Update `_get_unchanged_targets_metadata` - `updated_roles` is now a list ([246])
 
 ### Fixed
 
-Fix `validate_branch` indentation error caused by [246] ([247])
+Fix `validate_branch` indentation error caused by [246] ([249])
 
 ## [0.17.0] - 05/04/2022
 
@@ -35,7 +36,8 @@ Fix `validate_branch` indentation error caused by [246] ([247])
 
 ### Fixed
 
-[247]: https://github.com/openlawlibrary/taf/pull/247
+[250]: https://github.com/openlawlibrary/taf/pull/250
+[247]: https://github.com/openlawlibrary/taf/pull/249
 [246]: https://github.com/openlawlibrary/taf/pull/246
 [240]: https://github.com/openlawlibrary/taf/pull/240
 [239]: https://github.com/openlawlibrary/taf/pull/239

--- a/taf/auth_repo.py
+++ b/taf/auth_repo.py
@@ -248,13 +248,11 @@ class AuthenticationRepository(GitRepository, TAFRepository):
             for target_path, target_data in targets[commit].items():
                 if target_path in skipped_targets:
                     continue
-                skip_target = False
-                for excluded_target_glob in excluded_target_globs:
-                    if fnmatch.fnmatch(target_path, excluded_target_glob):
-                        skip_target = True
-                        skipped_targets.append(target_path)
-                        break
-                if skip_target:
+                if any(
+                    fnmatch.fnmatch(target_path, excluded_target_glob)
+                    for excluded_target_glob in excluded_target_globs
+                ):
+                    skipped_targets.append(target_path)
                     continue
                 target_branch = target_data.get("branch")
                 target_commit = target_data.get("commit")

--- a/taf/auth_repo.py
+++ b/taf/auth_repo.py
@@ -1,6 +1,7 @@
 import json
 import os
 import tempfile
+import fnmatch
 from collections import defaultdict
 from contextlib import contextmanager
 from pathlib import Path
@@ -203,7 +204,12 @@ class AuthenticationRepository(GitRepository, TAFRepository):
         Path(self.conf_dir, self.LAST_VALIDATED_FILENAME).write_text(commit)
 
     def sorted_commits_and_branches_per_repositories(
-        self, commits, target_repos=None, custom_fns=None, default_branch=None
+        self,
+        commits,
+        target_repos=None,
+        custom_fns=None,
+        default_branch=None,
+        excluded_target_globs=None,
     ):
         """Return a dictionary consisting of branches and commits belonging
         to it for every target repository:
@@ -236,8 +242,19 @@ class AuthenticationRepository(GitRepository, TAFRepository):
             *commits, target_repos=target_repos, default_branch=default_branch
         )
         previous_commits = {}
+        skipped_targets = []
         for commit in commits:
             for target_path, target_data in targets[commit].items():
+                if target_path in skipped_targets:
+                    continue
+                skip_target = False
+                for excluded_target_glob in excluded_target_globs:
+                    if fnmatch.fnmatch(target_path, excluded_target_glob):
+                        skip_target = True
+                        skipped_targets.append(target_path)
+                        break
+                if skip_target:
+                    continue
                 target_branch = target_data.get("branch")
                 target_commit = target_data.get("commit")
                 previous_commit = previous_commits.get(target_path)

--- a/taf/auth_repo.py
+++ b/taf/auth_repo.py
@@ -243,6 +243,7 @@ class AuthenticationRepository(GitRepository, TAFRepository):
         )
         previous_commits = {}
         skipped_targets = []
+        excluded_target_globs = excluded_target_globs or []
         for commit in commits:
             for target_path, target_data in targets[commit].items():
                 if target_path in skipped_targets:

--- a/taf/repositoriesdb.py
+++ b/taf/repositoriesdb.py
@@ -242,15 +242,13 @@ def load_repositories(
         for name, repo_data in repositories.items():
             if name in skipped_targets:
                 continue
-            skip_target = False
-            for excluded_target_glob in excluded_target_globs:
-                if fnmatch.fnmatch(name, excluded_target_glob):
-                    skip_target = True
-                    skipped_targets.append(name)
-                    break
-            if skip_target:
-                continue
             if name not in targets and only_load_targets:
+                continue
+            if any(
+                fnmatch.fnmatch(name, excluded_target_glob)
+                for excluded_target_glob in excluded_target_globs
+            ):
+                skipped_targets.append(name)
                 continue
             custom = _get_custom_data(repo_data, targets.get(name))
             urls = _get_urls(mirrors, name, repo_data)

--- a/taf/repositoriesdb.py
+++ b/taf/repositoriesdb.py
@@ -250,39 +250,21 @@ def load_repositories(
                     break
             if skip_target:
                 continue
-            urls = _get_urls(mirrors, name, repo_data)
             if name not in targets and only_load_targets:
                 continue
             custom = _get_custom_data(repo_data, targets.get(name))
-            allow_unsafe = False
-
-            git_repo = None
-            try:
-                if factory is not None:
-                    git_repo = factory(
-                        library_dir, name, urls, custom, default_branch, allow_unsafe
-                    )
-                else:
-                    git_repo_class = _determine_repo_class(repo_classes, name)
-                    git_repo = git_repo_class(
-                        library_dir, name, urls, custom, default_branch, allow_unsafe
-                    )
-            except Exception as e:
-                taf_logger.error(
-                    "Auth repo {}: an error occurred while instantiating repository {}: {}",
-                    auth_repo.path,
-                    name,
-                    str(e),
-                )
-                raise RepositoryInstantiationError(Path(library_dir, name), str(e))
-
-            # allows us to partially update repositories
+            urls = _get_urls(mirrors, name, repo_data)
+            git_repo = _initialize_repository(
+                factory,
+                repo_classes,
+                urls,
+                custom,
+                library_dir,
+                name,
+                default_branch,
+                auth_repo,
+            )
             if git_repo:
-                if not isinstance(git_repo, GitRepository):
-                    raise Exception(
-                        f"{type(git_repo)} is not a subclass of GitRepository"
-                    )
-
                 repositories_dict[name] = git_repo
 
         taf_logger.debug(
@@ -554,6 +536,37 @@ def get_repo_urls(auth_repo, repo_name, commit=None):
     mirrors = _load_mirrors_json(auth_repo, commit)
     if mirrors is not None:
         return _get_urls(mirrors, repo_name)
+
+
+def _initialize_repository(
+    factory, repo_classes, urls, custom, library_dir, name, default_branch, auth_repo
+):
+    git_repo = None
+
+    allow_unsafe = False
+    try:
+        if factory is not None:
+            git_repo = factory(
+                library_dir, name, urls, custom, default_branch, allow_unsafe
+            )
+        else:
+            git_repo_class = _determine_repo_class(repo_classes, name)
+            git_repo = git_repo_class(
+                library_dir, name, urls, custom, default_branch, allow_unsafe
+            )
+    except Exception as e:
+        taf_logger.error(
+            "Auth repo {}: an error occurred while instantiating repository {}: {}",
+            auth_repo.path,
+            name,
+            str(e),
+        )
+        raise RepositoryInstantiationError(Path(library_dir, name), str(e))
+    # allows us to partially update repositories
+    if git_repo:
+        if not isinstance(git_repo, GitRepository):
+            raise Exception(f"{type(git_repo)} is not a subclass of GitRepository")
+    return git_repo
 
 
 def _load_dependencies_json(auth_repo, commit=None):

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -196,9 +196,12 @@ def attach_to_group(group):
                   "out of the authentication repository for testing purposes (avoid dirty index). Scripts will be expected "
                   "to be located in scripts_root_dir/repo_name directory")
     @click.option("--profile", is_flag=True, help="Flag used to run profiler and generate .prof file")
-    @click.option('--format-output', is_flag=True, help='Return formatted output which includes information '
-                  'on if build was successful and error message if it was raised')
-    def update(url, clients_auth_path, clients_library_dir, default_branch, from_fs, expected_repo_type, scripts_root_dir, profile, format_output):
+    @click.option("--format-output", is_flag=True, help="Return formatted output which includes information "
+                  "on if build was successful and error message if it was raised")
+    @click.option("--exclude-target", multiple=True, help="globs defining which target repositories should be "
+                  "ignored during update.")
+    def update(url, clients_auth_path, clients_library_dir, default_branch, from_fs, expected_repo_type,
+               scripts_root_dir, profile, format_output, exclude_target):
         """
         Update and validate local authentication repository and target repositories. Remote
         authentication's repository url needs to be specified when calling this command. If the
@@ -221,6 +224,10 @@ def attach_to_group(group):
 
         Scripts root directory option can be used to move scripts out of the authentication repository for
         testing purposes (avoid dirty index). Scripts will be expected  o be located in scripts_root_dir/repo_name directory
+
+        One or more target repositories can be excluded from the update process using --exclude-target.
+        In that case, the library will only be partly validated, so last_validate_commit will not be updated
+        and no scripts will be called.
         """
         if clients_auth_path is None and clients_library_dir is None:
             raise click.UsageError('Must specify either authentication repository path or library directory!')
@@ -249,7 +256,8 @@ def attach_to_group(group):
                 default_branch,
                 from_fs,
                 UpdateType(expected_repo_type),
-                scripts_root_dir=scripts_root_dir
+                scripts_root_dir=scripts_root_dir,
+                excluded_target_globs=exclude_target
             )
             if format_output:
                 print(json.dumps({


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Add support for the use case where some target repositories should be ignored. For example, it might be convenient to
only clone a subset of all target repositories and big repositories that are not needed. This is only recommended to be used
if library as a whole is getting validated regularly. When partially updating repositories, handlers are not called and
the `last_validated_commit` is not updated. This can be expanded at a later date so that we also save the information
regarding what was validated and updated, and what was not

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
