### PR TITLE
fix: add missing `write` flag to `taf targets sign`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project adheres to [Semantic Versioning][semver].
 ### Changed
 
 ### Fixed
+- Add missing `write` flag to `taf targets sign` ([329])
 
+[329]: https://github.com/openlawlibrary/taf/pull/329
 ## [0.26.0] - 07/12/2023
 
 ### Added

--- a/taf/api/targets.py
+++ b/taf/api/targets.py
@@ -303,6 +303,7 @@ def register_target_files(
         removed_targets_data,
         keystore,
         scheme=scheme,
+        write=write,
     )
 
     if write:

--- a/taf/tools/targets/__init__.py
+++ b/taf/tools/targets/__init__.py
@@ -129,7 +129,7 @@ def attach_to_group(group):
         try:
             register_target_files(path, keystore=keystore,
                                   roles_key_infos=keys_description,
-                                  scheme=scheme)
+                                  scheme=scheme, write=True)
         except TAFError as e:
             click.echo()
             click.echo(str(e))


### PR DESCRIPTION


## Description (e.g. "Related to ...", etc.)

Signing was not working without adding this flag

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
