### PR TITLE
fix: pin pyOpenSSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+## [0.22.4] - 12/15/2022
+
+### Added
+
+### Changed
+
+### Fixed
+- Pin `pyOpenSSL` to newer version ([299])
+
+[299]: https://github.com/openlawlibrary/taf/pull/299
+
 ## [0.22.3] - 12/14/2022
 
 ### Added
@@ -823,7 +834,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 [keepachangelog]: https://keepachangelog.com/en/1.0.0/
 [semver]: https://semver.org/spec/v2.0.0.html
-[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.22.3...HEAD
+[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.22.4...HEAD
+[0.22.4]: https://github.com/openlawlibrary/taf/compare/v0.22.3...v0.22.4
 [0.22.3]: https://github.com/openlawlibrary/taf/compare/v0.22.2...v0.22.3
 [0.22.2]: https://github.com/openlawlibrary/taf/compare/v0.22.1...v0.22.2
 [0.22.1]: https://github.com/openlawlibrary/taf/compare/v0.22.0...v0.22.1

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 from importlib.util import find_spec
 
 PACKAGE_NAME = "taf"
-VERSION = "0.22.3"
+VERSION = "0.22.4"
 AUTHOR = "Open Law Library"
 AUTHOR_EMAIL = "info@openlawlib.org"
 DESCRIPTION = "Implementation of archival authentication"
@@ -69,6 +69,7 @@ kwargs = {
         "securesystemslib==0.25.*",
         "loguru==0.6.*",
         "pygit2==1.9.*",
+        "pyOpenSSL==22.1.*",
         "cattrs==1.*",
     ],
     "extras_require": {


### PR DESCRIPTION

## Description (e.g. "Related to ...", etc.)

Cryptography relies on pyOpenSSL, but is not automatically upgraded when Cryptography is updated. Since this dependency was pinned before in taf, we can safely pin again.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
