### PR TITLE
Fix cryptography missing and remove `timezone.utc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ and this project adheres to [Semantic Versioning][semver].
 ### Changed
 
 - Upgraded our TUF fork to newer version ([273])
+- Upgrade cryptography version ([279])
 
 ### Fixed
 
-- Remove pins for `cryptography`, `PyOpenSSL` ([273])
+- Remove pin for `PyOpenSSL` ([273])
 
+[279]: https://github.com/openlawlibrary/taf/pull/279
 [273]: https://github.com/openlawlibrary/taf/pull/273
 
 ## [0.21.1] - 09/07/2022

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ kwargs = {
         "click==7.*",
         "colorama>=0.3.9",
         "oll-tuf==0.20.0.dev1",
+        "cryptography>=37.0.0",
         "loguru==0.6.*",
         "pygit2==1.9.*",
         "cattrs==1.*",

--- a/taf/developer_tool.py
+++ b/taf/developer_tool.py
@@ -458,7 +458,7 @@ def check_expiration_dates(
     )
 
     if expired_dict or will_expire_dict:
-        now = datetime.datetime.now(datetime.timezone.utc)
+        now = datetime.datetime.now()
         print(
             f"Given a {interval} day interval from today ({start_date.strftime('%Y-%m-%d')}):"
         )

--- a/taf/repository_tool.py
+++ b/taf/repository_tool.py
@@ -610,7 +610,7 @@ class Repository:
         Results are sorted by expiration date.
         """
         if start_date is None:
-            start_date = datetime.datetime.now(datetime.timezone.utc)
+            start_date = datetime.datetime.now()
         if interval is None:
             interval = 30
         expiration_threshold = start_date + datetime.timedelta(days=interval)

--- a/taf/tools/metadata/__init__.py
+++ b/taf/tools/metadata/__init__.py
@@ -50,7 +50,7 @@ def attach_to_group(group):
     @metadata.command()
     @click.argument("path")
     @click.option("--interval", default=30, type=int, help="Number of days added to the start date")
-    @click.option("--start-date", default=datetime.datetime.now(datetime.timezone.utc), help="Date to which expiration interval is added", type=ISO_DATE)
+    @click.option("--start-date", default=datetime.datetime.now(), help="Date to which expiration interval is added", type=ISO_DATE)
     def check_expiration_dates(path, interval, start_date):
         """
         Check if the expiration dates of the metadata roles is still within an interval threshold.


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Cryptography was missing since we it's never installed by just relying on `oll-tuf`. 

Remove `timezone.utc` from datetime instances as upstream TUF has moved away from using `iso8601` module to make datetime objects.
Please see [current](https://github.com/openlawlibrary/tuf/blob/oll/tuf/repository_tool.py#L1404) vs [old](https://github.com/openlawlibrary/tuf/blob/24255c26b519efa4d466e35e9c2e50c4ed4ab002/tuf/repository_tool.py#L1281) `oll-tuf` 

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
