### PR TITLE
Validation fixes and error handling, command for listing git tags

### DIFF
--- a/taf/exceptions.py
+++ b/taf/exceptions.py
@@ -147,5 +147,9 @@ class UpdateFailedError(TAFError):
     pass
 
 
+class ValidationFailedError(TAFError):
+    pass
+
+
 class YubikeyError(Exception):
     pass

--- a/taf/git.py
+++ b/taf/git.py
@@ -819,6 +819,9 @@ class GitRepository:
                     files.append(modified_file.split(maxsplit=1)[1])
         return files
 
+    def list_tags(self):
+        return self._git("tag -l").splitlines()
+
     def list_untracked_files(self, path=None):
         ls_command = "ls-files --others"
         if path is not None:

--- a/taf/updater/handlers.py
+++ b/taf/updater/handlers.py
@@ -136,7 +136,6 @@ class GitUpdater(handlers.MetadataUpdater):
         the initial root.json).
         """
         # TODO check if users authentication repository is clean
-
         # load the last validated commit from the conf file
         if settings.overwrite_last_validated_commit:
             last_validated_commit = settings.last_validated_commit

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -271,7 +271,9 @@ def update_repository(
             excluded_target_globs=excluded_target_globs,
         )
     except Exception as e:
-        root_error = UpdateFailedError(f"Update of {auth_repo_name} failed due to error {e}")
+        root_error = UpdateFailedError(
+            f"Update of {auth_repo_name} failed due to error {e}"
+        )
 
     update_data = {}
     if not excluded_target_globs:
@@ -1234,7 +1236,7 @@ def validate_repository(
     clients_library_dir=None,
     default_branch="main",
     validate_from_commit=None,
-    excluded_target_globs=None
+    excluded_target_globs=None,
 ):
 
     clients_auth_path = Path(clients_auth_path).resolve()
@@ -1264,10 +1266,12 @@ def validate_repository(
             expected_repo_type=expected_repo_type,
             only_validate=True,
             validate_from_commit=validate_from_commit,
-            excluded_target_globs=excluded_target_globs
+            excluded_target_globs=excluded_target_globs,
         )
     except Exception as e:
-        raise ValidationFailedError(f"Validation or repository {auth_repo_name} failed due to error {e}")
+        raise ValidationFailedError(
+            f"Validation or repository {auth_repo_name} failed due to error {e}"
+        )
     settings.overwrite_last_validated_commit = False
     settings.last_validated_commit = None
 

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -20,6 +20,7 @@ from taf.exceptions import (
     GitError,
     MissingHostsError,
     InvalidHostsError,
+    ValidationFailedError,
 )
 from taf.updater.handlers import GitUpdater
 from taf.utils import on_rm_error
@@ -229,7 +230,6 @@ def update_repository(
     # if the repository's name is not provided, divide it in parent directory
     # and repository name, since TUF's updater expects a name
     # but set the validate_repo_name setting to False
-
     if clients_auth_path is not None:
         clients_auth_path = Path(clients_auth_path).resolve()
 
@@ -271,7 +271,7 @@ def update_repository(
             excluded_target_globs=excluded_target_globs,
         )
     except Exception as e:
-        root_error = e
+        root_error = UpdateFailedError(f"Update of {auth_repo_name} failed due to error {e}")
 
     update_data = {}
     if not excluded_target_globs:
@@ -600,9 +600,7 @@ def _update_current_repository(
     settings.update_from_filesystem = update_from_filesystem
     settings.conf_directory_root = conf_directory_root
     settings.default_branch = default_branch
-    if only_validate:
-        settings.overwrite_last_validated_commit = True
-        settings.last_validated_commit = validate_from_commit
+
     # instantiate TUF's updater
     repository_mirrors = {
         "mirror1": {
@@ -1236,6 +1234,7 @@ def validate_repository(
     clients_library_dir=None,
     default_branch="main",
     validate_from_commit=None,
+    excluded_target_globs=None
 ):
 
     clients_auth_path = Path(clients_auth_path).resolve()
@@ -1252,17 +1251,25 @@ def validate_repository(
         if (clients_auth_path / "targets" / "test-auth-repo").exists()
         else UpdateType.OFFICIAL
     )
-    _update_named_repository(
-        str(clients_auth_path),
-        clients_auth_library_dir,
-        clients_library_dir,
-        auth_repo_name,
-        default_branch,
-        True,
-        expected_repo_type=expected_repo_type,
-        only_validate=True,
-        validate_from_commit=validate_from_commit,
-    )
+    settings.overwrite_last_validated_commit = True
+    settings.last_validated_commit = validate_from_commit
+    try:
+        _update_named_repository(
+            str(clients_auth_path),
+            clients_auth_library_dir,
+            clients_library_dir,
+            auth_repo_name,
+            default_branch,
+            True,
+            expected_repo_type=expected_repo_type,
+            only_validate=True,
+            validate_from_commit=validate_from_commit,
+            excluded_target_globs=excluded_target_globs
+        )
+    except Exception as e:
+        raise ValidationFailedError(f"Validation or repository {auth_repo_name} failed due to error {e}")
+    settings.overwrite_last_validated_commit = False
+    settings.last_validated_commit = None
 
 
 def _validate_authentication_repository(


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Raise `ValidationFailedError` when validation fails, `UpdateFiledError` whenever update fails
When validating repositories, settings `last_validated_commit` variables are updated
and if they are not reset afterwards, update might fail if run in the same process
following the update
As a git command for listing tags

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
