### PR TITLE
fix: Validate if provided commit exists in `all_commits_since_commit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,11 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Fix `all_commits_since_commit` to validate provided commit ([278])
 - Remove pin for `PyOpenSSL` ([273])
 
 [279]: https://github.com/openlawlibrary/taf/pull/279
+[278]: https://github.com/openlawlibrary/taf/pull/278
 [273]: https://github.com/openlawlibrary/taf/pull/273
 
 ## [0.21.1] - 09/07/2022

--- a/taf/git.py
+++ b/taf/git.py
@@ -269,7 +269,7 @@ class GitRepository:
         try:
             self.commit_exists(commit_sha=since_commit)
         except GitError as e:
-            self._log_debug(f"Commit {since_commit} not found in local repository.")
+            self._log_warning(f"Commit {since_commit} not found in local repository.")
             raise e
         repo = self.pygit_repo
         if branch:

--- a/taf/git.py
+++ b/taf/git.py
@@ -259,10 +259,18 @@ class GitRepository:
     def all_commits_since_commit(self, since_commit, branch=None, reverse=True):
         """Returns a list of all commits since the specified commit on the
         specified or currently checked out branch
+
+        Raises:
+            exceptions.GitError: An error occured with provided commit SHA
         """
         if since_commit is None:
             return self.all_commits_on_branch(branch=branch, reverse=reverse)
 
+        try:
+            self.commit_exists(commit_sha=since_commit)
+        except GitError as e:
+            self._log_debug(f"Commit {since_commit} not found in local repository.")
+            raise e
         repo = self.pygit_repo
         if branch:
             branch = repo.branches.get(branch)
@@ -599,6 +607,9 @@ class GitRepository:
             message,
         )
         return self._git("rev-parse HEAD")
+
+    def commit_exists(self, commit_sha):
+        return self._git(f"rev-parse {commit_sha}")
 
     def commits_on_branch_and_not_other(
         self, branch1, branch2, include_branching_commit=False


### PR DESCRIPTION
`all_commits_since_commit` returned all commits on a branch or repository even if an invalid commit sha was provided. Validate current_commit and raise an error if commit is invalid.

## Description (e.g. "Related to ...", etc.)

Closes #277 

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
