### PR TITLE
fix: raise InvalidBranchError if target file does not exist and commit does in branch validation

### DIFF
--- a/taf/validation.py
+++ b/taf/validation.py
@@ -216,7 +216,15 @@ def _compare_commit_with_targets_metadata(
     specified target value in its target file.
     """
     repo_name = f"{TARGETS_DIRECTORY_NAME}/{target_repo.name}"
-    targets_head_sha = tuf_repo.get_json(tuf_commit, repo_name)["commit"]
+    try:
+        targets_head_sha = tuf_repo.get_json(tuf_commit, repo_name)["commit"]
+    except GitError:
+        if target_repo_commit is not None:
+            raise InvalidBranchError(
+                f"Target file {repo_name} does not exist in revision {tuf_commit}"
+            )
+        targets_head_sha = None
+
     if target_repo_commit != targets_head_sha:
         raise InvalidBranchError(
             f"Commit {target_repo_commit} of repository {target_repo.name} does "


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

During validation of branches, we compare if commits listed in target files are equal to commits of target repositories. This feature is similar to what the updater does, but validates content of branches that is yet to be merged into branches that the updater validates. If the target file does not exist and commit does, that should be an error, but we should raise a descriptive error instead of validation crashing because of a `GitError`

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
