### PR TITLE
Fix imports, do not require installation of ykman in order to run the updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,10 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Fix imports, do not require installation of yubikey-manager prior to running the update ([376])
 - Git: fix the commit method so that it raises an error if nothing is committed ([375])
 
+[376]: https://github.com/openlawlibrary/taf/pull/376
 [375]: https://github.com/openlawlibrary/taf/pull/375
 [374]: https://github.com/openlawlibrary/taf/pull/374
 

--- a/taf/api/utils/_roles.py
+++ b/taf/api/utils/_roles.py
@@ -5,7 +5,6 @@ from logdecorator import log_on_end, log_on_start
 from tuf.repository_tool import Repository as TUFRepository, Targets
 from taf.exceptions import TAFError
 from taf.models.types import RolesIterator
-from taf.yubikey import get_key_serial_by_id
 from tuf.repository_tool import Metadata
 from taf.keys import get_key_name
 from taf.auth_repo import AuthenticationRepository
@@ -17,6 +16,11 @@ from taf.repository_tool import (
 )
 from taf.models.types import Role
 from taf.log import taf_logger
+
+try:
+    from taf.yubikey import get_key_serial_by_id
+except ImportError:
+    pass
 
 
 @log_on_start(INFO, "Creating delegations", logger=taf_logger)

--- a/taf/keys.py
+++ b/taf/keys.py
@@ -31,8 +31,6 @@ from securesystemslib import keys
 
 try:
     import taf.yubikey as yk
-    from taf.yubikey import get_key_serial_by_id
-    from taf.yubikey import export_yk_certificate
 except ImportError:
     taf_logger.warning(
         "WARNING: yubikey-manager dependency not installed. You will not be able to use YubiKeys."
@@ -346,7 +344,7 @@ def _setup_yubikey_roles_keys(
             scheme = users_yubikeys_details[key_id].scheme
             public_key = keys.import_rsakey_from_public_pem(public_key_text, scheme)
             # check if signing key already loaded too
-            if not get_key_serial_by_id(key_id):
+            if not yk.get_key_serial_by_id(key_id):
                 yk_with_public_key[key_id] = public_key
             else:
                 loaded_keys_num += 1
@@ -512,7 +510,7 @@ def _setup_yubikey(
                 key = yk.setup_new_yubikey(serial_num, scheme)
 
             if certs_dir is not None:
-                export_yk_certificate(certs_dir, key)
+                yk.export_yk_certificate(certs_dir, key)
             return key
 
 

--- a/taf/keys.py
+++ b/taf/keys.py
@@ -10,7 +10,6 @@ from taf.models.types import Role, RolesIterator
 from taf.models.models import TAFKey
 from taf.models.types import TargetsRole, MainRoles, UserKeyData
 from taf.repository_tool import Repository
-from taf.yubikey import get_key_serial_by_id
 from tuf.repository_tool import (
     generate_and_write_unencrypted_rsa_keypair,
     generate_and_write_rsa_keypair,
@@ -32,6 +31,7 @@ from securesystemslib import keys
 
 try:
     import taf.yubikey as yk
+    from taf.yubikey import get_key_serial_by_id
     from taf.yubikey import export_yk_certificate
 except ImportError:
     taf_logger.warning(

--- a/taf/tests/test_updater/test_repo_update/test_updater.py
+++ b/taf/tests/test_updater/test_repo_update/test_updater.py
@@ -65,6 +65,7 @@ from taf.updater.updater import update_repository, UpdateType
 from taf.utils import on_rm_error
 
 from taf.log import disable_console_logging, disable_file_logging
+
 from taf.tests.test_updater.test_repo_update.conftest import (
     original_tuf_trusted_metadata_set,
 )
@@ -73,10 +74,10 @@ AUTH_REPO_REL_PATH = "organization/auth_repo"
 TARGET_REPO_REL_PATH = "namespace/TargetRepo1"
 
 TARGET_MISSMATCH_PATTERN = r"Update of organization\/auth_repo failed due to error: Failure to validate organization\/auth_repo commit ([0-9a-f]{40}) committed on (\d{4}-\d{2}-\d{2}): data repository ([\w\/-]+) was supposed to be at commit ([0-9a-z]{40}) but repo was at ([0-9a-f]{40})"
-TARGET_ADDITIONAL_COMMIT = r"Update of organization\/auth_repo failed due to error: Failure to validate organization\/auth_repo commit ([0-9a-f]{40}) committed on (\d{4}-\d{2}-\d{2}): data repository ([\w\/-]+) was supposed to be at commit ([0-9a-f]{40}) but commit not on branch (\w+)"
-TARGET_COMMIT_AFTER_LAST_VALIDATED = r"Update of organization\/auth_repo failed due to error: Target repository ([\w\/-]+) does not allow unauthenticated commits, but contains commit\(s\) ([0-9a-f]{40}(?:, [0-9a-f]{40})*) on branch (\w+)"
-TARGET_MISSING_COMMIT = r"Update of organization/auth_repo failed due to error: Failure to validate organization/auth_repo commit ([0-9a-f]{40}) committed on (\d{4}-\d{2}-\d{2}): data repository ([\w\/-]+) was supposed to be at commit ([0-9a-f]{40}) but commit not on branch (\w+)"
-INDEX_LOCKED = r"Update of organization/auth_repo failed due to error: Repo ([\w\/-]+): the index is locked; this might be due to a concurrent or crashed process"
+TARGET_ADDITIONAL_COMMIT_PATTERN = r"Update of organization\/auth_repo failed due to error: Failure to validate organization\/auth_repo commit ([0-9a-f]{40}) committed on (\d{4}-\d{2}-\d{2}): data repository ([\w\/-]+) was supposed to be at commit ([0-9a-f]{40}) but commit not on branch (\w+)"
+TARGET_COMMIT_AFTER_LAST_VALIDATED_PATTERN = r"Update of organization\/auth_repo failed due to error: Target repository ([\w\/-]+) does not allow unauthenticated commits, but contains commit\(s\) ([0-9a-f]{40}(?:, [0-9a-f]{40})*) on branch (\w+)"
+TARGET_MISSING_COMMIT_PATTERN = r"Update of organization/auth_repo failed due to error: Failure to validate organization/auth_repo commit ([0-9a-f]{40}) committed on (\d{4}-\d{2}-\d{2}): data repository ([\w\/-]+) was supposed to be at commit ([0-9a-f]{40}) but commit not on branch (\w+)"
+NOT_CLEAN_PATTERN = r"^Update of ([\w/]+) failed due to error: Repository ([\w/-]+) should contain only committed changes\."
 
 
 NO_WORKING_MIRRORS = (
@@ -249,14 +250,14 @@ def test_no_update_necessary(
         ("test-updater-invalid-target-sha", TARGET_MISSMATCH_PATTERN, True, True, True),
         (
             "test-updater-additional-target-commit",
-            TARGET_COMMIT_AFTER_LAST_VALIDATED,
+            TARGET_COMMIT_AFTER_LAST_VALIDATED_PATTERN,
             True,
             True,
             True,
         ),
         (
             "test-updater-missing-target-commit",
-            TARGET_ADDITIONAL_COMMIT,
+            TARGET_ADDITIONAL_COMMIT_PATTERN,
             True,
             True,
             True,
@@ -316,7 +317,7 @@ def test_updater_invalid_update(
     "test_name, expected_error",
     [
         ("test-updater-invalid-target-sha", TARGET_MISSMATCH_PATTERN),
-        ("test-updater-missing-target-commit", TARGET_MISSING_COMMIT),
+        ("test-updater-missing-target-commit", TARGET_MISSING_COMMIT_PATTERN),
     ],
 )
 def test_valid_update_no_auth_repo_one_invalid_target_repo_exists(
@@ -452,7 +453,7 @@ def test_update_repo_target_in_indeterminate_state(
     index_lock.touch()
 
     _update_invalid_repos_and_check_if_repos_exist(
-        client_dir, repositories, INDEX_LOCKED, True
+        client_dir, repositories, NOT_CLEAN_PATTERN, True
     )
 
 

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -7,7 +7,7 @@ import shutil
 import tempfile
 from typing import Any, Dict, List, Optional
 from attr import attrs, define, field
-from git import GitError
+from taf.git import GitError
 from logdecorator import log_on_end, log_on_start
 from taf.git import GitRepository
 


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

- Made it possible to run the updater without installing yubikey manager
- Fixed a `GitError` impor
- Fixed a failing tests following update of the imports. The behavior of this test is now the same as before the updater rework

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
