### PR TITLE
Fetched commits bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Replace buggy `all_fetched_commits` with `all_commits_on_branch` ([285])
 - Fix pygit2 performance regression ([283])
 - Fix `taf metadata update-expiration-date --role snapshot` to include `root` ([282])
 - Fix `all_commits_since_commit` to validate provided commit ([278])
@@ -24,6 +25,8 @@ and this project adheres to [Semantic Versioning][semver].
 - Fix `all_commits_since_commit` to validate provided commit ([278])
 - Remove pin for `PyOpenSSL` ([273])
 
+
+[285]: https://github.com/openlawlibrary/taf/pull/285
 [283]: https://github.com/openlawlibrary/taf/pull/283
 [282]: https://github.com/openlawlibrary/taf/pull/282
 [279]: https://github.com/openlawlibrary/taf/pull/279

--- a/taf/git.py
+++ b/taf/git.py
@@ -289,7 +289,6 @@ class GitRepository:
         self._log_debug(f"found the following commits: {', '.join(shas)}")
         return shas
 
-
     def branches(self, remote=False, all=False, strip_remote=False):
         """Returns all branches."""
         repo = self.pygit_repo

--- a/taf/git.py
+++ b/taf/git.py
@@ -289,16 +289,6 @@ class GitRepository:
         self._log_debug(f"found the following commits: {', '.join(shas)}")
         return shas
 
-    def all_fetched_commits(self, branch=None):
-        branch = branch or self.default_branch
-        commits = self._git("rev-list ..origin/{}", branch).strip()
-        if not commits:
-            commits = []
-        else:
-            commits = commits.split("\n")
-            commits.reverse()
-        self._log_debug(f"fetched the following commits {', '.join(commits)}")
-        return commits
 
     def branches(self, remote=False, all=False, strip_remote=False):
         """Returns all branches."""

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -998,7 +998,7 @@ def _get_commits(
 
     if old_head is not None:
         if not only_validate:
-            fetched_commits = repository.all_fetched_commits(branch=branch)
+            fetched_commits = repository.all_commits_on_branch(branch=f"origin/{branch}")
 
             # if the local branch does not exist (the branch was not checked out locally)
             # fetched commits will include already validated commits
@@ -1031,7 +1031,7 @@ def _get_commits(
             new_commits_on_repo_branch = []
         if not only_validate:
             try:
-                fetched_commits = repository.all_fetched_commits(branch=branch)
+                fetched_commits = repository.all_commits_on_branch(branch=f"origin/{branch}")
                 # if the local branch does not exist (the branch was not checked out locally)
                 # fetched commits will include already validated commits
                 # check which commits are newer that the previous head commit

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -998,7 +998,9 @@ def _get_commits(
 
     if old_head is not None:
         if not only_validate:
-            fetched_commits = repository.all_commits_on_branch(branch=f"origin/{branch}")
+            fetched_commits = repository.all_commits_on_branch(
+                branch=f"origin/{branch}"
+            )
 
             # if the local branch does not exist (the branch was not checked out locally)
             # fetched commits will include already validated commits
@@ -1031,7 +1033,9 @@ def _get_commits(
             new_commits_on_repo_branch = []
         if not only_validate:
             try:
-                fetched_commits = repository.all_commits_on_branch(branch=f"origin/{branch}")
+                fetched_commits = repository.all_commits_on_branch(
+                    branch=f"origin/{branch}"
+                )
                 # if the local branch does not exist (the branch was not checked out locally)
                 # fetched commits will include already validated commits
                 # check which commits are newer that the previous head commit


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Instead of all_fetched_commits, all_commits_on_branch, which
was implemented using pygit2 can be called - as long as the
branch which is passed to it is a remote branch.
all_fetched_commits would return an empty list in some cases when
there were commits on the remote branch. all_commits_on_branch returned
the correct commits in those cases on the other hand.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
