### PR TITLE
fix: (updater) only load repositories defined in the newest version of repositories.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- Updater: only load repositories defined in the newest version of repositories.json ([341])
 - Updater: automatically determined url if local repository exists ([340])
 - Remove hosts and hosts.json ([330])
 
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning][semver].
 - fix commits per repositories function when same target commits are on different branches ([337])
 - Add missing `write` flag to `taf targets sign` ([329])
 
+[341]: https://github.com/openlawlibrary/taf/pull/341
 [340]: https://github.com/openlawlibrary/taf/pull/340
 [337]: https://github.com/openlawlibrary/taf/pull/337
 [330]: https://github.com/openlawlibrary/taf/pull/330

--- a/taf/git.py
+++ b/taf/git.py
@@ -274,6 +274,11 @@ class GitRepository:
         repo = self.pygit_repo
         if branch:
             branch = repo.branches.get(branch)
+            if branch is None:
+                raise GitError(
+                    self,
+                    message=f"Error occurred while getting commits of branch {branch}. Branch does not exist",
+                )
             latest_commit_id = branch.target
         else:
             latest_commit_id = repo[repo.head.target].id

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -661,7 +661,7 @@ def _update_current_repository(
             excluded_target_globs=excluded_target_globs,
         )
         repositories = repositoriesdb.get_deduplicated_repositories(
-            users_auth_repo, commits
+            users_auth_repo, commits[-1::]
         )
         repositories_branches_and_commits = (
             users_auth_repo.sorted_commits_and_branches_per_repositories(
@@ -748,7 +748,7 @@ def _update_target_repositories(
         for branch in repositories_branches_and_commits[path]:
             taf_logger.info("Validating branch {}", branch)
             # if last_validated_commit is None or if the target repository didn't exist prior
-            # to calling update, start the update from the beggining
+            # to calling update, start the update from the beginning
             # otherwise, for each branch, start with the last validated commit of the local
             # branch
             branch_exists = repository.branch_exists(branch, include_remotes=False)


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

The problem with loading all repositories that were specified in `repositories.json`, even those that were removed is that a lot of the time the reason for removal is incorrect definition. For example, if there was a typo. At some point, we could implement something that could allow us to differentiate between invalid definitions and repositories that are no longer needed, but for now it makes sense to load only repositories specified in the newest version of `repositories.json`
 
## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
