### PR TITLE
performance: fix pygit2 breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,11 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Fix pygit2 performance regression ([283])
 - Fix `all_commits_since_commit` to validate provided commit ([278])
 - Remove pin for `PyOpenSSL` ([273])
 
+[283]: https://github.com/openlawlibrary/taf/pull/283
 [279]: https://github.com/openlawlibrary/taf/pull/279
 [278]: https://github.com/openlawlibrary/taf/pull/278
 [275]: https://github.com/openlawlibrary/taf/pull/275

--- a/taf/git.py
+++ b/taf/git.py
@@ -798,6 +798,9 @@ class GitRepository:
         except TAFError as e:
             raise e
         except Exception:
+            self._log_warning(
+                "Perfomance regression: Could not list files with pygit2. Reverting to git subprocess"
+            )
             return self._list_files_at_revision(commit, path)
 
     def _list_files_at_revision(self, commit, path):

--- a/taf/pygit.py
+++ b/taf/pygit.py
@@ -95,9 +95,9 @@ class PyGitRepository:
 
         for entry in tree:
             new_path = os.path.join(path, entry.name)
-            if entry.type == "blob":
+            if entry.type_str == "blob":
                 results.append(new_path)
-            elif entry.type == "tree":
+            elif entry.type_str == "tree":
                 obj = self._get_child(tree, entry.name)
                 self._list_files_at_revision(obj, new_path, results)
             else:


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)
Closes #284 

Since transitioning to Python 3.10 and `pygit2>=1.*`  there were some breaking changes which then defaulted to us using git submodule. This caused a significant slowdown of updater.


## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
