### PR TITLE
fix: fix commits per repositories function when same target commits are on different branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- fix commits per repositories function when same target commits are on different branches ([337])
 - Add missing `write` flag to `taf targets sign` ([329])
 
+[337]: https://github.com/openlawlibrary/taf/pull/337
 [330]: https://github.com/openlawlibrary/taf/pull/330
 [329]: https://github.com/openlawlibrary/taf/pull/329
 

--- a/taf/auth_repo.py
+++ b/taf/auth_repo.py
@@ -256,9 +256,9 @@ class AuthenticationRepository(GitRepository, TAFRepository):
                     continue
                 target_branch = target_data.get("branch")
                 target_commit = target_data.get("commit")
-                previous_commit = previous_commits.get(target_path)
+                previous_data = previous_commits.get(target_path)
                 target_data.setdefault("custom", {})
-                if previous_commit is None or target_commit != previous_commit:
+                if previous_data is None or (target_commit, target_branch) != previous_data:
                     if custom_fns is not None and target_path in custom_fns:
                         target_data["custom"].update(
                             custom_fns[target_path](target_commit)
@@ -273,7 +273,7 @@ class AuthenticationRepository(GitRepository, TAFRepository):
                             "auth_commit": commit,
                         }
                     )
-                previous_commits[target_path] = target_commit
+                previous_commits[target_path] = (target_commit, target_branch)
         self._log_debug(
             f"new commits per repositories according to target files: {repositories_commits}"
         )

--- a/taf/auth_repo.py
+++ b/taf/auth_repo.py
@@ -258,7 +258,10 @@ class AuthenticationRepository(GitRepository, TAFRepository):
                 target_commit = target_data.get("commit")
                 previous_data = previous_commits.get(target_path)
                 target_data.setdefault("custom", {})
-                if previous_data is None or (target_commit, target_branch) != previous_data:
+                if (
+                    previous_data is None
+                    or (target_commit, target_branch) != previous_data
+                ):
                     if custom_fns is not None and target_path in custom_fns:
                         target_data["custom"].update(
                             custom_fns[target_path](target_commit)


### PR DESCRIPTION
## Description

When finding all commits on branches based on target files, there was a check which skipped targets data in case
it remained the same between two consecutive authentication repo commits. However, this also skipped targets which
had the same commit, but different branches, causing validation failures.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
