### PR TITLE
fix: remove pytest11 default entrypoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,6 @@ kwargs = {
             "taf = taf.tools.cli.taf:main",
             "olc = taf.tools.cli.olc:main",
         ],
-        "pytest11": ["taf_yubikey_utils = taf.tests.yubikey_utils"],
     },
     "classifiers": [
         "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

In #200 attempted to conditionally add pytest11 only when tests were available, but forgot to remove pytest11 from the default set of entrypoints. This fixes that.

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
