### PR TITLE
List keys of roles and export certificate commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
+- List keys of roles with additional information read from certificates command ([355])
+- Export certificate from the inserted YubiKey ([355])
 - Add signing keys given a public key when creating a new authentication repository ([354])
 - Allow specification of names of YubiKeys in repository description json ([354])
 - Model repository description json input using `attrs` and `cattrs` and its validation ([354])
@@ -35,6 +37,7 @@ and this project adheres to [Semantic Versioning][semver].
 - Fix commits per repositories function when same target commits are on different branches ([337])
 - Add missing `write` flag to `taf targets sign` ([329])
 
+[355]: https://github.com/openlawlibrary/taf/pull/355
 [354]: https://github.com/openlawlibrary/taf/pull/354
 [353]: https://github.com/openlawlibrary/taf/pull/353
 [352]: https://github.com/openlawlibrary/taf/pull/352

--- a/taf/api/roles.py
+++ b/taf/api/roles.py
@@ -655,7 +655,7 @@ def list_keys_of_role(
     auth_repo = AuthenticationRepository(path=path)
     key_ids = auth_repo.get_role_keys(role=role)
     for key_id in key_ids:
-        print(get_metadata_key_info(auth_repo.certs_dir, key_id))
+        print(f"\n{get_metadata_key_info(auth_repo.certs_dir, key_id)}")
 
 
 @log_on_start(DEBUG, "Removing role {role:s}", logger=taf_logger)

--- a/taf/api/roles.py
+++ b/taf/api/roles.py
@@ -18,6 +18,7 @@ import tuf.roledb
 import taf.repositoriesdb as repositoriesdb
 from taf.keys import (
     get_key_name,
+    get_metadata_key_info,
     load_signing_keys,
     load_sorted_keys_of_new_roles,
 )
@@ -637,6 +638,24 @@ def _role_obj(role, repository, parent=None):
         if parent is None:
             return repository.targets(role)
         return parent(role)
+
+
+@log_on_error(
+    ERROR,
+    "Could not list keys of {role:s}: {e}",
+    logger=taf_logger,
+    on_exceptions=TAFError,
+    reraise=True,
+)
+@check_if_clean
+def list_keys_of_role(
+    path: str,
+    role: str,
+):
+    auth_repo = AuthenticationRepository(path=path)
+    key_ids = auth_repo.get_role_keys(role=role)
+    for key_id in key_ids:
+        print(get_metadata_key_info(auth_repo.certs_dir, key_id))
 
 
 @log_on_start(DEBUG, "Removing role {role:s}", logger=taf_logger)

--- a/taf/api/roles.py
+++ b/taf/api/roles.py
@@ -647,7 +647,6 @@ def _role_obj(role, repository, parent=None):
     on_exceptions=TAFError,
     reraise=True,
 )
-@check_if_clean
 def list_keys_of_role(
     path: str,
     role: str,

--- a/taf/api/targets.py
+++ b/taf/api/targets.py
@@ -219,7 +219,6 @@ def export_targets_history(path, commit=None, output=None, target_repos=None):
         print(commits_json)
 
 
-@check_if_clean
 def list_targets(
     path: str,
     library_dir: str = None,

--- a/taf/auth_repo.py
+++ b/taf/auth_repo.py
@@ -102,7 +102,6 @@ class AuthenticationRepository(GitRepository, TAFRepository):
     @property
     def certs_dir(self):
         certs_dir = Path(self.path, "certs")
-        certs_dir.mkdir(parents=True, exist_ok=True)
         return str(certs_dir)
 
     @property

--- a/taf/exceptions.py
+++ b/taf/exceptions.py
@@ -64,6 +64,13 @@ class InvalidPINError(TAFError):
     pass
 
 
+class RemoveMetadataKeyThresholdError(TAFError):
+    def __init__(self, threshold):
+        super().__init__(
+            f"Remaining key number must be greater or equal to threshold ({threshold})."
+        )
+
+
 class RepositoryInstantiationError(TAFError):
     def __init__(self, repo_path, message):
         super().__init__(f"Could not instantiate repository {repo_path}\n\n: {message}")

--- a/taf/keys.py
+++ b/taf/keys.py
@@ -13,7 +13,6 @@ from tuf.repository_tool import generate_and_write_unencrypted_rsa_keypair
 from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
 from taf.exceptions import (
     KeystoreError,
-    RemoveMetadataKeyThresholdError,
     SigningError,
     YubikeyError,
 )

--- a/taf/keys.py
+++ b/taf/keys.py
@@ -6,11 +6,17 @@ from logdecorator import log_on_start
 from taf.auth_repo import AuthenticationRepository
 from taf.log import taf_logger
 from taf.models.iterators import RolesIterator
+from taf.models.models import TAFKey
 from taf.models.types import DelegatedRole, MainRoles, UserKeyData
 from taf.yubikey import get_key_serial_by_id
 from tuf.repository_tool import generate_and_write_unencrypted_rsa_keypair
 from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
-from taf.exceptions import KeystoreError, SigningError, YubikeyError
+from taf.exceptions import (
+    KeystoreError,
+    RemoveMetadataKeyThresholdError,
+    SigningError,
+    YubikeyError,
+)
 from taf.keystore import (
     key_cmd_prompt,
     read_private_key_from_keystore,
@@ -35,6 +41,36 @@ def get_key_name(role_name, key_num, num_of_keys):
         return role_name
     else:
         return role_name + str(key_num + 1)
+
+
+def get_metadata_key_info(certs_dir, key_id):
+    cert_path = Path(certs_dir, key_id + ".cert")
+    if cert_path.exists():
+        cert_pem = cert_path.read_bytes()
+        return TAFKey(key_id, **_extract_x509(cert_pem))
+
+    return TAFKey(key_id)
+
+
+def _extract_x509(cert_pem):
+    from cryptography import x509
+    from cryptography.hazmat.backends import default_backend
+
+    cert = x509.load_pem_x509_certificate(cert_pem, default_backend())
+
+    def _get_attr(oid):
+        attrs = cert.subject.get_attributes_for_oid(oid)
+        return attrs[0].value if len(attrs) > 0 else ""
+
+    return {
+        "name": _get_attr(x509.OID_COMMON_NAME),
+        "organization": _get_attr(x509.OID_ORGANIZATION_NAME),
+        "country": _get_attr(x509.OID_COUNTRY_NAME),
+        "state": _get_attr(x509.OID_STATE_OR_PROVINCE_NAME),
+        "locality": _get_attr(x509.OID_LOCALITY_NAME),
+        "valid_from": cert.not_valid_before.strftime("%Y-%m-%d"),
+        "valid_to": cert.not_valid_after.strftime("%Y-%m-%d"),
+    }
 
 
 def load_sorted_keys_of_new_roles(

--- a/taf/models/models.py
+++ b/taf/models/models.py
@@ -1,0 +1,34 @@
+class TAFKey:
+    def __init__(
+        self,
+        key_id,
+        name=None,
+        organization=None,
+        country=None,
+        state=None,
+        locality=None,
+        valid_from=None,
+        valid_to=None,
+    ):
+        self.key_id = key_id
+        self.name = name or ""
+        self.organization = organization or ""
+        self.country = country or ""
+        self.state = state or ""
+        self.locality = locality or ""
+        self.valid_from = valid_from or ""
+        self.valid_to = valid_to or ""
+
+    def __str__(self):
+        attributes = [
+            f"Key ID: {self.key_id}",
+            f"Name: {self.name}" if self.name else None,
+            f"Organization: {self.organization}" if self.organization else None,
+            f"Country: {self.country}" if self.country else None,
+            f"State: {self.state}" if self.state else None,
+            f"Locality: {self.locality}" if self.locality else None,
+            f"Valid From: {self.valid_from}" if self.valid_from else None,
+            f"Valid To: {self.valid_to}" if self.valid_to else None,
+        ]
+
+        return "\n".join(filter(None, attributes))

--- a/taf/tools/roles/__init__.py
+++ b/taf/tools/roles/__init__.py
@@ -1,5 +1,5 @@
 import click
-from taf.api.roles import add_role, add_roles, remove_role, add_signing_key as add_roles_signing_key
+from taf.api.roles import add_role, add_roles, list_keys_of_role, remove_role, add_signing_key as add_roles_signing_key
 
 from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
 from taf.exceptions import TAFError
@@ -159,3 +159,24 @@ def attach_to_group(group):
             scheme=scheme,
             prompt_for_keys=prompt_for_keys
         )
+
+
+    @roles.command()
+    @catch_cli_exception(handle=TAFError)
+    @click.argument("role")
+    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
+    def list_keys(role, path):
+        """
+        Add a new signing key. This will make it possible to a sign metadata files
+        corresponding to the specified roles with another key. Although private keys are
+        used for signing, key identifiers are calculated based on the public keys. This
+        means that it's necessary to enter the public key in order to register
+        a new signing key. Public key can be loaded from a file, in which case it is
+        necessary to specify its path as the pub_key parameter's value. If this option
+        is not used when calling this command, the key can be directly entered later.
+        """
+        list_keys_of_role(
+            path=path,
+            role=role,
+        )
+

--- a/taf/tools/roles/__init__.py
+++ b/taf/tools/roles/__init__.py
@@ -1,6 +1,5 @@
 import click
 from taf.api.roles import add_role, add_roles, list_keys_of_role, remove_role, add_signing_key as add_roles_signing_key
-
 from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
 from taf.exceptions import TAFError
 from taf.tools.cli import catch_cli_exception
@@ -160,7 +159,6 @@ def attach_to_group(group):
             prompt_for_keys=prompt_for_keys
         )
 
-
     @roles.command()
     @catch_cli_exception(handle=TAFError)
     @click.argument("role")
@@ -179,4 +177,3 @@ def attach_to_group(group):
             path=path,
             role=role,
         )
-

--- a/taf/tools/roles/__init__.py
+++ b/taf/tools/roles/__init__.py
@@ -165,13 +165,8 @@ def attach_to_group(group):
     @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     def list_keys(role, path):
         """
-        Add a new signing key. This will make it possible to a sign metadata files
-        corresponding to the specified roles with another key. Although private keys are
-        used for signing, key identifiers are calculated based on the public keys. This
-        means that it's necessary to enter the public key in order to register
-        a new signing key. Public key can be loaded from a file, in which case it is
-        necessary to specify its path as the pub_key parameter's value. If this option
-        is not used when calling this command, the key can be directly entered later.
+        List all keys of the specified role. If certs directory exists and contains certificates exported from YubiKeys,
+        include additional information read from these certificates, like name or organization.
         """
         list_keys_of_role(
             path=path,

--- a/taf/tools/yubikey/__init__.py
+++ b/taf/tools/yubikey/__init__.py
@@ -1,6 +1,6 @@
 import click
 import json
-from taf.api.yubikey import export_yk_public_pem, setup_signing_yubikey, setup_test_yubikey
+from taf.api.yubikey import export_yk_certificate, export_yk_public_pem, setup_signing_yubikey, setup_test_yubikey
 from taf.exceptions import YubikeyError
 
 
@@ -36,6 +36,15 @@ def attach_to_group(group):
         Export the inserted Yubikey's public key and save it to the specified location.
         """
         export_yk_public_pem(output)
+
+    @yubikey.command()
+    @click.option("--output", help="File to which the exported certificate key will be written. "
+                  "The result will be written to the user's home directory by default")
+    def export_certificate(output):
+        """
+        Export the inserted Yubikey's public key and save it to the specified location.
+        """
+        export_yk_certificate(output)
 
     @yubikey.command()
     @click.option("--certs-dir", help="Path of the directory where the exported certificate will be saved."


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

- List all keys of the specified role. If certs directory exists and contains certificates exported from YubiKeys, include additional information read from these certificates, like name or organization.
- Export its certificate from the inserted YubiKey - not tested yet

This PR includes code which was previously only in the TAF management application.

Closes #17 

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
