### PR TITLE
fix: correctly retrieve `get_role_repositories`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Fix `get_role_repositories` to find common roles in both `repositories.json` and metadata ([286])
 - Replace buggy `all_fetched_commits` with `all_commits_on_branch` ([285])
 - Fix pygit2 performance regression ([283])
 - Fix `taf metadata update-expiration-date --role snapshot` to include `root` ([282])
@@ -25,7 +26,7 @@ and this project adheres to [Semantic Versioning][semver].
 - Fix `all_commits_since_commit` to validate provided commit ([278])
 - Remove pin for `PyOpenSSL` ([273])
 
-
+[286]: https://github.com/openlawlibrary/taf/pull/286
 [285]: https://github.com/openlawlibrary/taf/pull/285
 [283]: https://github.com/openlawlibrary/taf/pull/283
 [282]: https://github.com/openlawlibrary/taf/pull/282

--- a/taf/repository_tool.py
+++ b/taf/repository_tool.py
@@ -852,7 +852,7 @@ class Repository:
         return [
             repo
             for repo in target_repositories
-            if all([fnmatch(repo, path) for path in role_paths])
+            if any([fnmatch(repo, path) for path in role_paths])
         ]
 
     def get_delegations_info(self, role_name):

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -291,9 +291,11 @@ def attach_to_group(group):
                   "Authentication repo is presumed to be at library-dir/namespace/auth-repo-name")
     @click.option("--default-branch", default="main", help="Name of the default branch, like mian or master")
     @click.option("--from-commit", default=None, help="First commit which should be validated.")
+    @click.option("--exclude-target", multiple=True, help="globs defining which target repositories should be "
+                  "ignored during update.")
     @click.option("--strict", is_flag=True, default=False, help="Enable/disable strict mode - return an error"
                   "if warnings are raised")
-    def validate(clients_auth_path, clients_library_dir, default_branch, from_commit, strict):
+    def validate(clients_auth_path, clients_library_dir, default_branch, from_commit, exclude_target, strict):
         """
         Validates an authentication repository which is already on the file system
         and its target repositories (which are also expected to be on the file system).
@@ -302,4 +304,4 @@ def attach_to_group(group):
         Validation can be in strict or no-strict mode. Strict mode is set by specifying --strict, which will raise errors
         during validate if any/all warnings are found. By default, --strict is disabled.
         """
-        validate_repository(clients_auth_path, clients_library_dir, default_branch, from_commit, strict)
+        validate_repository(clients_auth_path, clients_library_dir, default_branch, from_commit, exclude_target, strict)

--- a/taf/utils.py
+++ b/taf/utils.py
@@ -231,7 +231,7 @@ def on_rm_error(_func, path, _exc_info):
     try:
         os.unlink(path)
     except (OSError, PermissionError) as e:
-        taf_logger.warning(
+        taf_logger.debug(
             "WARNING: Failed to clean up temporary update files: {}. This is a known issue when running TAF in a subprocess. You could consider upgrading taf to see if cleanup errors persist",
             e,
         )


### PR DESCRIPTION

## Description (e.g. "Related to ...", etc.)
Instead of confirming that every path specified in `paths` attribute of `targets` metadata also exists in `repositories.json`, we really want to be getting the paths that exist in both `repositories.json` and targets metadata. By specifying `any` instead of `all`, we get the intersection between targets and repositories.json. On the other hand, by specifying `all` we're locking ourselves out of getting any paths at all.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
