### PR TITLE
fix: top_commit_of_branch extended to handle HEAD as branch name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,14 @@ and this project adheres to [Semantic Versioning][semver].
 ### Added
 
 ### Changed 
+
 ### Fixed
+
+- Extended `top_commit_of_branch`, support references which are not branches, like HEAD ([270])
 - Add pygit_repo error handling and fix couple of `git.py` logs ([269])
 
 
+[270]: https://github.com/openlawlibrary/taf/pull/270
 [269]: https://github.com/openlawlibrary/taf/pull/269
 
 ## [0.21.0] - 08/30/2022

--- a/taf/git.py
+++ b/taf/git.py
@@ -996,7 +996,13 @@ class GitRepository:
     def top_commit_of_branch(self, branch_name):
         repo = self.pygit_repo
         branch = repo.branches.get(branch_name)
-        return branch.target.hex
+        if branch is not None:
+            return branch.target.hex
+        # a reference like HEAD
+        try:
+            return repo.revparse_single(branch_name).id.hex
+        except Exception:
+            return None
 
     def _validate_repo_name(self, name):
         """Ensure the repo name is not malicious"""


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

The old implementation, before pygit2 could handle inputs such as HEAD - branch_name which is not actually a branch, but a reference. Add the same support to the new implementation and ensure backwards compatibility

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
