### PR TITLE
Updater: automatically determined url if local repository exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- Updater: automatically determined url if local repository exists ([340])
 - Remove hosts and hosts.json ([330])
 
 ### Fixed
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning][semver].
 - fix commits per repositories function when same target commits are on different branches ([337])
 - Add missing `write` flag to `taf targets sign` ([329])
 
+[340]: https://github.com/openlawlibrary/taf/pull/340
 [337]: https://github.com/openlawlibrary/taf/pull/337
 [330]: https://github.com/openlawlibrary/taf/pull/330
 [329]: https://github.com/openlawlibrary/taf/pull/329

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -65,8 +65,8 @@ def attach_to_group(group):
         create_repository(path, keystore, keys_description, commit, test)
 
     @repo.command()
-    @click.argument("url")
     @click.argument("clients-auth-path", default=None, required=False)
+    @click.option("--url", default=None, help="Authentication repository's url")
     @click.option("--clients-library-dir", default=None, help="Directory where target repositories and, "
                   "optionally, authentication repository are located. If omitted it is "
                   "calculated based on authentication repository's path. "
@@ -87,7 +87,7 @@ def attach_to_group(group):
                   "ignored during update.")
     @click.option("--strict", is_flag=True, default=False, help="Enable/disable strict mode - return an error"
                   "if warnings are raised ")
-    def update(url, clients_auth_path, clients_library_dir, default_branch, from_fs, expected_repo_type,
+    def update(clients_auth_path, url, clients_library_dir, default_branch, from_fs, expected_repo_type,
                scripts_root_dir, profile, format_output, exclude_target, strict):
         """
         Update and validate local authentication repository and target repositories. Remote
@@ -141,6 +141,7 @@ def attach_to_group(group):
                 pr.dump_stats(filename)
 
             atexit.register(exit)
+
 
         try:
             update_repository(

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -142,7 +142,6 @@ def attach_to_group(group):
 
             atexit.register(exit)
 
-
         try:
             update_repository(
                 url,


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Closes #335 

When initially cloning the repo, url is still necessary, so `url` is now an option and not a required argument

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
