### PR TITLE
`--clients-auth-path` repo command improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- `--clients-auth-path` repo command improvements ([260])
 
 ### Fixed
 
@@ -31,6 +32,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 - Fix Warn when git object cleanup fails (`idx`,`pack`) and include cleanup warning message ([259])
 
+[260]: https://github.com/openlawlibrary/taf/pull/260
 [259]: https://github.com/openlawlibrary/taf/pull/259
 [257]: https://github.com/openlawlibrary/taf/pull/257
 [256]: https://github.com/openlawlibrary/taf/pull/256

--- a/taf/tests/test_updater.py
+++ b/taf/tests/test_updater.py
@@ -72,7 +72,7 @@ TARGETS_MISMATCH_ANY = "Mismatch between target commits specified in authenticat
 NO_WORKING_MIRRORS = (
     f"Validation of authentication repository {AUTH_REPO_REL_PATH} failed at revision"
 )
-NO_REPOSITORY_INFO_JSON = "Error during info.json parse. Check if info.json exists or provide full path to auth repo"
+NO_REPOSITORY_INFO_JSON = "Error during info.json parse. When specifying --clients-library-dir check if info.json metadata exists in targets/protected or provide full path to auth repo"
 ROOT_EXPIRED = "Metadata 'root' expired"
 REPLAYED_METADATA = "ReplayedMetadataError"
 IS_A_TEST_REPO = f"Repository {AUTH_REPO_REL_PATH} is a test repository."

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -181,7 +181,7 @@ def attach_to_group(group):
 
     @repo.command()
     @click.argument("url")
-    @click.option("--clients-auth-path", default=None, help="Directory where authentication repository is located.")
+    @click.argument("clients-auth-path", default=None, required=False)
     @click.option("--clients-library-dir", default=None, help="Directory where target repositories and, "
                   "optionally, authentication repository are located. If omitted it is "
                   "calculated based on authentication repository's path. "

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -209,12 +209,16 @@ def attach_to_group(group):
         locations of the target repositories are calculated based on the authentication repository's
         path. If that is not the case, it is necessary to redefine this default value using the
         --clients-library-dir option. This means that if authentication repository's path is
-        E:\\root\\namespace\\auth-repo, it will be assumed that E:\\root is the root direcotry
+        E:\\root\\namespace\\auth-repo, it will be assumed that E:\\root is the root directory
         if clients-library-dir is not specified.
         Names of target repositories (as defined in repositories.json) are appended to the root repository's
         path thus defining the location of each target repository. If names of target repositories
         are namespace/repo1, namespace/repo2 etc and the root directory is E:\\root, path of the target
         repositories will be calculated as E:\\root\\namespace\\repo1, E:\\root\\namespace\\root2 etc.
+
+        Path to authentication repository directory is set by clients-auth-path argument. If this
+        argument is not provided, it is expected that --clients-library-dir option is used. The updater
+        will raise an error if one of both isn't set.
 
         If remote repository's url is a file system path, it is necessary to call this command with
         --from-fs flag so that url validation is skipped. When updating a test repository (one that has

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -96,7 +96,7 @@ def _clone_validation_repo(url, repository_name, default_branch):
             repository_name = f'{info["namespace"]}/{info["name"]}'
         except Exception:
             raise UpdateFailedError(
-                "Error during info.json parse. Check if info.json exists or provide full path to auth repo"
+                "Error during info.json parse. When specifying --clients-library-dir check if info.json metadata exists in targets/protected or provide full path to auth repo"
             )
 
     validation_auth_repo.cleanup()


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Closes #217 

- Revert `taf repo update` click command back to old API by having `--clients-auth-path` as an argument. Now that argument is optional. `taf repo update` can be run by either specifying `<url>` and `<clients-auth-path>`, or with `<url>` and `--clients-library-dir`
- Do shutil.rmtree after unsuccessful `taf repo update` but not during validate. We don't want to clean up a law repository if validate fails.
- Clarify `info.json` error message

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
