### PR TITLE
Fix loading of keys and  create repo when old yubikey flag is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,12 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Fix loading of keys and create repo when old yubikey flag is used ([370])
 - Fix keys naming issue after adding a new signing key to a role that only had one signing key ([362])
 - Fix removal of targets when removing a role ([362])
 
-[362]: https://github.com/openlawlibrary/taf/pull/362
+[370]: https://github.com/openlawlibrary/taf/pull/370
+[365]: https://github.com/openlawlibrary/taf/pull/365
 [362]: https://github.com/openlawlibrary/taf/pull/362
 [360]: https://github.com/openlawlibrary/taf/pull/360
 

--- a/taf/api/roles.py
+++ b/taf/api/roles.py
@@ -895,8 +895,14 @@ def _update_role(
     from either a keystore file or yubikey and sign the file without updating
     snapshot and timestamp and writing changes to disk
     """
+    loaded_yubikeys: Dict = {}
     keystore_keys, yubikeys = load_signing_keys(
-        auth_repo, role, keystore, scheme=scheme, prompt_for_keys=prompt_for_keys
+        auth_repo,
+        role,
+        loaded_yubikeys,
+        keystore,
+        scheme=scheme,
+        prompt_for_keys=prompt_for_keys,
     )
     if len(keystore_keys):
         auth_repo.update_role_keystores(role, keystore_keys, write=False)

--- a/taf/api/utils/__init__.py
+++ b/taf/api/utils/__init__.py
@@ -1,11 +1,6 @@
 import functools
-from logging import ERROR
-from typing import Optional
-from logdecorator import log_on_error
-from taf.auth_repo import AuthenticationRepository
-from taf.exceptions import RepositoryNotCleanError, TAFError
+from taf.exceptions import RepositoryNotCleanError
 from taf.git import GitRepository
-from taf.log import taf_logger
 
 
 def check_if_clean(func):
@@ -24,23 +19,3 @@ def check_if_clean(func):
         return func(*args, **kwargs)
 
     return wrapper
-
-
-@log_on_error(
-    ERROR,
-    "An error occurred while committing and pushing changes: {e}",
-    logger=taf_logger,
-    on_exceptions=TAFError,
-    reraise=True,
-)
-def commit_and_push(
-    auth_repo: AuthenticationRepository,
-    commit_msg: Optional[str] = None,
-    push: Optional[bool] = True,
-) -> None:
-    if commit_msg is None:
-        commit_msg = input("\nEnter commit message and press ENTER\n\n")
-    auth_repo.commit(commit_msg)
-    if push:
-        auth_repo.push()
-        taf_logger.info("Successfully pushed to remote")

--- a/taf/api/utils/_git.py
+++ b/taf/api/utils/_git.py
@@ -41,6 +41,6 @@ def commit_and_push(
     if commit_msg is None:
         commit_msg = input("\nEnter commit message and press ENTER\n\n")
     auth_repo.commit(commit_msg)
-    if push:
+    if push and auth_repo.has_remote():
         auth_repo.push()
         taf_logger.info("Successfully pushed to remote")

--- a/taf/api/utils/_metadata.py
+++ b/taf/api/utils/_metadata.py
@@ -47,8 +47,8 @@ def update_snapshot_and_timestamp(
         keystore_keys, yubikeys = load_signing_keys(
             taf_repo,
             role,
-            keystore,
             loaded_yubikeys,
+            keystore,
             scheme=scheme,
             prompt_for_keys=prompt_for_keys,
         )
@@ -117,8 +117,8 @@ def update_target_metadata(
         keystore_keys, yubikeys = load_signing_keys(
             taf_repo,
             role,
-            keystore,
             loaded_yubikeys,
+            keystore,
             scheme=scheme,
             prompt_for_keys=prompt_for_keys,
         )

--- a/taf/keys.py
+++ b/taf/keys.py
@@ -165,7 +165,9 @@ def load_sorted_keys_of_new_roles(
         raise SigningError("Could not load keys of new roles")
 
 
-def _load_from_keystore(taf_repo, keystore_path, key_name, num_of_signatures, scheme, role):
+def _load_from_keystore(
+    taf_repo, keystore_path, key_name, num_of_signatures, scheme, role
+):
     if keystore_path is None:
         return None
     if (keystore_path / key_name).is_file():
@@ -242,7 +244,9 @@ def load_signing_keys(
         # there is no need to ask the user if they want to load more key, try to load from keystore
         if num_of_signatures < len(keystore_files):
             key_name = keystore_files[num_of_signatures]
-            key = _load_from_keystore(taf_repo, keystore_path, key_name, num_of_signatures, scheme, role)
+            key = _load_from_keystore(
+                taf_repo, keystore_path, key_name, num_of_signatures, scheme, role
+            )
             if key is not None:
                 keys.append(key)
                 num_of_signatures += 1

--- a/taf/keys.py
+++ b/taf/keys.py
@@ -473,7 +473,7 @@ def _setup_yubikey(
     yubikeys: Optional[Dict],
     role_name: str,
     key_name: str,
-    loaded_keys: Optional[list[str]] = None,
+    loaded_keys: List[str],
     scheme: Optional[str] = DEFAULT_RSA_SIGNATURE_SCHEME,
     certs_dir: Optional[Union[Path, str]] = None,
 ) -> Dict:

--- a/taf/keys.py
+++ b/taf/keys.py
@@ -253,9 +253,13 @@ def load_signing_keys(
                 continue
 
         if num_of_signatures >= threshold:
-            if not click.confirm(
-                f"Threshold of {role} keys reached. Do you want to load more {role} keys?"
-            ):
+            if use_yubikey_for_signing_confirmed:
+                if not click.confirm(
+                    f"Threshold of {role} keys reached. Do you want to load more {role} keys?"
+                ):
+                    break
+            else:
+                # loading from keystore files, couldn't load from all of them, but loaded enough
                 break
 
         # try to load from the inserted YubiKey, without asking the user to insert it

--- a/taf/models/types.py
+++ b/taf/models/types.py
@@ -57,7 +57,7 @@ class Role:
     @property
     def yubikey_ids(self):
         if not self.is_yubikey:
-            return []
+            return None
         if self.yubikeys:
             return self.yubikeys
         if self.number == 1:

--- a/taf/models/types.py
+++ b/taf/models/types.py
@@ -54,6 +54,16 @@ class Role:
             self.yubikey is True or (self.yubikeys is not None and len(self.yubikeys))
         )
 
+    @property
+    def yubikey_ids(self):
+        if not self.is_yubikey:
+            return []
+        if self.yubikeys:
+            return self.yubikeys
+        if self.number == 1:
+            return [self.name]
+        return [f"{self.name}{counter}" for counter in range(1, self.number + 1)]
+
 
 @attrs.define
 class RootRole(Role):

--- a/taf/yubikey.py
+++ b/taf/yubikey.py
@@ -416,6 +416,7 @@ def yubikey_prompt(
     pin_repeat=True,
     prompt_message=None,
     retry_on_failure=True,
+    hide_already_loaded_message=False,
 ):
     def _read_and_check_yubikey(
         key_name,
@@ -448,7 +449,8 @@ def yubikey_prompt(
             and serial_num in loaded_yubikeys
             and role in loaded_yubikeys[serial_num]
         ):
-            print("Key already loaded")
+            if not hide_already_loaded_message:
+                print("Key already loaded")
             return False, None, None
 
         # read the public key, unless a new key needs to be generated on the yubikey


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

When loading signing keys, we want to first try reading from keystore files, then from the inserted Yubikey, before asking the user to do anything. The problem was that the check if key was already read from a YubiKey was not properly implemented, so the same key was getting read twice. Also tried to improve the overall user experience when loading keys.
Found issues with creating a repository in case when old `yubikey` flag was used to specify that a role's metadata files should be signed using YubiKeys.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
