### PR TITLE
fix: update pygit_repo error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
-### Changed
-
+### Changed 
 ### Fixed
+- Add pygit_repo error handling and fix couple of `git.py` logs ([269])
 
+
+[269]: https://github.com/openlawlibrary/taf/pull/269
 
 ## [0.21.0] - 08/30/2022
 

--- a/taf/git.py
+++ b/taf/git.py
@@ -167,7 +167,8 @@ class GitRepository:
     def pygit_repo(self):
         try:
             return self.pygit.repo
-        except Exception:
+        except Exception as e:
+            self._log_info(f"Unable to instantiate pygit2 repo due to error: {str(e)}")
             return None
 
     def _git(self, cmd, *args, **kwargs):
@@ -375,7 +376,7 @@ class GitRepository:
             raise
         finally:
             self._log_info(
-                f"Repo {self.name}: created a new branch {branch_name} from branching off of {commit_sha}"
+                f"Created a new branch {branch_name} from branching off of {commit_sha}"
             )
 
     def branch_local_name(self, remote_branch_name):
@@ -545,7 +546,7 @@ class GitRepository:
             self._log_error(str(e))
             raise
         finally:
-            self._log_info(f"Repo {self.name}: created a new branch {branch_name}")
+            self._log_info(f"Created a new branch {branch_name}")
 
     def create_branch(self, branch_name, commit=None):
         repo = self.pygit_repo
@@ -559,7 +560,7 @@ class GitRepository:
             self._log_error(str(e))
             raise
         finally:
-            self._log_info(f"Repo {self.name}: created a new branch {branch_name}")
+            self._log_info(f"Created a new branch {branch_name}")
 
     def checkout_commit(self, commit):
         self._git(

--- a/taf/git.py
+++ b/taf/git.py
@@ -165,7 +165,10 @@ class GitRepository:
 
     @property
     def pygit_repo(self):
-        return self.pygit.repo
+        try:
+            return self.pygit.repo
+        except Exception:
+            return None
 
     def _git(self, cmd, *args, **kwargs):
         """Call git commands in subprocess


### PR DESCRIPTION
* If pygit.repo handler isn't instantiated, an exception is raised (and not caught) in other parts of `git.py` methods. For example, in `head_commit_sha()` there's a reference to pygit_repo, which will fail if repo handler wasn't properly instantiated. If handler is not instatiated, return None.

## Description (e.g. "Related to ...", etc.)

Minor fix to `pygit_repo` property in `git.py`

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
