### PR TITLE
feat: add a command for updating and signing targets of specified type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
+- Add a command for updating and signing targets of specified typed ([308])
+
 ### Changed
 
 ### Fixed
+
 - Use `generate_and_write_unencrypted_rsa_keypair` for no provided password ([305])
 
+[308]: https://github.com/openlawlibrary/taf/pull/308
 [305]: https://github.com/openlawlibrary/taf/pull/305
 
 ## [0.23.1] - 01/13/2022

--- a/taf/tools/metadata/__init__.py
+++ b/taf/tools/metadata/__init__.py
@@ -22,6 +22,8 @@ def attach_to_group(group):
                   "keys or a path to a json file which stores the needed information")
     @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme "
                   "used for signing")
+    @click.option("--no-commit", is_flag=True, default=False, help="Indicates if the changes should not be "
+                  "committed automatically")
     def add_signing_key(path, role, pub_key_path, keystore, keys_description, scheme):
         """
         Add a new signing key. This will make it possible to a sign metadata files

--- a/taf/tools/metadata/__init__.py
+++ b/taf/tools/metadata/__init__.py
@@ -22,8 +22,6 @@ def attach_to_group(group):
                   "keys or a path to a json file which stores the needed information")
     @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme "
                   "used for signing")
-    @click.option("--no-commit", is_flag=True, default=False, help="Indicates if the changes should not be "
-                  "committed automatically")
     def add_signing_key(path, role, pub_key_path, keystore, keys_description, scheme):
         """
         Add a new signing key. This will make it possible to a sign metadata files

--- a/taf/tools/targets/__init__.py
+++ b/taf/tools/targets/__init__.py
@@ -79,8 +79,8 @@ def attach_to_group(group):
         """
 
         if not len(target_type):
-          click.echo("Specify at least one target type")
-          return
+            click.echo("Specify at least one target type")
+            return
         try:
             developer_tool.update_and_sign_targets(
                 path,
@@ -94,8 +94,6 @@ def attach_to_group(group):
             click.echo()
             click.echo(str(e))
             click.echo()
-
-
 
     @targets.command()
     @click.argument("path")

--- a/taf/tools/targets/__init__.py
+++ b/taf/tools/targets/__init__.py
@@ -67,15 +67,13 @@ def attach_to_group(group):
     @click.option("--keystore", default=None, help="Location of the keystore files")
     @click.option("--keys-description", help="A dictionary containing information about the "
                   "keys or a path to a json file which stores the needed information")
-    @click.option("--no-commit", is_flag=True, default=False, help="Indicates if the changes should not be "
-                  "committed automatically")
     @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme "
                   "used for signing")
-    def update_and_sign_targets(path, library_dir, target_type, keystore, keys_description, no_commit, scheme):
+    def update_and_sign_targets(path, library_dir, target_type, keystore, keys_description, scheme):
         """
         Update target files corresponding to target repositories specified through the target type parameter
         by writing the current top commit and branch name to the target files. Sign the updated files
-        and then commit, unless the no-commit flag is provided.
+        and then commit.
         """
 
         if not len(target_type):
@@ -88,7 +86,6 @@ def attach_to_group(group):
                 target_type,
                 keystore=keystore,
                 roles_key_infos=keys_description,
-                no_commit=no_commit,
                 scheme=scheme)
         except TAFError as e:
             click.echo()

--- a/taf/tools/targets/__init__.py
+++ b/taf/tools/targets/__init__.py
@@ -61,6 +61,48 @@ def attach_to_group(group):
                   "optionally, authentication repository are located. If omitted it is "
                   "calculated based on authentication repository's path. "
                   "Authentication repo is presumed to be at library-dir/namespace/auth-repo-name")
+    @click.option("--target-type", multiple=True, help="Types of target repositories whose corresponding "
+                  "target files should be updated and signed. Should match a target type defined in "
+                  "repositories.json")
+    @click.option("--keystore", default=None, help="Location of the keystore files")
+    @click.option("--keys-description", help="A dictionary containing information about the "
+                  "keys or a path to a json file which stores the needed information")
+    @click.option("--no-commit", is_flag=True, default=False, help="Indicates if the changes should not be "
+                  "committed automatically")
+    @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme "
+                  "used for signing")
+    def update_and_sign_targets(path, library_dir, target_type, keystore, keys_description, no_commit, scheme):
+        """
+        Update target files corresponding to target repositories specified through the target type parameter
+        by writing the current top commit and branch name to the target files. Sign the updated files
+        and then commit, unless the no-commit flag is provided.
+        """
+
+        if not len(target_type):
+          click.echo("Specify at least one target type")
+          return
+        try:
+            developer_tool.update_and_sign_targets(
+                path,
+                library_dir,
+                target_type,
+                keystore=keystore,
+                roles_key_infos=keys_description,
+                no_commit=no_commit,
+                scheme=scheme)
+        except TAFError as e:
+            click.echo()
+            click.echo(str(e))
+            click.echo()
+
+
+
+    @targets.command()
+    @click.argument("path")
+    @click.option("--library-dir", default=None, help="Directory where target repositories and, "
+                  "optionally, authentication repository are located. If omitted it is "
+                  "calculated based on authentication repository's path. "
+                  "Authentication repo is presumed to be at library-dir/namespace/auth-repo-name")
     @click.option("--namespace", default=None, help="Namespace of the target repositories. "
                   "If omitted, it will be assumed that namespace matches the name of the "
                   "directory which contains the authentication repository")


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Added a command which updates target files corresponding to target repositories specified through the target type input parameter. Automatically sign and commit

`taf targets update-and-sign-targets law --target-type html --target-type xml --keystore ..\keystore-dev\keystore-dev`

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
