### PR TITLE
fix: use `generate_and_write_unencrypted_rsa_keypair` for no provided password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning][semver].
 ### Changed
 
 ### Fixed
+- Use `generate_and_write_unencrypted_rsa_keypair` for no provided password ([305])
+
+[305]: https://github.com/openlawlibrary/taf/pull/305
 
 ## [0.23.1] - 01/13/2022
 

--- a/taf/developer_tool.py
+++ b/taf/developer_tool.py
@@ -14,6 +14,7 @@ from tuf.repository_tool import (
     TARGETS_DIRECTORY_NAME,
     create_new_repository,
     generate_and_write_rsa_keypair,
+    generate_and_write_unencrypted_rsa_keypair,
     generate_rsa_key,
 )
 
@@ -685,8 +686,8 @@ def _setup_keystore_key(
                 password = input(
                     "Enter keystore password and press ENTER (can be left empty)"
                 )
-            generate_and_write_rsa_keypair(
-                str(Path(keystore) / key_name), bits=length, password=""
+            generate_and_write_unencrypted_rsa_keypair(
+                filepath=str(Path(keystore) / key_name), bits=length
             )
             public_key = read_public_key_from_keystore(keystore, key_name, scheme)
             private_key = read_private_key_from_keystore(
@@ -951,7 +952,9 @@ def generate_keys(keystore, roles_key_infos):
                 password = passwords[key_num]
                 path = str(Path(keystore, key_name))
                 print(f"Generating {path}")
-                generate_and_write_rsa_keypair(path, bits=bits, password=password)
+                generate_and_write_rsa_keypair(
+                    filepath=path, bits=bits, password=password
+                )
         if "delegations" in key_info:
             generate_keys(keystore, key_info["delegations"])
 


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

securesystemslib v0.25 uses a different interface to generate an rsa keypair with no password

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
