### PR TITLE
fix: address missing logging handler by importing `tuf.repository_tool`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][keepachangelog],
 and this project adheres to [Semantic Versioning][semver].
 
-
 ## [Unreleased]
 
 ### Added
@@ -13,6 +12,17 @@ and this project adheres to [Semantic Versioning][semver].
 ### Changed
 
 ### Fixed
+
+## [0.22.3] - 12/14/2022
+
+### Added
+
+### Changed
+
+### Fixed
+ - Add missing tuf import in `log.py` ([298])
+
+[298]: https://github.com/openlawlibrary/taf/pull/298
 
 ## [0.22.2] - 12/14/2022
 
@@ -813,7 +823,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 [keepachangelog]: https://keepachangelog.com/en/1.0.0/
 [semver]: https://semver.org/spec/v2.0.0.html
-[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.22.2...HEAD
+[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.22.3...HEAD
+[0.22.3]: https://github.com/openlawlibrary/taf/compare/v0.22.2...v0.22.3
 [0.22.2]: https://github.com/openlawlibrary/taf/compare/v0.22.1...v0.22.2
 [0.22.1]: https://github.com/openlawlibrary/taf/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/openlawlibrary/taf/compare/v0.21.1...v0.22.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 from importlib.util import find_spec
 
 PACKAGE_NAME = "taf"
-VERSION = "0.22.2"
+VERSION = "0.22.3"
 AUTHOR = "Open Law Library"
 AUTHOR_EMAIL = "info@openlawlib.org"
 DESCRIPTION = "Implementation of archival authentication"

--- a/taf/log.py
+++ b/taf/log.py
@@ -5,6 +5,7 @@ import securesystemslib
 from pathlib import Path
 
 import tuf.log
+import tuf.repository_tool
 import tuf.exceptions
 from loguru import logger as taf_logger
 


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Logging handler wasn't added until tuf.repository_tool gets imported. Tried manually adding a logging handler, but it results in logging handler getting added twice with a warning message. So instead, we import `repository_tool` in `log.py`.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
