### PR TITLE
CLI and docs improvements: standardize auth path parameter name, check if worktree is clean, update docs

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -105,10 +105,10 @@ up YubiKeys.
 Use the `repo create` command to create a new authentication repository:
 
 ```bash
-taf repo create repo_path --keystore keystore_path --keys-description keys-description.json --commit --test
+taf repo create --path auth-path --keystore keystore_path --keys-description keys-description.json --commit --test
 ```
 
-- `repo-path` is the only argument and is required. It should point to a folder where the new authentication repository's content should be stored to e.g. `test/law`.
+- `path` is an optional parameter which represents a path to a folder where the new authentication repository's content should be stored to e.g. `test/law`. If not specified, the repository will be created inside the current working directory.
 - `keys-description` was described at the top of this document
 - `keystore` is the location of the keystore files. Use this options if the keystore files were previously generated and not all metadata files should be signed using Yubikeys. This location can also be defined using the `keystore` property of the `keys-description` json.
 - `commit` flag determines if the changes should be automatically committed
@@ -136,9 +136,10 @@ repositories listed in `repositories.json` to appropriate target files and autom
 targets metadata files, as well as snapshot and timestamp.
 
 ```bash
-taf targets update-and-sign-targets E:\\root\\namespace\\auth_repo --keystore E:\\keystore
+taf targets update-and-sign-targets --path auth-path --keystore E:\\keystore
 ```
 
+- `path` is an optional parameter which represents a path to a folder where the new authentication repository's content should be stored to e.g. `test/law`. If not specified, the repository will be created inside the current working directory.
 `keystore` defines location of the keystore files. If a key is not in the provided keystore, or if keystore
 location is not specified when calling the command, it will be necessary to either use previously set up
 Yubikey for signing, or directly paste key values.

--- a/docs/repo-creation-and-update-util.md
+++ b/docs/repo-creation-and-update-util.md
@@ -43,15 +43,6 @@ corresponding to the targets repository. If a repository's namespaced name is
 placed inside `namespace` directory inside `targets`. Namespace can be left empty. In that case the
 target file will be directly inside `targets`.
 
-### `targets-rel-dir`
-
-This option is used when generating `repositories.json`. More precisely, for determining the
-repository's url. If a repository does not have a remote set, the url
-which is to be saved in `repositories.json` is set based on the target repository's path on the filesystem.
-If `targets-rel-dir` is specified, the url is calculated as the repository's path relative to this path.
-It is useful when creating test repositories, when we do not want to use absolute paths. Since
-`repositories.json` is also a target file, its content cannot just be modified prior to executing a test.
-
 
 ### `keys-description`
 
@@ -142,14 +133,16 @@ Many commands have the `scheme` optional parameter. It represents the signature 
 
 Commands are separated into several subcommands:
 
+- `dependencies`, containing command for adding, updating and removing authentication repository's dependencies (other
+authentication repositories which are linked with them)
 - `keystore`, containing commands for generating keystore files.
 - `metadata`, containing commands for updating metadata - adding signing keys and checking and updating expiration
 dates of metadata files.
 - `repo`, containing commands for creating, validating and updating new authentication repositories.
+- `roles` , containing commands for adding and removing roles
 - `targets`, containing commands for listing, adding and removing target repositories and signing targets (updating
 target files corresponding to target repositories and signing all metadata files that need to be updated in order
 to make sure that the authentication repository stays valid)
-- `roles` , containing commands for adding and removing roles
 - `yubikey`, containing commands for setting up a new Yubikey and exporting public keys from Yubikeys
 
 Here are some of the most important commands. Use the `--help` flag to see more information
@@ -172,10 +165,11 @@ This command can be used to generate the initial authentication repository. The 
 of all metadata files are created, but no targets are added.
 
 ```bash
-taf repo create E:\\OLL\\auth_repo_path --keystore E:\\OLL\\keystore --keys-description E:\\OLL\\data\\keys.json --commit --test
+taf repo create --path E:\\OLL\\auth_repo_path --keystore E:\\OLL\\keystore --keys-description E:\\OLL\\data\\keys.json --test
 ```
 
-will generate a new authentication repository at `E:\OLL\auth_repo_path`. There are several options
+will generate a new authentication repository at `E:\OLL\auth_repo_path`, if `path` is provide, or inside
+the current working directory, in case this parameter is omitted. There are several options
 for signing metadata files - from keystore, by directly entering the key when prompted and by using
 Yubikeys. If one or more keys are stored in the keystore, keystore path should be specified
 when calling this command. If `keystore` is specified in `keys-description`, it is not necessary
@@ -184,18 +178,19 @@ execution of this command. Keys can generated on the Yubikeys, but that will del
 stored on that key and will require new pins to be set. It is possible to reuse existing keys
 stored on Yubikeys.
 
-The generated files and folders will automatically be committed if `--commit` flag is present. If the
+The generated files and folders will automatically be committed unless `--no-commit` unless flag is present. If the
 new repository is only be meant to be used for testing, use `--test` flag. This will create a special
 target file called `test-auth-repo`.
 
 ### `repo update`
 
 Update and validate local authentication repository, its child authentication repositories (specified in `dependencies.json` )
-and target repositories. Remote authentication's repository url and its filesystem path need to be specified when calling this command. If the
-authentication repository and the target repositories are in the same root directory,
+and target repositories. When running the updater for the first time, it is necessary to specify the repository's remote url.
+When updating an existing authentication repository, the url is automatically determined. Similarly, the repository's filesystem
+path can, but does have to be specified. If it is omitted, it will be assumed that the repository is located inside the current
+working directory. If the authentication repository and the target repositories are in the same root directory,
 locations of the target repositories are calculated based on the authentication repository's
-path, using `--clients-auth-path`. If that is not the case, it is necessary to redefine this default value using the
-`--clients-library-dir` option.
+path. If that is not the case, it is necessary to redefine this default value using the `--clients-library-dir` option.
 Names of target repositories (as defined in repositories.json) are appended to the root
 path thus defining the location of each target repository. If names of target repositories
 are namespace/repo1, namespace/repo2 etc and the root directory is E:\\root, path of the target
@@ -208,16 +203,26 @@ flag when validating non-test repository as that will also result in an error.
 For example:
 
 ```bash
-taf repo update https://github.com/orgname/auth-repo --clients-auth-path E:\\root\\namespace\\auth_repo  --authenticate-test-repo
+taf repo update --path E:\\root\\namespace\\auth_repo --url https://github.com/orgname/auth-repo   --authenticate-test-repo
 ```
 
 In this example, all target repositories will be expected to be in `E:\root`.
 
-```
-taf repo update https://github.com/orgname/auth-repo --clients-auth-path E:\\root\\namespace\\auth_repo --clients-library-dir E:\\target-repos
+
+```bash
+taf repo update E:\\root\\namespace\\auth_repo --url https://github.com/orgname/auth-repo --clients-library-dir E:\\target-repos
 ```
 
 In this example, the target repositories will be expected to be in `E:\\target-repos`.
+
+or just
+
+```bash
+taf repo update
+```
+
+if repository already exists and is located inside the current working directory.
+
 
 If remote repository's url is a file system path, it is necessary to call this command with
 `--from-fs` flag so that url validation is skipped. This option is mostly of interest to the
@@ -232,20 +237,26 @@ to make sure that the recent updates of the authentication repository and its ta
 before pushing them.
 
 Locations of target repositories are calculated in the same way as when updating repositories.
-Unlike the update command, this command does not have the `url` argument or the `--authenticate-test-repoparameter` flag among its inputs. Additionally,
-it allows specification of the firs commit which should be validated through the `--from-commit`
+Unlike the update command, this command does not have the `url` argument or the `--authenticate-test-repo`
+flag among its inputs. Additionally, it allows specification of the firs commit which should be validated through the `--from-commit`
 option. That means that we can only validate new authentication repository's commits. This
 command does not store information about the last validated commit. See updater documentation
 for more information about how it works.
 Here are a few examples:
 
 ```bash
-taf repo validate E:\\root\\namespace\\auth_repo
+taf repo validate --path E:\\root\\namespace\\auth_repo
 ```
 
 ```bash
 taf repo validate E:\\root\\namespace\\auth_repo --from-commit d0d0fafdc9a6b8c6dd8829635698ac75774b8eb3
 ```
+
+```bash
+taf repo validate
+```
+
+if repository is located inside the current working directory.
 
 ### `targets update-and-sign-targets`
 
@@ -271,8 +282,14 @@ metadata files, as well as snapshot and timestamp are automatically signed.
 For example,
 
 ```bash
-taf targets update-and-sign-targets E:\\root\\namespace\\auth_repo --keystore E:\\keystore  --target-type html
+taf targets update-and-sign --path E:\\root\\namespace\\auth_repo --keystore E:\\keystore --target-type html
 ```
+
+```bash
+taf targets update-and-sign --keystore E:\\keystore --target-type html
+```
+
+If `path` option is omitted, the repository will be expected to be located inside the current working directory.
 
 will update target files corresponding to target repositories whose `custom\type` attribute in `repositories.json`
 is equal to `html`. NOTE - should be updated to be made more generic.
@@ -283,9 +300,8 @@ that the target repositories are on the correct branch before running the comman
 
  TAF can be used to implement an automated process which will update all repositories in accordance with a specific project's needs.
 
-
 ```bash
-taf targets update-and-sign-targets E:\\root\\namespace\\auth_repo --keystore E:\\keystore
+taf targets update-and-sign --path E:\\root\\namespace\\auth_repo --keystore E:\\keystore
 ```
 
 will sign all target repositories listed in `repositories.json`
@@ -315,13 +331,16 @@ will update `targets.json` and `delegated_role1.json` metadata files by modifyin
 about the updated targets. Once the targets metadata files are updated, so are `snapshot` and `timestamp`. Metadata files can be signed using the keystore files, Yubikeys or by directly entering keys. If one or more of the mentioned metadata files should be
 signed with keys stored on disk, it's necessary to provide the keystore pat, by either using the `--keystore` option or providing a `--keys-description` json which contains the `keystore` property.
 
-If the changes should be committed automatically, use the `commit` flag.
+Unless `no-commit` flag is specified, changes will be committed automatically.
 
 ```bash
-taf targets sign E:\\OLL\\auth_rpeo --keystore E:\\OLL\\keystore --commit
+taf targets sign --path E:\\OLL\\auth_rpeo --keystore E:\\OLL\\keystore
 ```
 
-### `metadata update-expiration-date`
+If `path` option is omitted, the repository will be expected to be located inside the current working directory.
+
+
+### `metadata update-expiration-dates`
 
 This command updates expiration date of the given role's metadata file. The metadata file
 can be signed by directly entering the key when prompted to do so, by loading the key
@@ -336,15 +355,26 @@ By default, start date is today's date, while interval depends on the role and i
 - 7 in case of snapshot
 - 1 in case of timestamp and all other roles
 
-If the changes should be automatically committed, use the `commit` flag.
+Unless `no-commit` flag is specified, changes will be committed automatically.
 
 For example:
 
 ```bash
-taf metadata update-expiration-date E:\\OLL\\auth_rpeo snapshot --interval 5 --commit
+taf metadata update-expiration-dates --path E:\\OLL\\auth_rpeo --role targets1 --role targets2 --interval 5 --keystore E:\\OLL\\keystore
 ```
 
-This will set the new expiration date of the snapshot role to 5 days after the current date
+or
+
+```bash
+taf metadata update-expiration-dates --interval 5 --role targets1 --role targets2 --interval 5 --keystore E:\\OLL\\keystore
+```
+
+If `path` option is omitted, the repository will be expected to be located inside the current working directory.
+At least one role needs to be specified. All metadata files that need to be updated in order to ensure the validity
+of the repository will be updated automatically (snapshot and timestamp are updated after a targets role is updated, and
+timestamp is updated after snapshot is updated).
+
+This will set the new expiration date of the targets1 and targets2 roles to 5 days after the current date
 and automatically commit the changes.
 
 ### dependencies add
@@ -357,9 +387,12 @@ this commit (one commit can belong to multiple branches, so storing just commit 
 the validity of this commit. If additional information that is not required by TAF should also be stored in `dependencies.json`,
 it is specified by providing additional options when calling the command. Here is an example:
 
-`taf dependencies add auth-path namespace1/auth --branch-name main --out-of-band-commit d4d768da4e8f74f54c644923b7ed0e19a0faf3c5 --custom-property some-value --keystore keystore-path`
+```bash
+taf dependencies add --path auth-path namespace1/auth --branch-name main --out-of-band-commit d4d768da4e8f74f54c644923b7ed0e19a0faf3c5 --custom-property some-value --keystore keystore-path
+```
 
-In this case, custom-property: some-value will be added to the custom part of the dependency dependencies.json.
+In this case, custom-property: some-value will be added to the custom part of the dependency dependencies.json. If `path` option is
+omitted, the repository will be expected to be located inside the current working directory.
 
 If branch-name and out-of-band-commit are omitted, the default branch and its first commit will be written to dependencies.json.
 
@@ -375,6 +408,9 @@ will be set to `E:\\examples\\root\\namespace1\\auth`.
 
 To remove a dependency from dependencies.json, run
 
-`taf dependencies remove auth-path namespace1/auth --keystore keystore-path`
+```bash
+taf dependencies remove --path auth-path namespace1/auth --keystore keystore-path
+```
 
-This will also update and sign targets metadata, snapshot and timestamp using yubikeys or keys loaded from the specified keystore location.
+This will also update and sign targets metadata, snapshot and timestamp using yubikeys or keys loaded from the specified keystore
+location.  If `path` option is omitted, the repository will be expected to be located inside the current working directory.

--- a/docs/setting-up-new-library.md
+++ b/docs/setting-up-new-library.md
@@ -106,13 +106,12 @@ set up YubiKeys.
 Use the `repo create` command to create a new authentication repository:
 
 ```bash
-taf repo create auth_path --keystore keystore_path --keys-description keys-description.json --commit --test
+taf repo create --path auth_path --keystore keystore_path --keys-description keys-description.json --test
 ```
 
-- `auth-path` is the only argument and is required. It should point to a folder where the new authentication repository's content should be stored to e.g. `test/auth_repo`.
+- `path` is an optional parameter which represents a path to a folder where the new authentication repository's content should be stored to e.g. `test/law`. If not specified, the repository will be created inside the current working directory.
 - `keys-description` is the previously described dictionary containing information about roles, keys and optionally keystore location. If one or more keys should be loaded from the disk their location can be determined based on `keystore` property of this json.
 - `keystore` is the location of the keystore files. Use this options if the keystore files were previously generated and not all metadata files should be signed using Yubikeys. This location can also be defined using the `keystore` property of the `keys-description` json.
-- `commit` flag determines if the changes should be automatically committed
 - `test`  flag determines if a special target file called `test-auth-repo` will be created. That
 signalizes that an authentication repository is a test repository. When calling the updater,
 it's necessary to use a flag which makes it clear that it is a test repository which is to
@@ -126,8 +125,9 @@ For each role, keys can be:
 - loaded from previously initialized Yubikeys
 - generated and stored on a Yubikey (this deletes all existing data from that key)
 
-IMPORTANT: If the command was run without the commit flag, commit the changes before updating metadata files
-or adding targets. The updater will raise and error if version numbers of metadata files in two subsequent
+Changes will be committed automatically, unless the `--no-commit` flag is provided.
+If changes are not committed automatically, it's important to commit manually before updating metadata files
+or adding targets. The updater will raise an error if version numbers of metadata files in two subsequent
 commits differ by more than one!
 
 ## Set up remote repositories
@@ -249,18 +249,26 @@ metadata files corresponding to roles responsible for modified target files, `sn
 and `timestamp.json`
 
 ```bash
-taf targets sign auth_path --keys-description keys_description.json --commit
+taf targets sign --path auth_path --keys-description keys_description.json
 ```
 
+or
+
+```bash
+taf targets sign --keys-description keys_description.json
+```
+
+- `path` is an optional parameter which represents authentication repository's path. If not specified, the repository will be expected to be inside the current working directory.
 - `keys-description` is the previously described dictionary containing information about roles, keys and optionally keystore location. If one or more keys should be loaded from the disk their location can be determined based on `keystore` property of this json.
 - `keystore` defines location of the keystore files and should be used when keystore location is not specified in `keys-description` or when not using `keys-description` option, but one or more keys should be loaded from the disk.
-- `commit` flag determines if the changes should be automatically committed
 
-Commit and push the changes. Having pushed the changes, run local validation to be sure that the authentication repository is in a valid state:
+Unless the `--no-commit` flag is specified, changes will be committed automatically. If you want to be on the safe side, run local validation to be sure that the authentication repository is in a valid state:
 
 ```bash
 taf repo validate auth_path
 ```
+
+Finally, push the changes.
 
 ## Add targets corresponding to target repositories
 
@@ -279,7 +287,13 @@ after every commit.
 **_WARNING:_**: If you added initial README or license using the GitHub interface, register those commits before making further changes.
 
 ```bash
-taf targets update-and-sign-targets E:\\root\\namespace\\auth_repo --keystore E:\\keystore
+taf targets update-and-sign --path E:\\root\\namespace\\auth_repo --keystore E:\\keystore
+```
+
+or
+
+```bash
+taf targets update-and-sign --keystore E:\\keystore
 ```
 
 will sign all target repositories listed in `repositories.json`
@@ -304,16 +318,23 @@ For more information about the updater and how to use it, see [the update proces
 By default, timestamp needs to be resigned every day, while snapshot expires a week after being signed. The updater will raise an error if the top metadata file has expired. To resign metadata files, run:
 
 ```bash
-taf metadata update-expiration-date auth_repo_path role --keystore keystore_path --interval days
+taf metadata update-expiration-dates --path auth_repo_path --keystore keystore_path --role targets1 --role targets2 --interval days
 ```
 
-- `role` represents a role whose metadata's expiration date should be updated - `root`, `targets`, `snapshot`, `timestamp`, delegated targets role
-- `keystore path` is the location of the keystore files. Can be omitted if YubiKeys should be used instead
-- `interval` refers to the number of days added to today's date to calculate the expiration date
+or
+
+```bash
+taf metadata update-expiration-dates --keystore keystore_path --role targets1 --role targets2 --interval days
+```
+
+- `path` is an optional parameter which represents authentication repository's path. If not specified, the repository will be expected to be inside the current working directory.
+- `role` represents a role whose metadata's expiration date should be updated - `root`, `targets`, `snapshot`, `timestamp`, delegated targets role.
+- `keystore path` is the location of the keystore files. Can be omitted if YubiKeys should be used instead.
+- `interval` refers to the number of days added to today's date to calculate the expiration date.
 
 When a metadata file is updated, all other metadata files which need to be updated according to TUF specification
-are updated as well. So, when `snapshot` is updated, `timestamp` is updated is well. When `root`, `targets` or a
-delegated target role is updated, both `snapshot` and `timestamp` are updated too. This is done automatically
+are updated as well. So, when `snapshot` is updated, `timestamp` is updated too. When `root`, `targets` or a
+delegated target role is updated, both `snapshot` and `timestamp` are updated as. This is done automatically
 to ensure that the repository will stay valid.
 
 A few examples:

--- a/taf/api/metadata.py
+++ b/taf/api/metadata.py
@@ -11,14 +11,14 @@ from taf.log import taf_logger
 
 
 def check_expiration_dates(
-    repo_path, interval=None, start_date=None, excluded_roles=None
+    path, interval=None, start_date=None, excluded_roles=None
 ):
     """
     Check if any metadata files (roles) are expired or will expire in the next <interval> days.
     Prints a list of expired roles.
 
     Arguments:
-        repo_path: Authentication repository's location.
+        path: Authentication repository's location.
         interval: Number of days ahead to check for expiration.
         start_date: Date from which to start checking for expiration.
         excluded_roles: List of roles to exclude from the check.
@@ -29,8 +29,8 @@ def check_expiration_dates(
     Returns:
         None
     """
-    repo_path = Path(repo_path)
-    taf_repo = Repository(repo_path)
+    path = Path(path)
+    taf_repo = Repository(path)
 
     expired_dict, will_expire_dict = taf_repo.check_roles_expiration_dates(
         interval, start_date, excluded_roles
@@ -56,7 +56,7 @@ def check_expiration_dates(
 
 
 def update_metadata_expiration_date(
-    repo_path,
+    path,
     roles,
     interval,
     keystore=None,
@@ -70,7 +70,7 @@ def update_metadata_expiration_date(
     and timestamp need to be signed after a targets role is updated.
 
     Arguments:
-        repo_path: Authentication repository's location.
+        path: Authentication repository's location.
         roles: A list of roles whose expiration dates should be updated.
         interval: Number of days added to the start date in order to calculate the
             expiration date.
@@ -90,7 +90,7 @@ def update_metadata_expiration_date(
     if start_date is None:
         start_date = datetime.datetime.now()
 
-    taf_repo = Repository(repo_path)
+    taf_repo = Repository(path)
     loaded_yubikeys = {}
     roles_to_update = []
 
@@ -117,7 +117,7 @@ def update_metadata_expiration_date(
     if no_commit:
         print("\nNo commit was set. Please commit manually. \n")
     else:
-        auth_repo = GitRepository(path=repo_path)
+        auth_repo = GitRepository(path=path)
         commit_message = input("\nEnter commit message and press ENTER\n\n")
         auth_repo.commit(commit_message)
 

--- a/taf/api/metadata.py
+++ b/taf/api/metadata.py
@@ -2,6 +2,7 @@ import datetime
 from logging import ERROR, INFO
 from pathlib import Path
 from logdecorator import log_on_end, log_on_error
+from taf.api.utils import check_if_clean
 from taf.exceptions import TargetsMetadataUpdateError
 from taf.git import GitRepository
 from taf.keys import load_signing_keys
@@ -10,9 +11,13 @@ from taf.repository_tool import Repository, is_delegated_role
 from taf.log import taf_logger
 
 
-def check_expiration_dates(
-    path, interval=None, start_date=None, excluded_roles=None
-):
+@log_on_error(
+    ERROR,
+    "An error occurred while checking expiration dates: {e!r}",
+    logger=taf_logger,
+    reraise=False,
+)
+def check_expiration_dates(path, interval=None, start_date=None, excluded_roles=None):
     """
     Check if any metadata files (roles) are expired or will expire in the next <interval> days.
     Prints a list of expired roles.
@@ -55,6 +60,7 @@ def check_expiration_dates(
         print(f"No roles will expire within the given {interval} day interval")
 
 
+@check_if_clean
 def update_metadata_expiration_date(
     path,
     roles,
@@ -125,7 +131,7 @@ def update_metadata_expiration_date(
 @log_on_end(INFO, "Updated expiration date of {role:s}", logger=taf_logger)
 @log_on_error(
     ERROR,
-    "Could not update expiration date of {role:s} {e!r}",
+    "Could not update expiration date of {role:s}: {e!r}",
     logger=taf_logger,
     reraise=True,
 )
@@ -150,6 +156,13 @@ def _update_expiration_date_of_role(
         )
 
 
+@log_on_end(INFO, "Updated snapshot and timestamp", logger=taf_logger)
+@log_on_error(
+    ERROR,
+    "Could not update snapshot and timestamp: {e!r}",
+    logger=taf_logger,
+    reraise=True,
+)
 def update_snapshot_and_timestamp(
     taf_repo, keystore, scheme=DEFAULT_RSA_SIGNATURE_SCHEME, write_all=True
 ):
@@ -186,6 +199,13 @@ def update_snapshot_and_timestamp(
         taf_repo.writeall()
 
 
+@log_on_end(INFO, "Updated target metadata", logger=taf_logger)
+@log_on_error(
+    ERROR,
+    "Could not update target metadata: {e!r}",
+    logger=taf_logger,
+    reraise=True,
+)
 def update_target_metadata(
     taf_repo,
     added_targets_data,

--- a/taf/api/repository.py
+++ b/taf/api/repository.py
@@ -26,7 +26,7 @@ from taf.log import taf_logger
 )
 @log_on_end(DEBUG, "Finished adding or updating dependency", logger=taf_logger)
 def add_dependency(
-    auth_path: str,
+    path: str,
     dependency_name: str,
     branch_name: str,
     out_of_band_commit: str,
@@ -44,7 +44,7 @@ def add_dependency(
     commit belongs to the specified branch.
 
     Arguments:
-        auth_path: Path to the authentication repository.
+        path: Path to the authentication repository.
         dependency_name: Name of the dependency.
         branch_name: Name of the branch which contains the out-of-band authentication commit.
         out_of_band_commit: SHA of out-of-band authentication commit.
@@ -64,12 +64,12 @@ def add_dependency(
     Returns:
         None
     """
-    if auth_path is None:
+    if path is None:
         raise TAFError("Authentication repository's path not provided")
 
-    auth_repo = AuthenticationRepository(path=auth_path)
+    auth_repo = AuthenticationRepository(path=path)
     if not auth_repo.is_git_repository_root:
-        print(f"{auth_path} is not a git repository!")
+        print(f"{path} is not a git repository!")
         return
     if library_dir is None:
         library_dir = auth_repo.path.parent.parent
@@ -137,7 +137,7 @@ def add_dependency(
 )
 @log_on_end(INFO, "Finished creating a new repository", logger=taf_logger)
 def create_repository(
-    repo_path, keystore=None, roles_key_infos=None, commit=False, test=False
+    path, keystore=None, roles_key_infos=None, commit=False, test=False
 ):
     """
     Create a new authentication repository. Generate initial metadata files.
@@ -145,7 +145,7 @@ def create_repository(
     targets metadata files.
 
     Arguments:
-        repo_path: Authentication repository's location.
+        path: Authentication repository's location.
         keystore: Location of the keystore files.
         roles_key_infos: A dictionary whose keys are role names, while values contain information about the keys.
         commit: Specifies if the changes should be automatically committed.
@@ -158,8 +158,8 @@ def create_repository(
         None
     """
     yubikeys = defaultdict(dict)
-    auth_repo = AuthenticationRepository(path=repo_path)
-    repo_path = Path(repo_path)
+    auth_repo = AuthenticationRepository(path=path)
+    path = Path(path)
 
     if not _check_if_can_create_repository(auth_repo):
         return
@@ -198,10 +198,10 @@ def create_repository(
 
     # register and sign target files (if any)
     try:
-        taf_repository = Repository(repo_path)
+        taf_repository = Repository(path)
         taf_repository._tuf_repository = repository
         register_target_files(
-            repo_path,
+            path,
             keystore,
             roles_key_infos,
             commit=False,
@@ -234,17 +234,17 @@ def _check_if_can_create_repository(auth_repo):
     Returns:
         True if a new authentication repository can be created, False otherwise.
     """
-    repo_path = Path(auth_repo.path)
-    if repo_path.is_dir():
+    path = Path(auth_repo.path)
+    if path.is_dir():
         # check if there is non-empty metadata directory
         if auth_repo.metadata_path.is_dir() and any(auth_repo.metadata_path.iterdir()):
             if auth_repo.is_git_repository:
                 print(
-                    f'"{repo_path}" is a git repository containing the metadata directory. Generating new metadata files could make the repository invalid. Aborting.'
+                    f'"{path}" is a git repository containing the metadata directory. Generating new metadata files could make the repository invalid. Aborting.'
                 )
                 return False
             if not click.confirm(
-                f'Metadata directory found inside "{repo_path}". Recreate metadata files?'
+                f'Metadata directory found inside "{path}". Recreate metadata files?'
             ):
                 return False
     return True
@@ -291,7 +291,7 @@ def _determine_out_of_band_data(dependency, branch_name, out_of_band_commit):
 @log_on_start(DEBUG, "Remove dependency {dependency_name:s}", logger=taf_logger)
 @log_on_end(DEBUG, "Finished removing dependency", logger=taf_logger)
 def remove_dependency(
-    auth_path: str,
+    path: str,
     dependency_name: str,
     keystore: str,
     scheme: str = DEFAULT_RSA_SIGNATURE_SCHEME,
@@ -300,7 +300,7 @@ def remove_dependency(
     Remove a dependency (an authentication repository) from dependencies.json
 
     Arguments:
-        auth_path: Path to the authentication repository.
+        path: Path to the authentication repository.
         dependency_name: Name of the dependency which should be removed.
         keystore: Location of the keystore files.
         scheme (optional): Signing scheme. Set to rsa-pkcs1v15-sha256 by default.
@@ -312,12 +312,12 @@ def remove_dependency(
     Returns:
         None
     """
-    if auth_path is None:
+    if path is None:
         raise TAFError("Authentication repository's path not provided")
 
-    auth_repo = AuthenticationRepository(path=auth_path)
+    auth_repo = AuthenticationRepository(path=path)
     if not auth_repo.is_git_repository_root:
-        print(f"{auth_path} is not a git repository!")
+        print(f"{path} is not a git repository!")
         return
 
     # add to dependencies.json or update the entry

--- a/taf/api/repository.py
+++ b/taf/api/repository.py
@@ -1,9 +1,10 @@
 from functools import partial
 import json
-from logging import DEBUG, INFO
+from logging import DEBUG, ERROR, INFO
 import click
-from logdecorator import log_on_end, log_on_start
+from logdecorator import log_on_end, log_on_error, log_on_start
 from taf.api.metadata import update_snapshot_and_timestamp, update_target_metadata
+from taf.api.utils import check_if_clean
 
 import taf.repositoriesdb as repositoriesdb
 from collections import defaultdict
@@ -25,6 +26,13 @@ from taf.log import taf_logger
     DEBUG, "Adding or updating dependency {dependency_name:s}", logger=taf_logger
 )
 @log_on_end(DEBUG, "Finished adding or updating dependency", logger=taf_logger)
+@log_on_error(
+    ERROR,
+    "An error occurred while adding a new dependency: {e!r}",
+    logger=taf_logger,
+    reraise=True,
+)
+@check_if_clean
 def add_dependency(
     path: str,
     dependency_name: str,
@@ -136,6 +144,12 @@ def add_dependency(
     INFO, "Creating a new authentication repository {repo_path:s}", logger=taf_logger
 )
 @log_on_end(INFO, "Finished creating a new repository", logger=taf_logger)
+@log_on_error(
+    ERROR,
+    "An error occurred while creating a new repository: {e!r}",
+    logger=taf_logger,
+    reraise=True,
+)
 def create_repository(
     path, keystore=None, roles_key_infos=None, commit=False, test=False
 ):
@@ -290,6 +304,13 @@ def _determine_out_of_band_data(dependency, branch_name, out_of_band_commit):
 
 @log_on_start(DEBUG, "Remove dependency {dependency_name:s}", logger=taf_logger)
 @log_on_end(DEBUG, "Finished removing dependency", logger=taf_logger)
+@log_on_error(
+    ERROR,
+    "An error occurred while removing a dependency: {e!r}",
+    logger=taf_logger,
+    reraise=True,
+)
+@check_if_clean
 def remove_dependency(
     path: str,
     dependency_name: str,

--- a/taf/api/roles.py
+++ b/taf/api/roles.py
@@ -265,7 +265,7 @@ def add_roles(
 @log_on_end(DEBUG, "Finished adding new signing key to roles", logger=taf_logger)
 @log_on_error(
     ERROR,
-    "AAdding new signing key to roles: {e!r}",
+    ""An error occurred while adding new signing key to roles: {e!r}",
     logger=taf_logger,
     reraise=True,
 )

--- a/taf/api/roles.py
+++ b/taf/api/roles.py
@@ -39,7 +39,7 @@ MAIN_ROLES = ["root", "snapshot", "timestamp", "targets"]
 @log_on_start(DEBUG, "Adding a new role {role:s}", logger=taf_logger)
 @log_on_end(DEBUG, "Finished adding a new role", logger=taf_logger)
 def add_role(
-    auth_path: str,
+    path: str,
     role: str,
     parent_role: str,
     paths: list,
@@ -56,7 +56,7 @@ def add_role(
     Automatically commit the changes if commit is set to True.
 
     Arguments:
-        auth_path: Path to the authentication repository.
+        path: Path to the authentication repository.
         role: Name of the role which is to be added.
         parent_role: Name of the target role that is the new role's parent. Can be targets or another delegated role.
         paths: A list of target paths that are delegated to the new role.
@@ -76,8 +76,8 @@ def add_role(
     """
     yubikeys = defaultdict(dict)
     if auth_repo is None:
-        auth_repo = AuthenticationRepository(path=auth_path)
-    auth_path = Path(auth_path)
+        auth_repo = AuthenticationRepository(path=path)
+    path = Path(path)
     existing_roles = auth_repo.get_all_targets_roles()
     existing_roles.extend(MAIN_ROLES)
     if role in existing_roles:
@@ -151,7 +151,7 @@ def add_role_paths(
 @log_on_start(DEBUG, "Adding new roles", logger=taf_logger)
 @log_on_end(DEBUG, "Finished adding new roles", logger=taf_logger)
 def add_roles(
-    auth_path,
+    path,
     keystore=None,
     roles_key_infos=None,
     scheme=DEFAULT_RSA_SIGNATURE_SCHEME,
@@ -161,7 +161,7 @@ def add_roles(
     dictionary or .json file
 
     Arguments:
-        auth_path: Path to the authentication repository.
+        path: Path to the authentication repository.
         keystore (optional): Location of the keystore files.
         roles_key_infos (optional): A dictionary containing information about the roles:
             - total number of keys per role
@@ -181,8 +181,8 @@ def add_roles(
         None
     """
     yubikeys = defaultdict(dict)
-    auth_repo = AuthenticationRepository(path=auth_path)
-    auth_path = Path(auth_path)
+    auth_repo = AuthenticationRepository(path=path)
+    path = Path(path)
 
     roles_key_infos, keystore = _initialize_roles_and_keystore(
         roles_key_infos, keystore
@@ -243,7 +243,7 @@ def add_roles(
 @log_on_start(DEBUG, "Adding new signing key to roles", logger=taf_logger)
 @log_on_end(DEBUG, "Finished adding new signing key to roles", logger=taf_logger)
 def add_signing_key(
-    auth_path,
+    path,
     roles,
     pub_key_path=None,
     keystore=None,
@@ -255,7 +255,7 @@ def add_signing_key(
     parent target role if one of the roles is a delegated target role and timestamp and snapshot in any case.
 
     Arguments:
-        auth_path: Path to the authentication repository.
+        path: Path to the authentication repository.
         roles: A list of roles whose signing keys need to be extended.
         pub_key_path (optional): path to the file containing the public component of the new key. If not provided,
             it will be necessary to ender the key when prompted.
@@ -276,7 +276,7 @@ def add_signing_key(
     Returns:
         None
     """
-    taf_repo = Repository(auth_path)
+    taf_repo = Repository(path)
     roles_key_infos, keystore = _initialize_roles_and_keystore(
         roles_key_infos, keystore, enter_info=False
     )
@@ -595,7 +595,7 @@ def _role_obj(role, repository, parent=None):
 @log_on_start(DEBUG, "Removing role {role:s}", logger=taf_logger)
 @log_on_end(DEBUG, "Finished removing the role", logger=taf_logger)
 def remove_role(
-    auth_path: str,
+    path: str,
     role: str,
     keystore: str,
     scheme: str = DEFAULT_RSA_SIGNATURE_SCHEME,
@@ -609,7 +609,7 @@ def remove_role(
     It is not possible to remove any of the main TUF roles
 
     Arguments:
-        auth_path: Path to the authentication repository.
+        path: Path to the authentication repository.
         role: Name of the role which is to be removed.
         keystore: Location of the keystore files.
         scheme (optional): Signing scheme. Set to rsa-pkcs1v15-sha256 by default.
@@ -631,7 +631,7 @@ def remove_role(
         return
 
     if auth_repo is None:
-        auth_repo = AuthenticationRepository(path=auth_path)
+        auth_repo = AuthenticationRepository(path=path)
 
     parent_role = auth_repo.find_delegated_roles_parent(role)
     if parent_role is None:
@@ -645,7 +645,7 @@ def remove_role(
         if delegations_data["name"] == role:
             paths = delegations_data["paths"]
             for path in paths:
-                target_file_path = Path(auth_path, TARGETS_DIRECTORY_NAME, path)
+                target_file_path = Path(path, TARGETS_DIRECTORY_NAME, path)
                 if target_file_path.is_file():
                     if remove_targets:
                         os.unlink(str(target_file_path))

--- a/taf/api/roles.py
+++ b/taf/api/roles.py
@@ -1,11 +1,12 @@
-from logging import DEBUG
+from logging import DEBUG, ERROR
 import os
 import click
 from collections import defaultdict
 from functools import partial
 import json
 from pathlib import Path
-from logdecorator import log_on_end, log_on_start
+from logdecorator import log_on_end, log_on_error, log_on_start
+from taf.api.utils import check_if_clean
 from taf.repositoriesdb import REPOSITORIES_JSON_PATH
 from tuf.repository_tool import TARGETS_DIRECTORY_NAME
 import tuf.roledb
@@ -38,6 +39,13 @@ MAIN_ROLES = ["root", "snapshot", "timestamp", "targets"]
 
 @log_on_start(DEBUG, "Adding a new role {role:s}", logger=taf_logger)
 @log_on_end(DEBUG, "Finished adding a new role", logger=taf_logger)
+@log_on_error(
+    ERROR,
+    "An error occurred while adding a new role {role:s}: {e!r}",
+    logger=taf_logger,
+    reraise=True,
+)
+@check_if_clean
 def add_role(
     path: str,
     role: str,
@@ -114,6 +122,13 @@ def add_role(
 
 @log_on_start(DEBUG, "Adding new paths to role {role:s}", logger=taf_logger)
 @log_on_end(DEBUG, "Finished adding new paths to role", logger=taf_logger)
+@log_on_error(
+    ERROR,
+    "An error occurred while adding new paths to role {role:s}: {e!r}",
+    logger=taf_logger,
+    reraise=True,
+)
+@check_if_clean
 def add_role_paths(
     paths, delegated_role, keystore, commit=True, auth_repo=None, auth_path=None
 ):
@@ -150,6 +165,13 @@ def add_role_paths(
 
 @log_on_start(DEBUG, "Adding new roles", logger=taf_logger)
 @log_on_end(DEBUG, "Finished adding new roles", logger=taf_logger)
+@log_on_error(
+    ERROR,
+    "An error occurred while adding new roles: {e!r}",
+    logger=taf_logger,
+    reraise=True,
+)
+@check_if_clean
 def add_roles(
     path,
     keystore=None,
@@ -242,6 +264,13 @@ def add_roles(
 
 @log_on_start(DEBUG, "Adding new signing key to roles", logger=taf_logger)
 @log_on_end(DEBUG, "Finished adding new signing key to roles", logger=taf_logger)
+@log_on_error(
+    ERROR,
+    "AAdding new signing key to roles: {e!r}",
+    logger=taf_logger,
+    reraise=True,
+)
+@check_if_clean
 def add_signing_key(
     path,
     roles,
@@ -594,6 +623,13 @@ def _role_obj(role, repository, parent=None):
 
 @log_on_start(DEBUG, "Removing role {role:s}", logger=taf_logger)
 @log_on_end(DEBUG, "Finished removing the role", logger=taf_logger)
+@log_on_error(
+    ERROR,
+    "An error occurred while removing role {role:s}: {e!r}",
+    logger=taf_logger,
+    reraise=True,
+)
+@check_if_clean
 def remove_role(
     path: str,
     role: str,
@@ -688,8 +724,16 @@ def remove_role(
         auth_repo.commit(commit_message)
 
 
+# TODO this resolve this auth_path
 @log_on_start(DEBUG, "Removing paths", logger=taf_logger)
 @log_on_end(DEBUG, "Finished removing paths", logger=taf_logger)
+@log_on_error(
+    ERROR,
+    "An error occurred while removing roles: {e!r}",
+    logger=taf_logger,
+    reraise=True,
+)
+@check_if_clean
 def remove_paths(paths, keystore, commit=True, auth_repo=None, auth_path=None):
     """
     Remove delegated paths. Update parent roles of the roles associated with the removed paths,

--- a/taf/api/targets.py
+++ b/taf/api/targets.py
@@ -26,7 +26,7 @@ from tuf.repository_tool import TARGETS_DIRECTORY_NAME
 @log_on_start(DEBUG, "Adding target repository {target_name:s}", logger=taf_logger)
 @log_on_end(DEBUG, "Finished adding target repository", logger=taf_logger)
 def add_target_repo(
-    auth_path: str,
+    path: str,
     target_path: str,
     target_name: str,
     role: str,
@@ -41,7 +41,7 @@ def add_target_repo(
     Also saves custom information about the repositories to repositories.json if it is provided.
 
     Arguments:
-        auth_path: Path to the authentication repository.
+        path: Path to the authentication repository.
         target_path: Path to the target repository which is to be added.
         target_name (optional): Target repository's name. If not provided, it is determined based on the target path (the last two directories).
         role: Name of the role which will be responsible for signing the new target file.
@@ -61,9 +61,9 @@ def add_target_repo(
         None
     """
 
-    auth_repo = AuthenticationRepository(path=auth_path)
+    auth_repo = AuthenticationRepository(path=path)
     if not auth_repo.is_git_repository_root:
-        print(f"{auth_path} is not a git repository!")
+        print(f"{path} is not a git repository!")
         return
     if library_dir is None:
         library_dir = auth_repo.path.parent.parent
@@ -93,7 +93,7 @@ def add_target_repo(
             paths.append(target_name)
 
         add_role(
-            auth_path,
+            path,
             role,
             parent_role or "targets",
             paths,
@@ -149,13 +149,13 @@ def add_target_repo(
     auth_repo.commit(commit_message)
 
 
-def export_targets_history(auth_path, commit=None, output=None, target_repos=None):
+def export_targets_history(path, commit=None, output=None, target_repos=None):
     """
     Form a dictionary consisting of branches and commits belonging to it for every target repository
     and either save it to a file or write to console.
 
     Arguments:
-        auth_path: Path to the authentication repository.
+        path: Path to the authentication repository.
         commit (optional): Authentication repository's commit which marks the first commit for which the data should be generated.
         output (optional): File to which the exported history should be written.
         target_repos (optional): A list of target repository names whose history should be generated. All target repositories
@@ -167,7 +167,7 @@ def export_targets_history(auth_path, commit=None, output=None, target_repos=Non
     Returns:
         None
     """
-    auth_repo = AuthenticationRepository(path=auth_path)
+    auth_repo = AuthenticationRepository(path=path)
     commits = auth_repo.all_commits_since_commit(commit, auth_repo.default_branch)
     if not len(target_repos):
         target_repos = None
@@ -199,14 +199,14 @@ def export_targets_history(auth_path, commit=None, output=None, target_repos=Non
 
 
 def list_targets(
-    auth_path: str,
+    path: str,
     library_dir: str = None,
 ):
     """
     Save the top commit of specified target repositories to the corresponding target files and sign
 
     Arguments:
-        auth_path: Authentication repository's location
+        path: Authentication repository's location
         library_dir (optional): Path to the library's root directory. Determined based on the authentication repository's path if not provided.
 
     Side Effects:
@@ -215,11 +215,11 @@ def list_targets(
     Returns:
         None
     """
-    auth_path = Path(auth_path).resolve()
-    auth_repo = AuthenticationRepository(path=auth_path)
+    path = Path(path).resolve()
+    auth_repo = AuthenticationRepository(path=path)
     top_commit = [auth_repo.head_commit_sha()]
     if library_dir is None:
-        library_dir = auth_path.parent.parent
+        library_dir = path.parent.parent
     repositoriesdb.load_repositories(auth_repo)
     target_repositories = repositoriesdb.get_deduplicated_repositories(auth_repo)
     repositories_data = auth_repo.sorted_commits_and_branches_per_repositories(
@@ -264,7 +264,7 @@ def list_targets(
 
 @log_on_start(INFO, "Signing target files", logger=taf_logger)
 def register_target_files(
-    auth_path,
+    path,
     keystore=None,
     roles_key_infos=None,
     commit=False,
@@ -277,7 +277,7 @@ def register_target_files(
     metadata file, snapshot and timestamp and sign them. Commit changes if commit is set to True.
 
     Arguments:
-        auth_path: Authentication repository's path.
+        path: Authentication repository's path.
         keystore: Location of the keystore files.
         roles_key_infos: A dictionary whose keys are role names, while values contain information about the keys.
         scheme (optional): Signing scheme. Set to rsa-pkcs1v15-sha256 by default.
@@ -294,8 +294,8 @@ def register_target_files(
         roles_key_infos, keystore, enter_info=False
     )
     if taf_repo is None:
-        auth_path = Path(auth_path).resolve()
-        taf_repo = Repository(str(auth_path))
+        path = Path(path).resolve()
+        taf_repo = Repository(str(path))
 
     # find files that should be added/modified/removed
     added_targets_data, removed_targets_data = taf_repo.get_all_target_files_state()
@@ -320,7 +320,7 @@ def register_target_files(
 @log_on_start(DEBUG, "Removing target repository {target_name:s}", logger=taf_logger)
 @log_on_end(DEBUG, "Finished removing target repository", logger=taf_logger)
 def remove_target_repo(
-    auth_path: str,
+    path: str,
     target_name: str,
     keystore: str,
 ):
@@ -329,7 +329,7 @@ def remove_target_repo(
     commit changes.
 
     Arguments:
-        auth_path: Authentication repository's path.
+        path: Authentication repository's path.
         target_name: Name of the target name which is to be removed.
         keystore: Location of the keystore files.
 
@@ -339,11 +339,11 @@ def remove_target_repo(
     Returns:
         None
     """
-    auth_repo = AuthenticationRepository(path=auth_path)
+    auth_repo = AuthenticationRepository(path=path)
     removed_targets_data = {}
     added_targets_data = {}
     if not auth_repo.is_git_repository_root:
-        print(f"{auth_path} is not a git repository!")
+        print(f"{path} is not a git repository!")
         return
     repositories_json = repositoriesdb.load_repositories_json(auth_repo)
     repositories = repositories_json["repositories"]
@@ -409,7 +409,7 @@ def _save_top_commit_of_repo_to_target(
 @log_on_start(DEBUG, "Updating target files", logger=taf_logger)
 @log_on_end(DEBUG, "Finished updating target files", logger=taf_logger)
 def update_target_repos_from_repositories_json(
-    auth_path,
+    path,
     library_dir,
     keystore,
     add_branch=True,
@@ -419,7 +419,7 @@ def update_target_repos_from_repositories_json(
     Create or update target files by reading the latest commit's repositories.json
 
     Arguments:
-        auth_path: Authentication repository's location.
+        path: Authentication repository's location.
         library_dir: Path to the library's root directory. Determined based on the authentication repository's path if not provided.
         keystore: Location of the keystore files.
         add_branch: Indicates whether to add the current branch's name to the target file.
@@ -431,26 +431,26 @@ def update_target_repos_from_repositories_json(
     Returns:
         None
     """
-    auth_path = Path(auth_path).resolve()
+    path = Path(path).resolve()
     if library_dir is None:
-        library_dir = auth_path.parent.parent
+        library_dir = path.parent.parent
     else:
         library_dir = Path(library_dir)
-    auth_repo_targets_dir = auth_path / TARGETS_DIRECTORY_NAME
+    auth_repo_targets_dir = path / TARGETS_DIRECTORY_NAME
     repositories_json = json.loads(
         Path(auth_repo_targets_dir / "repositories.json").read_text()
     )
     for repo_name in repositories_json.get("repositories"):
         _save_top_commit_of_repo_to_target(
-            library_dir, repo_name, auth_path, add_branch
+            library_dir, repo_name, path, add_branch
         )
-    register_target_files(auth_path, keystore, None, True, scheme, write=True)
+    register_target_files(path, keystore, None, True, scheme, write=True)
 
 
 @log_on_start(DEBUG, "Updating target files", logger=taf_logger)
 @log_on_end(DEBUG, "Finished updating target files", logger=taf_logger)
 def update_and_sign_targets(
-    auth_path: str,
+    path: str,
     library_dir: str,
     target_types: list,
     keystore: str,
@@ -461,7 +461,7 @@ def update_and_sign_targets(
     Save the top commit of specified target repositories to the corresponding target files and sign.
 
     Arguments:
-        auth_path: Authentication repository's location.
+        path: Authentication repository's location.
         library_dir (optional): Path to the library's root directory. Determined based on the authentication repository's path if not provided.
         target_types: Types of target repositories whose corresponding target files should be updated and signed.
         keystore: Location of the keystore files.
@@ -474,10 +474,10 @@ def update_and_sign_targets(
     Returns:
         None
     """
-    auth_path = Path(auth_path).resolve()
-    auth_repo = AuthenticationRepository(path=auth_path)
+    path = Path(path).resolve()
+    auth_repo = AuthenticationRepository(path=path)
     if library_dir is None:
-        library_dir = auth_path.parent.parent
+        library_dir = path.parent.parent
     repositoriesdb.load_repositories(auth_repo)
     nonexistent_target_types = []
     target_names = []
@@ -498,10 +498,10 @@ def update_and_sign_targets(
 
     # only update target files if all specified types are valid
     for target_name in target_names:
-        _save_top_commit_of_repo_to_target(library_dir, target_name, auth_path, True)
+        _save_top_commit_of_repo_to_target(library_dir, target_name, path, True)
         print(f"Updated {target_name} target file")
     register_target_files(
-        auth_path, keystore, roles_key_infos, True, scheme, write=True
+        path, keystore, roles_key_infos, True, scheme, write=True
     )
 
 

--- a/taf/api/targets.py
+++ b/taf/api/targets.py
@@ -441,9 +441,7 @@ def update_target_repos_from_repositories_json(
         Path(auth_repo_targets_dir / "repositories.json").read_text()
     )
     for repo_name in repositories_json.get("repositories"):
-        _save_top_commit_of_repo_to_target(
-            library_dir, repo_name, path, add_branch
-        )
+        _save_top_commit_of_repo_to_target(library_dir, repo_name, path, add_branch)
     register_target_files(path, keystore, None, True, scheme, write=True)
 
 
@@ -500,9 +498,7 @@ def update_and_sign_targets(
     for target_name in target_names:
         _save_top_commit_of_repo_to_target(library_dir, target_name, path, True)
         print(f"Updated {target_name} target file")
-    register_target_files(
-        path, keystore, roles_key_infos, True, scheme, write=True
-    )
+    register_target_files(path, keystore, roles_key_infos, True, scheme, write=True)
 
 
 def _update_target_repos(repo_path, targets_dir, target_repo_path, add_branch):

--- a/taf/api/utils.py
+++ b/taf/api/utils.py
@@ -1,0 +1,21 @@
+import functools
+from taf.exceptions import RepositoryNotCleanError
+from taf.git import GitRepository
+
+
+def check_if_clean(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        path = kwargs.get("path", None)
+        if path is None:
+            path = args[0]
+        repo = GitRepository(path=path)
+        if repo.something_to_commit():
+            raise RepositoryNotCleanError(
+                "Repository has uncommitted changes. Commit or revert the changes and run the command again."
+            )
+
+        # Call the original function
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/taf/exceptions.py
+++ b/taf/exceptions.py
@@ -71,6 +71,10 @@ class RepositoryInstantiationError(TAFError):
         self.message = message
 
 
+class RepositoryNotCleanError(TAFError):
+    pass
+
+
 class ScriptExecutionError(TAFError):
     def __init__(self, script, error_msg):
         message = (

--- a/taf/tools/dependencies/__init__.py
+++ b/taf/tools/dependencies/__init__.py
@@ -15,14 +15,14 @@ def attach_to_group(group):
         ignore_unknown_options=True,
         allow_extra_args=True,
     ))
-    @click.argument("auth_path")
     @click.argument("dependency_name")
+    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.option("--branch-name", default=None, help="Name of the branch which contains the out-of-band commit")
     @click.option("--out-of-band-commit", default=None, help="Out-of-band commit SHA")
     @click.option("--dependency-path", default=None, help="Dependency's filesystem path")
     @click.option("--keystore", default=None, help="Location of the keystore files")
     @click.pass_context
-    def add(ctx, auth_path, dependency_name, branch_name, out_of_band_commit, dependency_path, keystore):
+    def add(ctx, dependency_name, path, branch_name, out_of_band_commit, dependency_path, keystore):
         """Add a dependency (an authentication repository) to dependencies.json or update it if it was already added to this file.
         Update and sign targets metadata, snapshot and timestamp using yubikeys or keys loaded from the specified keystore location.
         Information that is added to dependencies.json includes out-of-band authentication commit and name
@@ -51,7 +51,7 @@ def attach_to_group(group):
         """
         custom = {ctx.args[i][2:]: ctx.args[i + 1] for i in range(0, len(ctx.args), 2)} if len(ctx.args) else {}
         add_dependency(
-            auth_path=auth_path,
+            path=path,
             dependency_name=dependency_name,
             branch_name=branch_name,
             out_of_band_commit=out_of_band_commit,
@@ -61,14 +61,14 @@ def attach_to_group(group):
         )
 
     @dependencies.command()
-    @click.argument("auth_path")
     @click.argument("dependency-name")
+    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.option("--keystore", default=None, help="Location of the keystore files")
-    def remove(auth_path, dependency_name, keystore):
+    def remove(dependency_name, path, keystore):
         """Remove a dependency from dependencies.json.
         Update and sign targets metadata, snapshot and timestamp using yubikeys or keys loaded from the specified keystore location.
 
         `taf dependencies remove auth-path namespace1/auth --keystore keystore-path`
 
         """
-        remove_dependency(auth_path, dependency_name, keystore)
+        remove_dependency(path, dependency_name, keystore)

--- a/taf/tools/metadata/__init__.py
+++ b/taf/tools/metadata/__init__.py
@@ -12,7 +12,7 @@ def attach_to_group(group):
         pass
 
     @metadata.command()
-    @click.argument("path")
+    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.option("--interval", default=30, type=int, help="Number of days added to the start date")
     @click.option("--start-date", default=datetime.datetime.now(), help="Date to which expiration interval is added", type=ISO_DATE)
     def check_expiration_dates(path, interval, start_date):
@@ -34,10 +34,10 @@ def attach_to_group(group):
             snapshot will expire on 2022-07-28
             root will expire on 2022-08-19
         """
-        check_metadata_expiration_dates(repo_path=path, interval=interval, start_date=start_date)
+        check_metadata_expiration_dates(path=path, interval=interval, start_date=start_date)
 
     @metadata.command()
-    @click.argument("path")
+    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.option("--role", multiple=True, help="A list of roles which expiration date should get updated")
     @click.option("--interval", default=None, help="Number of days added to the start date",
                   type=int)

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -65,7 +65,7 @@ def attach_to_group(group):
         create_repository(path, keystore, keys_description, commit, test)
 
     @repo.command()
-    @click.argument("clients-auth-path", default=None, required=False)
+    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.option("--url", default=None, help="Authentication repository's url")
     @click.option("--clients-library-dir", default=None, help="Directory where target repositories and, "
                   "optionally, authentication repository are located. If omitted it is "
@@ -86,7 +86,7 @@ def attach_to_group(group):
                   "ignored during update.")
     @click.option("--strict", is_flag=True, default=False, help="Enable/disable strict mode - return an error"
                   "if warnings are raised ")
-    def update(clients_auth_path, url, clients_library_dir, from_fs, expected_repo_type,
+    def update(path, url, clients_library_dir, from_fs, expected_repo_type,
                scripts_root_dir, profile, format_output, exclude_target, strict):
         """
         Update and validate local authentication repository and target repositories. Remote
@@ -123,7 +123,7 @@ def attach_to_group(group):
         Update can be in strict or no-strict mode. Strict mode is set by specifying --strict, which will raise errors
         during update if any/all warnings are found. By default, --strict is disabled.
         """
-        if clients_auth_path is None and clients_library_dir is None:
+        if path is None and clients_library_dir is None:
             raise click.UsageError('Must specify either authentication repository path or library directory!')
 
         if profile:
@@ -145,7 +145,7 @@ def attach_to_group(group):
         try:
             update_repository(
                 url,
-                clients_auth_path,
+                path,
                 clients_library_dir,
                 from_fs,
                 UpdateType(expected_repo_type),
@@ -168,7 +168,7 @@ def attach_to_group(group):
                 raise e
 
     @repo.command()
-    @click.argument("clients-auth-path")
+    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.option("--clients-library-dir", default=None, help="Directory where target repositories and, "
                   "optionally, authentication repository are located. If omitted it is "
                   "calculated based on authentication repository's path. "
@@ -178,7 +178,7 @@ def attach_to_group(group):
                   "ignored during update.")
     @click.option("--strict", is_flag=True, default=False, help="Enable/disable strict mode - return an error"
                   "if warnings are raised")
-    def validate(clients_auth_path, clients_library_dir, from_commit, exclude_target, strict):
+    def validate(path, clients_library_dir, from_commit, exclude_target, strict):
         """
         Validates an authentication repository which is already on the file system
         and its target repositories (which are also expected to be on the file system).
@@ -187,4 +187,4 @@ def attach_to_group(group):
         Validation can be in strict or no-strict mode. Strict mode is set by specifying --strict, which will raise errors
         during validate if any/all warnings are found. By default, --strict is disabled.
         """
-        validate_repository(clients_auth_path, clients_library_dir, from_commit, exclude_target, strict)
+        validate_repository(path, clients_library_dir, from_commit, exclude_target, strict)

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -11,7 +11,7 @@ def attach_to_group(group):
         pass
 
     @repo.command()
-    @click.argument("path")
+    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.option("--keys-description", help="A dictionary containing information about the "
                   "keys or a path to a json file which stores the needed information")
     @click.option("--keystore", default=None, help="Location of the keystore files")

--- a/taf/tools/roles/__init__.py
+++ b/taf/tools/roles/__init__.py
@@ -11,8 +11,8 @@ def attach_to_group(group):
         pass
 
     @roles.command()
-    @click.argument("path")
     @click.argument("role")
+    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.option("--parent-role", default="targets", help="Parent targets role of this role. Defaults to targets")
     @click.option("--delegated-path", multiple=True, help="Paths associated with the delegated role")
     @click.option("--keystore", default=None, help="Location of the keystore files")
@@ -21,7 +21,7 @@ def attach_to_group(group):
                   "role whose signatures are required in order to consider a file as being properly signed by that role")
     @click.option("--yubikey", is_flag=True, default=None, help="A flag determining if the new role should be signed using a Yubikey")
     @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme used for signing")
-    def add(path, role, parent_role, delegated_path, keystore, keys_number, threshold, yubikey, scheme):
+    def add(role, path, parent_role, delegated_path, keystore, keys_number, threshold, yubikey, scheme):
         """Add a new delegated target role, specifying which paths are delegated to the new role.
         Its parent role, number of signing keys and signatures threshold can also be defined.
         Update and sign all metadata files and commit.
@@ -33,7 +33,7 @@ def attach_to_group(group):
         add_role(path, role, parent_role, delegated_path, keys_number, threshold, yubikey, keystore, scheme)
 
     @roles.command()
-    @click.argument("path")
+    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.argument("keys-description")
     @click.option("--keystore", default=None, help="Location of the keystore files")
     @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme "
@@ -72,14 +72,14 @@ def attach_to_group(group):
         add_roles(path, keystore, keys_description, scheme)
 
     @roles.command()
-    @click.argument("path")
     @click.argument("role")
+    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.option("--keystore", default=None, help="Location of the keystore files")
     @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme "
                   "used for signing")
     @click.option("--remove-targets/--no-remove-targets", default=True, help="Should targets delegated to this "
                   "role also be removed. If not removed, they are signed by the parent role")
-    def remove(path, role, keystore, scheme, remove_targets):
+    def remove(role, path, keystore, scheme, remove_targets):
         """Remove a delegated target role, and, optionally, its targets (depending on the remove-targets parameter).
         If targets should also be deleted, target files are remove and their corresponding entires are removed
         from repositoires.json. If targets should not get removed, the target files are signed using the

--- a/taf/tools/targets/__init__.py
+++ b/taf/tools/targets/__init__.py
@@ -22,14 +22,14 @@ def attach_to_group(group):
         ignore_unknown_options=True,
         allow_extra_args=True,
     ))
-    @click.argument("auth_path")
+    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.option("--target-name", default=None, help="Namespace prefixed name of the target repository")
     @click.option("--target-path", default=None, help="Target repository's filesystem path")
     @click.option("--role", default="targets", help="Signing role of the corresponding target file. "
                   "Can be a new role, in which case it will be necessary to enter its information when prompted")
     @click.option("--keystore", default=None, help="Location of the keystore files")
     @click.pass_context
-    def add_repo(ctx, auth_path, target_path, target_name, role, keystore):
+    def add_repo(ctx, path, target_path, target_name, role, keystore):
         """Add a new repository by adding it to repositories.json, creating a delegation (if targets is not
         its signing role) and adding and signing initial target files if the repository is found on the filesystem.
         All additional information that should be saved as the repository's custom content in `repositories.json`
@@ -50,7 +50,7 @@ def attach_to_group(group):
         """
         custom = {ctx.args[i][2:]: ctx.args[i + 1] for i in range(0, len(ctx.args), 2)} if len(ctx.args) else {}
         add_target_repo(
-            auth_path=auth_path,
+            path=path,
             target_path=target_path,
             target_name=target_name,
             library_dir=None,
@@ -60,13 +60,13 @@ def attach_to_group(group):
         )
 
     @targets.command()
-    @click.argument("repo_path")
+    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.option("--commit", default=None, help="Starting authentication repository commit")
     @click.option("--output", default=None, help="File to which the resulting json will be written. "
                   "If not provided, the output will be printed to console")
     @click.option("--repo", multiple=True, help="Target repository whose historical data "
                   "should be collected")
-    def export_history(repo_path, commit, output, repo):
+    def export_history(path, commit, output, repo):
         """Export lists of sorted commits, grouped by branches and target repositories, based
         on target files stored in the authentication repository. If commit is specified,
         only return changes made at that revision and all subsequent revisions. If it is not,
@@ -77,10 +77,10 @@ def attach_to_group(group):
         to a file whose location is specified using the output option, or print it to
         console.
         """
-        export_targets_history(repo_path, commit, output, repo)
+        export_targets_history(path, commit, output, repo)
 
     @targets.command()
-    @click.argument("path")
+    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.option("--library-dir", default=None, help="Directory where target repositories and, "
                   "optionally, authentication repository are located. If omitted it is "
                   "calculated based on authentication repository's path. "
@@ -102,16 +102,16 @@ def attach_to_group(group):
         list_targets(path, library_dir)
 
     @targets.command()
-    @click.argument("auth_path")
+    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.argument("target-name")
     @click.option("--keystore", default=None, help="Location of the keystore files")
-    def remove_repo(auth_path, target_name, keystore):
+    def remove_repo(path, target_name, keystore):
         """Remove a target repository (from repsoitories.json and target file) and sign
         """
-        remove_target_repo(auth_path, target_name, keystore)
+        remove_target_repo(path, target_name, keystore)
 
     @targets.command()
-    @click.argument("path")
+    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.option("--keystore", default=None, help="Location of the keystore files")
     @click.option("--keys-description", help="A dictionary containing information about the "
                   "keys or a path to a json file which stores the needed information")
@@ -136,7 +136,7 @@ def attach_to_group(group):
             click.echo()
 
     @targets.command()
-    @click.argument("path")
+    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.option("--library-dir", default=None, help="Directory where target repositories and, "
                   "optionally, authentication repository are located. If omitted it is "
                   "calculated based on authentication repository's path. "


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

- Standardize the way in which authentication repository's path is specified. Make it optional and set the default value to the current working directory. The option is now called `--path` across all commands.
- Check if working repository is clean before running repo, targets, metadata, roles and dependecies commands
- Added additional logging
- Update documentation following recent reworks

Closes #224 
Closes #27

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
