### PR TITLE
fix: Use `is_test_repo` AuthRepository property in updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Use `is_test_repo` AuthRepository property in updater ([293])
 - Remove leftover git worktree code in error handling ([291])
 - Fix `get_role_repositories` to find common roles in both `repositories.json` and metadata ([286])
 - Replace buggy `all_fetched_commits` with `all_commits_on_branch` ([285])
@@ -27,6 +28,7 @@ and this project adheres to [Semantic Versioning][semver].
 - Fix `all_commits_since_commit` to validate provided commit ([278])
 - Remove pin for `PyOpenSSL` ([273])
 
+[293]: https://github.com/openlawlibrary/taf/pull/293
 [291]: https://github.com/openlawlibrary/taf/pull/291
 [286]: https://github.com/openlawlibrary/taf/pull/286
 [285]: https://github.com/openlawlibrary/taf/pull/285

--- a/taf/updater/handlers.py
+++ b/taf/updater/handlers.py
@@ -10,7 +10,6 @@ from taf.log import taf_logger
 import taf.settings as settings
 from taf.auth_repo import AuthenticationRepository
 from taf.exceptions import UpdateFailedError
-from taf.git import GitRepository
 from taf.utils import on_rm_error
 from taf.updater.git_trusted_metadata_set import GitTrustedMetadataSet
 
@@ -266,7 +265,7 @@ class GitUpdater(FetcherInterface):
         """
         Used outside of GitUpdater to access validation auth repo.
         """
-        self.validation_auth_repo = GitRepository(path=path, urls=[url])
+        self.validation_auth_repo = AuthenticationRepository(path=path, urls=[url])
 
     def cleanup(self):
         """

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -10,7 +10,6 @@ from tuf.repository_tool import TARGETS_DIRECTORY_NAME
 from collections import defaultdict
 from pathlib import Path
 from taf.log import taf_logger, disable_tuf_console_logging
-from taf.git import GitRepository
 import taf.repositoriesdb as repositoriesdb
 from taf.auth_repo import AuthenticationRepository
 from taf.utils import timed_run
@@ -85,7 +84,7 @@ def _clone_validation_repo(url, repository_name, default_branch):
     """
     temp_dir = tempfile.mkdtemp()
     path = Path(temp_dir, "auth_repo").absolute()
-    validation_auth_repo = GitRepository(path=path, urls=[url])
+    validation_auth_repo = AuthenticationRepository(path=path, urls=[url])
     validation_auth_repo.clone(bare=True)
     validation_auth_repo.fetch(fetch_all=True)
 

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -1319,15 +1319,16 @@ def _validate_authentication_repository(
 
     if expected_repo_type != UpdateType.EITHER:
         # check if the repository being updated is a test repository
-        targets = validation_auth_repo.get_json(commits[-1], "metadata/targets.json")
-        test_repo = "test-auth-repo" in targets["signed"]["targets"]
-        if test_repo and expected_repo_type != UpdateType.TEST:
+        if validation_auth_repo.is_test_repo and expected_repo_type != UpdateType.TEST:
             error_msg = UpdateFailedError(
                 f"Repository {users_auth_repo.name} is a test repository. "
                 'Call update with "--expected-repo-type" test to update a test '
                 "repository"
             )
-        elif not test_repo and expected_repo_type == UpdateType.TEST:
+        elif (
+            not validation_auth_repo.is_test_repo
+            and expected_repo_type == UpdateType.TEST
+        ):
             error_msg = UpdateFailedError(
                 f"Repository {users_auth_repo.name} is not a test repository,"
                 ' but update was called with the "--expected-repo-type" test'


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

1. `validation_auth_repo` should be an instance of `AuthenticationRepository`, not `GitRepository`.
2. Move loading `targets.json` metadata from updater to `is_test_repo` property
3. Change `_validate_authentication_repository` to check against the `is_test_repo` property.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
