### PR TITLE
`taf repo validate` cleanup fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,12 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Do not remove authentication repository folder when running `taf repo validate` ([267])
 - fix git push - remove pygit2 push implementation which does not fully support ssh ([263])
 - Warn when git object cleanup fails (`idx`,`pack`) and include cleanup warning message ([259])
 
 
+[267]: https://github.com/openlawlibrary/taf/pull/267
 [266]: https://github.com/openlawlibrary/taf/pull/266
 [263]: https://github.com/openlawlibrary/taf/pull/263
 [261]: https://github.com/openlawlibrary/taf/pull/261

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -635,11 +635,6 @@ def _update_current_repository(
 
     try:
         commits = None
-        users_repo_existed = False
-
-        # first clone the validation repository in temp. this is needed because tuf expects auth_repo_name to be valid (not None)
-        # and in the right format (seperated by '/'). this approach covers a case where we don't know authentication repo path upfront.
-        auth_repo_name = _clone_validation_repo(url, auth_repo_name, default_branch)
         # check whether the directory that runs clone exists or contains additional files.
         # we need to check the state of folder before running tuf. Resolves issue #22
         # if auth_repo_name isn't specified then the current directory doesn't contain additional files.
@@ -648,6 +643,10 @@ def _update_current_repository(
             if auth_repo_name is not None
             else True
         )
+
+        # first clone the validation repository in temp. this is needed because tuf expects auth_repo_name to be valid (not None)
+        # and in the right format (seperated by '/'). this approach covers a case where we don't know authentication repo path upfront.
+        auth_repo_name = _clone_validation_repo(url, auth_repo_name, default_branch)
 
         repository_updater = tuf_updater.Updater(
             auth_repo_name, repository_mirrors, GitUpdater

--- a/taf/utils.py
+++ b/taf/utils.py
@@ -228,7 +228,7 @@ def on_rm_error(_func, path, _exc_info):
         os.unlink(path)
     except (OSError, PermissionError) as e:
         taf_logger.warning(
-            "Failed to clean up temporary update files: {}. This is a known issue when running TAF in a subprocess. You could consider upgrading taf to see if cleanup errors persist",
+            "WARNING: Failed to clean up temporary update files: {}. This is a known issue when running TAF in a subprocess. You could consider upgrading taf to see if cleanup errors persist",
             e,
         )
         pass


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)
Closes #264 

## To test
- `taf repo validate .` on a repository without specifying `--default-branch`

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
