### PR TITLE
Branch check update - support first commits on branches with a missing branch file

### DIFF
--- a/taf/validation.py
+++ b/taf/validation.py
@@ -93,8 +93,12 @@ def validate_branch(
             if updated_role in check_branch_roles:
                 no_initial_branch_id = check_branch_roles[updated_role]
                 branch_id = _check_branch_id(
-                    auth_repo, auth_commit, branch_id, updated_role,
-                    is_first_commit=no_initial_branch_id and commit_index==len(auth_commits) - 1
+                    auth_repo,
+                    auth_commit,
+                    branch_id,
+                    updated_role,
+                    is_first_commit=no_initial_branch_id
+                    and commit_index == len(auth_commits) - 1,
                 )
 
             for target, target_commits in targets_and_commits.items():
@@ -134,8 +138,11 @@ def _check_branch_id(auth_repo, auth_commit, branch_id, role, is_first_commit):
                 pass
             else:
                 break
-    if (branch_id is not None and new_branch_id is None and not is_first_commit) or \
-        branch_id is not None and new_branch_id != branch_id:
+    if (
+        (branch_id is not None and new_branch_id is None and not is_first_commit)
+        or branch_id is not None
+        and new_branch_id != branch_id
+    ):
         raise InvalidBranchError(
             f"Branch ID at revision {auth_commit} is not the same as the "
             "version at the following revision"


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

In some cases, branch file might not be present in the first new commit
of the authentication repository. check_branch_roles turned into a dictionary
where repo name is the key and a flag indicating if a missing branch
is a valid state or not in case of that repo. This should be made
more generic in the future

A branch file can be inside a folder named after the role inside the
targets folder, but also directly inside targets, depending on
how many roles need these files. Only try to load a branch file
from a certain location if that location was delegated to the current role

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
