### PR TITLE
Add check if metadata roles are expiring; condition-based automatic signing of snapshot and timestamp 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,15 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
+- Add cli metadata command that checks if metadata roles are soon to expire ([261])
 - Document a solution to a YubiKey communication issue ([257])
 
 ### Changed
 
+- If target role expiration date is being updated, sign timestamp and snapshot automatically ([261])
 - `--clients-auth-path` repo command improvements ([260])
 - port a number of git functionalities to pygit2 ([227])
-- Migrated yubikey-manager from v3.0.0 to v4.0.7 ([191])
+- Migrated yubikey-manager from v3.0.0 to v4.0.* ([191])
 
 
 ### Fixed
@@ -26,6 +28,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 
 [263]: https://github.com/openlawlibrary/taf/pull/263
+[261]: https://github.com/openlawlibrary/taf/pull/261
 [260]: https://github.com/openlawlibrary/taf/pull/260
 [259]: https://github.com/openlawlibrary/taf/pull/259
 [257]: https://github.com/openlawlibrary/taf/pull/257

--- a/taf/developer_tool.py
+++ b/taf/developer_tool.py
@@ -1250,7 +1250,7 @@ def setup_test_yubikey(key_path=None):
 
 def update_metadata_expiration_date(
     repo_path,
-    role,
+    roles,
     interval,
     keystore=None,
     scheme=None,
@@ -1263,14 +1263,18 @@ def update_metadata_expiration_date(
     taf_repo = Repository(repo_path)
     loaded_yubikeys = {}
     roles_to_update = []
-    shared_roles = ["snapshot", "timestamp"]
 
-    if role not in shared_roles:
-        roles_to_update = [role, *shared_roles]
-    elif role == "snapshot":
-        roles_to_update = [*shared_roles]
-    elif role == "timestamp":
-        roles_to_update = ["timestamp"]
+    if "root" in roles:
+        roles_to_update.append("root")
+    if "targets" in roles:
+        roles_to_update.append("targets")
+    for role in roles:
+        if is_delegated_role(role):
+            roles_to_update.append(role)
+
+    if len(roles_to_update) or "snapshot" in roles:
+        roles_to_update.append("snapshot")
+    roles_to_update.append("timestamp")
 
     for role in roles_to_update:
         try:

--- a/taf/developer_tool.py
+++ b/taf/developer_tool.py
@@ -1227,7 +1227,13 @@ def setup_test_yubikey(key_path=None):
 
 
 def update_metadata_expiration_date(
-    repo_path, role, interval, keystore=None, scheme=None, start_date=None, commit=False
+    repo_path,
+    role,
+    interval,
+    keystore=None,
+    scheme=None,
+    start_date=None,
+    no_commit=False,
 ):
     if start_date is None:
         start_date = datetime.datetime.now()
@@ -1268,7 +1274,9 @@ def update_metadata_expiration_date(
         else:
             print(f"Updated expiration date of {role}")
 
-    if commit:
+    if no_commit:
+        print("\nNo commit was set. Please commit manually. \n")
+    else:
         auth_repo = GitRepository(path=repo_path)
         commit_message = input("\nEnter commit message and press ENTER\n\n")
         auth_repo.commit(commit_message)

--- a/taf/developer_tool.py
+++ b/taf/developer_tool.py
@@ -458,13 +458,20 @@ def check_expiration_dates(
     )
 
     if expired_dict or will_expire_dict:
+        now = datetime.datetime.now(datetime.timezone.utc)
         print(
             f"Given a {interval} day interval from today ({start_date.strftime('%Y-%m-%d')}):"
         )
         for role, expiry_date in expired_dict.items():
-            print(f"{role} expired on {expiry_date.strftime('%Y-%m-%d')}")
+            delta = now - expiry_date
+            print(
+                f"{role} expired {delta.days} days ago (on {expiry_date.strftime('%Y-%m-%d')})"
+            )
         for role, expiry_date in will_expire_dict.items():
-            print(f"{role} will expire on {expiry_date.strftime('%Y-%m-%d')}")
+            delta = expiry_date - now
+            print(
+                f"{role} will expire in {delta.days} days (on {expiry_date.strftime('%Y-%m-%d')})"
+            )
     else:
         print(f"No roles will expire within the given {interval} day interval")
 

--- a/taf/developer_tool.py
+++ b/taf/developer_tool.py
@@ -436,6 +436,20 @@ def create_repository(
 def check_expiration_dates(
     repo_path, interval=None, start_date=None, excluded_roles=None
 ):
+    """
+    <Purpose>
+        Check if any metadata files (roles) are expired or will expire in the next <interval> days.
+        Prints a list of expired roles.
+    <Arguments>
+        repo_path:
+        Authentication repository's location
+        interval:
+        Number of days ahead to check for expiration
+        start_date:
+        Date from which to start checking for expiration
+        excluded_roles:
+        List of roles to exclude from the check
+    """
     repo_path = Path(repo_path)
     taf_repo = Repository(repo_path)
 

--- a/taf/developer_tool.py
+++ b/taf/developer_tool.py
@@ -433,6 +433,28 @@ def create_repository(
         auth_repo.commit(commit_message)
 
 
+def check_expiration_dates(
+    repo_path, interval=None, start_date=None, excluded_roles=None
+):
+    repo_path = Path(repo_path)
+    taf_repo = Repository(repo_path)
+
+    expired_dict, will_expire_dict = taf_repo.check_roles_expiration_dates(
+        interval, start_date, excluded_roles
+    )
+
+    if expired_dict or will_expire_dict:
+        print(
+            f"Given a {interval} day interval from today ({start_date.strftime('%Y-%m-%d')}):"
+        )
+        for role, expiry_date in expired_dict.items():
+            print(f"{role} expired on {expiry_date.strftime('%Y-%m-%d')}")
+        for role, expiry_date in will_expire_dict.items():
+            print(f"{role} will expire on {expiry_date.strftime('%Y-%m-%d')}")
+    else:
+        print(f"No roles will expire within the given {interval} day interval")
+
+
 def _create_delegations(
     roles_infos, repository, verification_keys, signing_keys, existing_roles=None
 ):

--- a/taf/tools/metadata/__init__.py
+++ b/taf/tools/metadata/__init__.py
@@ -74,6 +74,8 @@ def attach_to_group(group):
         the keystore file, it's necessary to specify its path when calling this command. If
         that is not the case, it will be needed to either enter the signing key directly or
         sign the file using a yubikey.
+
+        If targets or other delegated role is updated, automatically sign snapshot and timestamp.
         """
         developer_tool.update_metadata_expiration_date(path, role, interval, keystore,
                                                        scheme, start_date, commit)

--- a/taf/tools/metadata/__init__.py
+++ b/taf/tools/metadata/__init__.py
@@ -49,6 +49,31 @@ def attach_to_group(group):
 
     @metadata.command()
     @click.argument("path")
+    @click.option("--interval", default=30, type=int, help="Number of days added to the start date")
+    @click.option("--start-date", default=datetime.datetime.now(datetime.timezone.utc), help="Date to which expiration interval is added", type=ISO_DATE)
+    def check_expiration_dates(path, interval, start_date):
+        """
+        Check if the expiration dates of the metadata roles is still within an interval threshold.
+        Expiration date is calculated by adding interval to start date. Interval is specified in days.
+        The default value for interval in method is set to 30 days.
+        Result contains metadata roles which have already expired and also roles which will expire (within the interval).
+        Result is printed to the console and contains the following information:
+        header:
+            - start date
+            - interval (in days)
+        information:
+            - role name
+            - expiration date
+        Example console output:
+        Given a 30 day interval from today (2022-07-22):
+            timestamp will expire on 2022-07-22
+            snapshot will expire on 2022-07-28
+            root will expire on 2022-08-19
+        """
+        developer_tool.check_expiration_dates(repo_path=path, interval=interval, start_date=start_date)
+
+    @metadata.command()
+    @click.argument("path")
     @click.argument("role")
     @click.option("--interval", default=None, help="Number of days added to the start date",
                   type=int)

--- a/taf/tools/metadata/__init__.py
+++ b/taf/tools/metadata/__init__.py
@@ -57,9 +57,9 @@ def attach_to_group(group):
                   "used for signing")
     @click.option("--start-date", default=datetime.datetime.now(), help="Date to which the "
                   "interval is added", type=ISO_DATE)
-    @click.option("--commit", is_flag=True, help="Indicates if the changes should be "
+    @click.option("--no-commit", is_flag=True, default=False, help="Indicates if the changes should not be "
                   "committed automatically")
-    def update_expiration_date(path, role, interval, keystore, scheme, start_date, commit):
+    def update_expiration_date(path, role, interval, keystore, scheme, start_date, no_commit):
         """
         \b
         Update expiration date of the metadata file corresponding to the specified role.
@@ -78,4 +78,4 @@ def attach_to_group(group):
         If targets or other delegated role is updated, automatically sign snapshot and timestamp.
         """
         developer_tool.update_metadata_expiration_date(path, role, interval, keystore,
-                                                       scheme, start_date, commit)
+                                                       scheme, start_date, no_commit)

--- a/taf/tools/metadata/__init__.py
+++ b/taf/tools/metadata/__init__.py
@@ -74,7 +74,7 @@ def attach_to_group(group):
 
     @metadata.command()
     @click.argument("path")
-    @click.argument("role")
+    @click.option("--role", multiple=True, help="A list of roles which expiration date should get updated")
     @click.option("--interval", default=None, help="Number of days added to the start date",
                   type=int)
     @click.option("--keystore", default=None, help="Location of the keystore files")
@@ -102,5 +102,8 @@ def attach_to_group(group):
 
         If targets or other delegated role is updated, automatically sign snapshot and timestamp.
         """
+        if not len(role):
+            print("Specify at least one role")
+            return
         developer_tool.update_metadata_expiration_date(path, role, interval, keystore,
                                                        scheme, start_date, no_commit)


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

- [x] update `taf metadata update-expiration-date` to update expiration date for parent and (`snapshot`, and/or `timestamp`) as well. set command to autocommit
- [x] add cli command that checks if any role is expiring soon and print results


## Testing `update-expiration-date`
- [ ] clone a test repo partner law and reset --hard couple of commits back 
- [ ] run `taf metadata update-expiration-date . targets`
- [ ] see if snapshot and timestamp are updated and automatically committed

## Testing `check-expiration-dates`
- [ ] for any partner, run `taf metadata check-expiration-dates .`; dot is a path to auth repository
- [ ] run `taf metadata check-expiration-dates . --interval 400`, print statement should say that every role is expiring in 400 days

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
