### PR TITLE
fix: move _tuf_patches to repository lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][keepachangelog],
 and this project adheres to [Semantic Versioning][semver].
 
+
 ## [Unreleased]
 
 ### Added
 
 ### Changed
 
+
 ### Fixed
+
+
+## [0.22.1] - 12/09/2022
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Move _tuf_patches to repository lib ([296])
+
+
+[296]: https://github.com/openlawlibrary/taf/pull/296
+
 
 ## [0.22.0] - 12/09/2022
 
@@ -777,7 +794,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 [keepachangelog]: https://keepachangelog.com/en/1.0.0/
 [semver]: https://semver.org/spec/v2.0.0.html
-[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.22.0...HEAD
+[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.22.1...HEAD
+[0.22.1]: https://github.com/openlawlibrary/taf/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/openlawlibrary/taf/compare/v0.21.1...v0.22.0
 [0.21.1]: https://github.com/openlawlibrary/taf/compare/v0.20.0...v0.21.1
 [0.21.0]: https://github.com/openlawlibrary/taf/compare/v0.20.0...v0.21.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 from importlib.util import find_spec
 
 PACKAGE_NAME = "taf"
-VERSION = "0.22.0"
+VERSION = "0.22.1"
 AUTHOR = "Open Law Library"
 AUTHOR_EMAIL = "info@openlawlib.org"
 DESCRIPTION = "Implementation of archival authentication"

--- a/taf/repository_tool.py
+++ b/taf/repository_tool.py
@@ -1594,3 +1594,34 @@ class Repository:
                                                 have the minimum threshold of signatures.
         """
         self._repository.writeall()
+
+
+def _tuf_patches():
+    from functools import wraps
+    import tuf.repository_lib
+    import tuf.repository_tool
+
+    from taf.utils import normalize_file_line_endings
+
+    # Replace staging metadata directory name
+    tuf.repository_tool.METADATA_STAGED_DIRECTORY_NAME = (
+        tuf.repository_tool.METADATA_DIRECTORY_NAME
+    )
+
+    # Replace get_metadata_fileinfo with file-endings normalization
+    def get_targets_metadata_fileinfo(get_targets_metadata_fileinfo_fn):
+        @wraps(get_targets_metadata_fileinfo_fn)
+        def normalized(filename, storage_backend, custom=None):
+            normalize_file_line_endings(filename)
+            return get_targets_metadata_fileinfo_fn(
+                filename, storage_backend, custom=None
+            )
+
+        return normalized
+
+    tuf.repository_lib.get_targets_metadata_fileinfo = get_targets_metadata_fileinfo(
+        tuf.repository_lib.get_targets_metadata_fileinfo
+    )
+
+
+_tuf_patches()


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

This needs to be run before a TUF repositry is instantiated. However, it was causing issues with installation of TAF.
tuf.repository_lib.get_targets_metadata_fileinfo does not exist in older versions of TUF, so TUF had to be manually updated before TAF could be installed


## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
