### PR TITLE
Separate clone and update commands and read repository name from info.json when cloning

### DIFF
--- a/docs/repo-creation-and-update-util.md
+++ b/docs/repo-creation-and-update-util.md
@@ -50,7 +50,7 @@ To make commands such as creation of repositories, generation of keys and all ot
 require certain information about roles and keys easier to use, an option called
 `keys-description` was introduced. It allows passing in a json, like the following one:
 
-```
+```json
 {
   "yubikeys": {
     "user1": {
@@ -208,51 +208,53 @@ The generated files and folders will automatically be committed unless `--no-com
 new repository is only be meant to be used for testing, use `--test` flag. This will create a special
 target file called `test-auth-repo`.
 
-### `repo update`
+### `repo clone`
 
-Update and validate local authentication repository, its child authentication repositories (specified in `dependencies.json` )
-and target repositories. When running the updater for the first time, it is necessary to specify the repository's remote url.
-When updating an existing authentication repository, the url is automatically determined. Similarly, the repository's filesystem
-path can, but does have to be specified. If it is omitted, it will be assumed that the repository is located inside the current
-working directory. If the authentication repository and the target repositories are in the same root directory,
+Clone the local authentication repository and its associated target and child authentication repositories (if specified in `dependencies.json` ). Specify the repository's remote URL when running the cloner for the first time. The `--path` option sets the location of the authentication repository; if not specified, it is calculated by reading repository's name and namespace from `targets/protected/info.json` and appending it to the `library-dir` path. The `--library-dir` option specifies the root directory and is set to the current dirrectory by defailt. `--from-fs` flag needs to be provided if repositories URL is actually a filesystem path.
+
+Additional options include setting the expected repository type (`--expected-repo-type`, which can be `test`, `official` or `either`), specifying a scripts root directory (`--scripts-root-dir`), enabling profiling (`--profile`), returning formatted output (`--format-output`), excluding specific target repositories (`--exclude-target`), and enabling/disabling strict mode (`--strict`).
+
+For example:
+
+```bash
+taf repo clone https://github.com/orgname/auth_repo
+```
+
+```bash
+`taf repo clone --path E:\\root\\namespace\\auth_repo --library-dir E:\\root https://github.com/orgname/auth_repo`
+```
+
+```bash
+taf repo clone --url file://path/to/repo --from-fs
+```
+
+If the authentication repository and the target repositories are in the same root directory,
 locations of the target repositories are calculated based on the authentication repository's
-path. If that is not the case, it is necessary to redefine this default value using the `--clients-library-dir` option.
-Names of target repositories (as defined in repositories.json) are appended to the root
+path. If that is not the case, it is necessary to redefine this default value using the `--library-dir` option.
+Names of target repositories (as defined in `repositories.json`) are appended to the root
 path thus defining the location of each target repository. If names of target repositories
-are namespace/repo1, namespace/repo2 etc and the root directory is E:\\root, path of the target
+are `namespace/repo1`, `namespace/repo2` etc and the root directory is `E:\\root`, path of the target
 repositories will be calculated as `E:\\root\\namespace\\repo1`, `E:\\root\\namespace\\root2` etc.
 
 When updating a test repository (that has the "test" target file), use `--authenticate-test-repo`
 flag. An error will be raised if this flag is omitted in the mentioned case. Do not use this
 flag when validating non-test repository as that will also result in an error.
 
+### `repo update`
+
+Update and validate an existing local authentication repository and its target repositories and dependencies. The URL of the repository is automatically determined. The `--path` option, if not specified, defaults to the current directory, while the `--library-dir` option specifies the library root directory (where targets and dependencies are expected to be located and is determined based on the authentication repository's path if not provided).
+
+Options include setting the expected repository type (`--expected-repo-type`), specifying a scripts root directory (`--scripts-root-dir`), enabling profiling (`--profile`), returning formatted output (`--format-output`), excluding specific target repositories (`--exclude-target`), and enabling/disabling strict mode (`--strict`).
+
 For example:
-
-```bash
-taf repo update --path E:\\root\\namespace\\auth_repo --url https://github.com/orgname/auth-repo   --authenticate-test-repo
-```
-
-In this example, all target repositories will be expected to be in `E:\root`.
-
-
-```bash
-taf repo update E:\\root\\namespace\\auth_repo --url https://github.com/orgname/auth-repo --clients-library-dir E:\\target-repos
-```
-
-In this example, the target repositories will be expected to be in `E:\\target-repos`.
-
-or just
 
 ```bash
 taf repo update
 ```
 
-if repository already exists and is located inside the current working directory.
-
-
-If remote repository's url is a file system path, it is necessary to call this command with
-`--from-fs` flag so that url validation is skipped. This option is mostly of interest to the
-implementation of updater tests. To validate local repositories, use the `validate` command.
+```bash
+taf repo update --path E:\\root\\namespace\\auth_repo
+```
 
 ### `repo validate`
 
@@ -263,11 +265,10 @@ to make sure that the recent updates of the authentication repository and its ta
 before pushing them.
 
 Locations of target repositories are calculated in the same way as when updating repositories.
-Unlike the update command, this command does not have the `url` argument or the `--authenticate-test-repo`
-flag among its inputs. Additionally, it allows specification of the firs commit which should be validated through the `--from-commit`
-option. That means that we can only validate new authentication repository's commits. This
-command does not store information about the last validated commit. See updater documentation
-for more information about how it works.
+It allows specification of the first commit which should be validated through the `--from-commit`
+option. This command does not store information about the last validated commit or make any modifications
+to the repositories.
+
 Here are a few examples:
 
 ```bash

--- a/taf/exceptions.py
+++ b/taf/exceptions.py
@@ -113,6 +113,10 @@ class MetadataUpdateError(TAFError):
         self.message = message
 
 
+class MissingInfoJsonError(TAFError):
+    pass
+
+
 class NothingToCommitError(GitError):
     pass
 

--- a/taf/tests/test_updater/test_repo_update/test_updater.py
+++ b/taf/tests/test_updater/test_repo_update/test_updater.py
@@ -87,19 +87,13 @@ NOT_CLEAN_PATTERN = r"^Update of ([\w/]+) failed due to error: Repository ([\w/-
 INVALID_KEYS_PATTERN = r"^Update of ([\w/-]+)/([\w/-]+) failed due to error: Validation of authentication repository failed at revision ([0-9a-f]{40}) due to error: ([\w/-]+) was signed by (\d+)/(\d+) keys$"
 
 
-NO_WORKING_MIRRORS = (
-    f"Validation of authentication repository {AUTH_REPO_REL_PATH} failed at revision"
-)
 NO_REPOSITORY_INFO_JSON = "Update of repository failed due to error: Error during info.json parse. If the authentication repository's path is not specified, info.json metadata is expected to be in targets/protected"
 ROOT_EXPIRED = "Final root.json is expired"
 REPLAYED_METADATA = "New timestamp version 3 must be >= 4"
 METADATA_FIELD_MISSING = "New snapshot is missing info for 'root.json'"
 IS_A_TEST_REPO = f"Repository {AUTH_REPO_REL_PATH} is a test repository."
 NOT_A_TEST_REPO = f"Repository {AUTH_REPO_REL_PATH} is not a test repository."
-LAST_VALIDATED_COMMIT_MISMATCH = "Saved last validated commit {} of repository {} does not match the current head commit {}"
-UNCOMMITTED_TARGET_CHANGES = (
-    f"Repository {TARGET_REPO_REL_PATH} should contain only committed changes."
-)
+
 
 disable_console_logging()
 disable_file_logging()

--- a/taf/tests/test_updater/test_repo_update/test_updater.py
+++ b/taf/tests/test_updater/test_repo_update/test_updater.py
@@ -61,7 +61,12 @@ from tuf.ngclient._internal import trusted_metadata_set
 from taf.auth_repo import AuthenticationRepository
 from taf.exceptions import UpdateFailedError
 from taf.git import GitRepository
-from taf.updater.updater import update_repository, UpdateType
+from taf.updater.updater import (
+    RepositoryConfig,
+    clone_repository,
+    update_repository,
+    UpdateType,
+)
 from taf.utils import on_rm_error
 
 from taf.log import disable_console_logging, disable_file_logging
@@ -69,6 +74,7 @@ from taf.log import disable_console_logging, disable_file_logging
 from taf.tests.test_updater.test_repo_update.conftest import (
     original_tuf_trusted_metadata_set,
 )
+from taf.updater.types.update import OperationType
 
 AUTH_REPO_REL_PATH = "organization/auth_repo"
 TARGET_REPO_REL_PATH = "namespace/TargetRepo1"
@@ -78,12 +84,13 @@ TARGET_ADDITIONAL_COMMIT_PATTERN = r"Update of organization\/auth_repo failed du
 TARGET_COMMIT_AFTER_LAST_VALIDATED_PATTERN = r"Update of organization\/auth_repo failed due to error: Target repository ([\w\/-]+) does not allow unauthenticated commits, but contains commit\(s\) ([0-9a-f]{40}(?:, [0-9a-f]{40})*) on branch (\w+)"
 TARGET_MISSING_COMMIT_PATTERN = r"Update of organization/auth_repo failed due to error: Failure to validate organization/auth_repo commit ([0-9a-f]{40}) committed on (\d{4}-\d{2}-\d{2}): data repository ([\w\/-]+) was supposed to be at commit ([0-9a-f]{40}) but commit not on branch (\w+)"
 NOT_CLEAN_PATTERN = r"^Update of ([\w/]+) failed due to error: Repository ([\w/-]+) should contain only committed changes\."
+INVALID_KEYS_PATTERN = r"^Update of ([\w/-]+)/([\w/-]+) failed due to error: Validation of authentication repository failed at revision ([0-9a-f]{40}) due to error: ([\w/-]+) was signed by (\d+)/(\d+) keys$"
 
 
 NO_WORKING_MIRRORS = (
     f"Validation of authentication repository {AUTH_REPO_REL_PATH} failed at revision"
 )
-NO_REPOSITORY_INFO_JSON = "Error during info.json parse. When specifying --clients-library-dir check if info.json metadata exists in targets/protected or provide full path to auth repo"
+NO_REPOSITORY_INFO_JSON = "Update of repository failed due to error: Error during info.json parse. If the authentication repository's path is not specified, info.json metadata is expected to be in targets/protected"
 ROOT_EXPIRED = "Final root.json is expired"
 REPLAYED_METADATA = "New timestamp version 3 must be >= 4"
 METADATA_FIELD_MISSING = "New snapshot is missing info for 'root.json'"
@@ -142,7 +149,13 @@ def test_valid_update_no_client_repo(
     repositories = updater_repositories[test_name]
     origin_dir = origin_dir / test_name
     _update_and_check_commit_shas(
-        None, repositories, origin_dir, client_dir, test_repo, auth_repo_name_exists
+        OperationType.CLONE,
+        None,
+        repositories,
+        origin_dir,
+        client_dir,
+        test_repo,
+        auth_repo_name_exists,
     )
 
 
@@ -155,6 +168,7 @@ def test_excluded_targets_update_no_client_repo(
     origin_dir = origin_dir / "test-updater-valid"
     excluded_target_globs = ["*/TargetRepo1"]
     _update_and_check_commit_shas(
+        OperationType.CLONE,
         None,
         repositories,
         origin_dir,
@@ -185,7 +199,9 @@ def test_valid_update_no_auth_repo_one_target_repo_exists(
     repositories = updater_repositories[test_name]
     origin_dir = origin_dir / test_name
     _clone_client_repo(TARGET_REPO_REL_PATH, origin_dir, client_dir)
-    _update_and_check_commit_shas(None, repositories, origin_dir, client_dir, test_repo)
+    _update_and_check_commit_shas(
+        OperationType.CLONE, None, repositories, origin_dir, client_dir, test_repo
+    )
 
 
 @pytest.mark.parametrize(
@@ -214,7 +230,9 @@ def test_valid_update_existing_client_repos(
     _create_last_validated_commit(
         client_dir, client_repos[AUTH_REPO_REL_PATH].head_commit_sha()
     )
-    _update_and_check_commit_shas(client_repos, repositories, origin_dir, client_dir)
+    _update_and_check_commit_shas(
+        OperationType.UPDATE, client_repos, repositories, origin_dir, client_dir
+    )
 
 
 @pytest.mark.parametrize(
@@ -240,7 +258,12 @@ def test_no_update_necessary(
         client_dir, client_repos[AUTH_REPO_REL_PATH].head_commit_sha()
     )
     _update_and_check_commit_shas(
-        client_repos, repositories, origin_dir, client_dir, test_repo
+        OperationType.UPDATE,
+        client_repos,
+        repositories,
+        origin_dir,
+        client_dir,
+        test_repo,
     )
 
 
@@ -262,7 +285,7 @@ def test_no_update_necessary(
             True,
             True,
         ),
-        ("test-updater-wrong-key", NO_WORKING_MIRRORS, True, True, False),
+        ("test-updater-wrong-key", INVALID_KEYS_PATTERN, True, True, False),
         ("test-updater-invalid-version-number", REPLAYED_METADATA, True, True, False),
         (
             "test-updater-delegated-roles-wrong-sha",
@@ -273,7 +296,7 @@ def test_no_update_necessary(
         ),
         (
             "test-updater-updated-root-invalid-metadata",
-            NO_WORKING_MIRRORS,
+            INVALID_KEYS_PATTERN,
             True,
             True,
             False,
@@ -301,6 +324,7 @@ def test_updater_invalid_update(
     clients_auth_repo_path = client_dir / AUTH_REPO_REL_PATH
 
     _update_invalid_repos_and_check_if_repos_exist(
+        OperationType.CLONE,
         client_dir,
         repositories,
         expected_error,
@@ -328,7 +352,7 @@ def test_valid_update_no_auth_repo_one_invalid_target_repo_exists(
     origin_dir = origin_dir / test_name
     _clone_client_repo(TARGET_REPO_REL_PATH, origin_dir, client_dir)
     _update_invalid_repos_and_check_if_repos_exist(
-        client_dir, repositories, expected_error, True
+        OperationType.CLONE, client_dir, repositories, expected_error, True
     )
     # make sure that the last validated commit does not exist
     _check_if_last_validated_commit_exists(clients_auth_repo_path, True)
@@ -343,7 +367,13 @@ def test_updater_expired_metadata(updater_repositories, origin_dir, client_dir):
     repositories = updater_repositories["test-updater-expired-metadata"]
     clients_auth_repo_path = client_dir / AUTH_REPO_REL_PATH
     _update_invalid_repos_and_check_if_repos_exist(
-        client_dir, repositories, ROOT_EXPIRED, False, set_time=False, strict=True
+        OperationType.CLONE,
+        client_dir,
+        repositories,
+        ROOT_EXPIRED,
+        False,
+        set_time=False,
+        strict=True,
     )
     # make sure that the last validated commit does not exist
     _check_if_last_validated_commit_exists(clients_auth_repo_path, False)
@@ -384,7 +414,9 @@ def test_no_target_repositories(updater_repositories, origin_dir, client_dir):
     origin_dir = origin_dir / "test-updater-valid"
     client_auth_repo = _clone_client_repo(AUTH_REPO_REL_PATH, origin_dir, client_dir)
     _create_last_validated_commit(client_dir, client_auth_repo.head_commit_sha())
-    _update_and_check_commit_shas(None, repositories, origin_dir, client_dir, False)
+    _update_and_check_commit_shas(
+        OperationType.UPDATE, None, repositories, origin_dir, client_dir, False
+    )
 
 
 def test_no_last_validated_commit(updater_repositories, origin_dir, client_dir):
@@ -397,7 +429,9 @@ def test_no_last_validated_commit(updater_repositories, origin_dir, client_dir):
     )
     # update without setting the last validated commit
     # update should start from the beginning and be successful
-    _update_and_check_commit_shas(client_repos, repositories, origin_dir, client_dir)
+    _update_and_check_commit_shas(
+        OperationType.UPDATE, client_repos, repositories, origin_dir, client_dir
+    )
 
 
 def test_older_last_validated_commit(updater_repositories, origin_dir, client_dir):
@@ -413,7 +447,9 @@ def test_older_last_validated_commit(updater_repositories, origin_dir, client_di
 
     _create_last_validated_commit(client_dir, first_commit)
     # try to update without setting the last validated commit
-    _update_and_check_commit_shas(client_repos, repositories, origin_dir, client_dir)
+    _update_and_check_commit_shas(
+        OperationType.UPDATE, client_repos, repositories, origin_dir, client_dir
+    )
 
 
 def test_update_test_repo_no_flag(updater_repositories, origin_dir, client_dir):
@@ -421,7 +457,12 @@ def test_update_test_repo_no_flag(updater_repositories, origin_dir, client_dir):
     origin_dir = origin_dir / "test-updater-test-repo"
     # try to update a test repo, set update type to official
     _update_invalid_repos_and_check_if_repos_exist(
-        client_dir, repositories, IS_A_TEST_REPO, False, UpdateType.OFFICIAL
+        OperationType.CLONE,
+        client_dir,
+        repositories,
+        IS_A_TEST_REPO,
+        False,
+        UpdateType.OFFICIAL,
     )
 
 
@@ -430,7 +471,12 @@ def test_update_repo_wrong_flag(updater_repositories, origin_dir, client_dir):
     origin_dir = origin_dir / "test-updater-valid"
     # try to update without setting the last validated commit
     _update_invalid_repos_and_check_if_repos_exist(
-        client_dir, repositories, NOT_A_TEST_REPO, False, UpdateType.TEST
+        OperationType.CLONE,
+        client_dir,
+        repositories,
+        NOT_A_TEST_REPO,
+        False,
+        UpdateType.TEST,
     )
 
 
@@ -445,7 +491,12 @@ def test_update_repo_target_in_indeterminate_state(
     targets_repo_path = client_dir / TARGET_REPO_REL_PATH
 
     _update_and_check_commit_shas(
-        None, repositories, origin_dir, client_dir, UpdateType.OFFICIAL
+        OperationType.CLONE,
+        None,
+        repositories,
+        origin_dir,
+        client_dir,
+        UpdateType.OFFICIAL,
     )
     # Create an `index.lock` file, indicating that an incomplete git operation took place
     # index.lock is created by git when a git operation is interrupted.
@@ -453,7 +504,7 @@ def test_update_repo_target_in_indeterminate_state(
     index_lock.touch()
 
     _update_invalid_repos_and_check_if_repos_exist(
-        client_dir, repositories, NOT_CLEAN_PATTERN, True
+        OperationType.UPDATE, client_dir, repositories, NOT_CLEAN_PATTERN, True
     )
 
 
@@ -596,6 +647,7 @@ def _get_valid_update_time(origin_auth_repo_path):
 
 
 def _update_and_check_commit_shas(
+    operation,
     client_repos,
     repositories,
     origin_dir,
@@ -607,15 +659,23 @@ def _update_and_check_commit_shas(
     start_head_shas = _get_head_commit_shas(client_repos)
     clients_auth_repo_path = client_dir / AUTH_REPO_REL_PATH
     origin_auth_repo_path = repositories[AUTH_REPO_REL_PATH]
+
+    config = RepositoryConfig(
+        operation=operation,
+        url=str(origin_auth_repo_path),
+        update_from_filesystem=True,
+        path=str(clients_auth_repo_path) if auth_repo_name_exists else None,
+        library_dir=str(client_dir),
+        expected_repo_type=expected_repo_type,
+        excluded_target_globs=excluded_target_globs,
+    )
+
     with freeze_time(_get_valid_update_time(origin_auth_repo_path)):
-        update_repository(
-            str(origin_auth_repo_path),
-            str(clients_auth_repo_path) if auth_repo_name_exists else None,
-            str(client_dir),
-            True,
-            expected_repo_type=expected_repo_type,
-            excluded_target_globs=excluded_target_globs,
-        )
+        if operation == OperationType.CLONE:
+            clone_repository(config)
+        else:
+            update_repository(config)
+
     _check_if_commits_match(
         repositories, origin_dir, client_dir, start_head_shas, excluded_target_globs
     )
@@ -635,15 +695,18 @@ def _update_invalid_repos_and_check_if_remained_same(
     clients_auth_repo_path = client_dir / AUTH_REPO_REL_PATH
     origin_auth_repo_path = repositories[AUTH_REPO_REL_PATH]
 
+    config = RepositoryConfig(
+        operation=OperationType.UPDATE,
+        url=str(origin_auth_repo_path),
+        update_from_filesystem=True,
+        path=str(clients_auth_repo_path),
+        library_dir=str(client_dir),
+        expected_repo_type=expected_repo_type,
+    )
+
     with freeze_time(_get_valid_update_time(origin_auth_repo_path)):
         with pytest.raises(UpdateFailedError, match=expected_error):
-            update_repository(
-                str(origin_auth_repo_path),
-                str(clients_auth_repo_path),
-                str(client_dir),
-                True,
-                expected_repo_type=expected_repo_type,
-            )
+            update_repository(config)
 
     # all repositories should still have the same head commit
     for repo_path, repo in client_repos.items():
@@ -654,6 +717,7 @@ def _update_invalid_repos_and_check_if_remained_same(
 
 
 def _update_invalid_repos_and_check_if_repos_exist(
+    operation,
     client_dir,
     repositories,
     expected_error,
@@ -672,22 +736,28 @@ def _update_invalid_repos_and_check_if_repos_exist(
         if (client_dir / repository_rel_path).exists()
     ]
 
-    def _update_expect_error(client_dir, expected_repo_type):
+    config = RepositoryConfig(
+        operation=operation,
+        url=str(origin_auth_repo_path),
+        update_from_filesystem=True,
+        path=str(clients_auth_repo_path) if auth_repo_name_exists else None,
+        library_dir=str(client_dir),
+        expected_repo_type=expected_repo_type,
+        strict=strict,
+    )
+
+    def _update_expect_error():
         with pytest.raises(UpdateFailedError, match=expected_error):
-            update_repository(
-                str(origin_auth_repo_path),
-                str(clients_auth_repo_path) if auth_repo_name_exists else None,
-                str(client_dir),
-                True,
-                expected_repo_type=expected_repo_type,
-                strict=strict,
-            ),
+            if operation == OperationType.CLONE:
+                clone_repository(config)
+            else:
+                update_repository(config)
 
     if set_time:
         with freeze_time(_get_valid_update_time(origin_auth_repo_path)):
-            _update_expect_error(client_dir, expected_repo_type)
+            _update_expect_error()
     else:
-        _update_expect_error(client_dir, expected_repo_type)
+        _update_expect_error()
 
     if not expect_partial_update:
         # the client repositories should not exits

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -252,7 +252,7 @@ def attach_to_group(group):
 
     @repo.command()
     @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--clients-library-dir", default=None, help="Directory where target repositories and, "
+    @click.option("--library-dir", default=None, help="Directory where target repositories and, "
                   "optionally, authentication repository are located. If omitted it is "
                   "calculated based on authentication repository's path. "
                   "Authentication repo is presumed to be at library-dir/namespace/auth-repo-name")
@@ -261,7 +261,7 @@ def attach_to_group(group):
                   "ignored during update.")
     @click.option("--strict", is_flag=True, default=False, help="Enable/disable strict mode - return an error"
                   "if warnings are raised")
-    def validate(path, clients_library_dir, from_commit, exclude_target, strict):
+    def validate(path, library_dir, from_commit, exclude_target, strict):
         """
         Validates an authentication repository which is already on the file system
         and its target repositories (which are also expected to be on the file system).
@@ -270,4 +270,4 @@ def attach_to_group(group):
         Validation can be in strict or no-strict mode. Strict mode is set by specifying --strict, which will raise errors
         during validate if any/all warnings are found. By default, --strict is disabled.
         """
-        validate_repository(path, clients_library_dir, from_commit, exclude_target, strict)
+        validate_repository(path, library_dir, from_commit, exclude_target, strict)

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -3,7 +3,37 @@ import json
 from taf.api.repository import create_repository
 from taf.exceptions import TAFError, UpdateFailedError
 from taf.tools.cli import catch_cli_exception
-from taf.updater.updater import update_repository, validate_repository, UpdateType
+from taf.updater.updater import RepositoryConfig, clone_repository, update_repository, validate_repository, UpdateType
+
+
+def common_update_options(f):
+    f = click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")(f)
+    f = click.option("--url", default=None, help="Authentication repository's url")(f)
+    f = click.option("--library-dir", default=None, help="Directory where target repositories and, optionally, authentication repository are located.")(f)
+    f = click.option("--from-fs", is_flag=True, default=False, help="Indicates if we want to clone a repository from the filesystem")(f)
+    f = click.option("--expected-repo-type", default="either", type=click.Choice(["test", "official", "either"]), help="Indicates expected authentication repository type - test or official.")(f)
+    f = click.option("--scripts-root-dir", default=None, help="Scripts root directory, which can be used to move scripts out of the authentication repository for testing purposes.")(f)
+    f = click.option("--profile", is_flag=True, help="Flag used to run profiler and generate .prof file")(f)
+    f = click.option("--format-output", is_flag=True, help="Return formatted output which includes information on if build was successful and error message if it was raised")(f)
+    f = click.option("--exclude-target", multiple=True, help="Globs defining which target repositories should be ignored during update.")(f)
+    f = click.option("--strict", is_flag=True, default=False, help="Enable/disable strict mode - return an error if warnings are raised.")(f)
+    return f
+
+def start_profiling():
+    import cProfile
+    import atexit
+
+    print("Profiling...")
+    pr = cProfile.Profile()
+    pr.enable()
+
+    def exit_profiler():
+        pr.disable()
+        print("Profiling completed")
+        filename = 'updater.prof'  # You can change the filename if needed
+        pr.dump_stats(filename)
+
+    atexit.register(exit_profiler)
 
 
 def attach_to_group(group):
@@ -75,28 +105,8 @@ def attach_to_group(group):
 
     @repo.command()
     @catch_cli_exception(handle=UpdateFailedError)
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--url", default=None, help="Authentication repository's url")
-    @click.option("--clients-library-dir", default=None, help="Directory where target repositories and, "
-                  "optionally, authentication repository are located. If omitted it is "
-                  "calculated based on authentication repository's path. "
-                  "Authentication repo is presumed to be at root-dir/namespace/auth-repo-name")
-    @click.option("--from-fs", is_flag=True, default=False, help="Indicates if the we want to clone a "
-                  "repository from the filesystem")
-    @click.option("--expected-repo-type", default="either", type=click.Choice(["test", "official", "either"]),
-                  help="Indicates expected authentication repository type - test or official. If type is set to either, "
-                  "the updater will not check the repository's type")
-    @click.option("--scripts-root-dir", default=None, help="Scripts root directory, which can be used to move scripts "
-                  "out of the authentication repository for testing purposes (avoid dirty index). Scripts will be expected "
-                  "to be located in scripts_root_dir/repo_name directory")
-    @click.option("--profile", is_flag=True, help="Flag used to run profiler and generate .prof file")
-    @click.option("--format-output", is_flag=True, help="Return formatted output which includes information "
-                  "on if build was successful and error message if it was raised")
-    @click.option("--exclude-target", multiple=True, help="globs defining which target repositories should be "
-                  "ignored during update.")
-    @click.option("--strict", is_flag=True, default=False, help="Enable/disable strict mode - return an error"
-                  "if warnings are raised ")
-    def update(path, url, clients_library_dir, from_fs, expected_repo_type,
+    @common_update_options
+    def clone(path, url, library_dir, from_fs, expected_repo_type,
                scripts_root_dir, profile, format_output, exclude_target, strict):
         """
         Update and validate local authentication repository and target repositories. Remote
@@ -133,30 +143,90 @@ def attach_to_group(group):
         Update can be in strict or no-strict mode. Strict mode is set by specifying --strict, which will raise errors
         during update if any/all warnings are found. By default, --strict is disabled.
         """
-        if path is None and clients_library_dir is None:
+        if path is None and library_dir is None:
             raise click.UsageError('Must specify either authentication repository path or library directory!')
 
         if profile:
-            import cProfile
-            import atexit
+            start_profiling()
 
-            print("Profiling...")
-            pr = cProfile.Profile()
-            pr.enable()
+        config = RepositoryConfig(
+            url=url,
+            path=path,
+            library_dir=library_dir,
+            update_from_filesystem=from_fs,
+            expected_repo_type=expected_repo_type,
+            scripts_root_dir=scripts_root_dir,
+            excluded_target_globs=exclude_target,
+            strict=strict
+        )
 
-            def exit():
-                pr.disable()
-                print("Profiling completed")
-                filename = 'updater.prof'  # You can change this if needed
-                pr.dump_stats(filename)
+        try:
+            clone_repository(config)
+            if format_output:
+                print(json.dumps({
+                    'updateSuccessful': True
+                }))
+        except Exception as e:
+            if format_output:
+                error_data = {
+                    'updateSuccessful': False,
+                    'error': str(e)
+                }
+                print(json.dumps(error_data))
+            else:
+                raise e
 
-            atexit.register(exit)
+    @repo.command()
+    @catch_cli_exception(handle=UpdateFailedError)
+    @common_update_options
+    def update(path, url, library_dir, from_fs, expected_repo_type,
+               scripts_root_dir, profile, format_output, exclude_target, strict):
+        """
+        Update and validate local authentication repository and target repositories. Remote
+        authentication's repository url needs to be specified when calling this command when
+        calling the updater for the first time for the given repository. If the
+        authentication repository and the target repositories are in the same root directory,
+        locations of the target repositories are calculated based on the authentication repository's
+        path. If that is not the case, it is necessary to redefine this default value using the
+        --clients-library-dir option. This means that if authentication repository's path is
+        E:\\root\\namespace\\auth-repo, it will be assumed that E:\\root is the root directory
+        if clients-library-dir is not specified.
+        Names of target repositories (as defined in repositories.json) are appended to the root repository's
+        path thus defining the location of each target repository. If names of target repositories
+        are namespace/repo1, namespace/repo2 etc and the root directory is E:\\root, path of the target
+        repositories will be calculated as E:\\root\\namespace\\repo1, E:\\root\\namespace\\root2 etc.
+
+        Path to authentication repository directory is set by clients-auth-path argument. If this
+        argument is not provided, it is expected that --clients-library-dir option is used. The updater
+        will raise an error if one of both isn't set.
+
+        If remote repository's url is a file system path, it is necessary to call this command with
+        --from-fs flag so that url validation is skipped. When updating a test repository (one that has
+        the "test" target file), use --authenticate-test-repo flag. An error will be raised
+        if this flag is omitted in the mentioned case. Do not use this flag when validating a non-test
+        repository as that will also result in an error.
+
+        Scripts root directory option can be used to move scripts out of the authentication repository for
+        testing purposes (avoid dirty index). Scripts will be expected  o be located in scripts_root_dir/repo_name directory
+
+        One or more target repositories can be excluded from the update process using --exclude-target.
+        In that case, the library will only be partly validated, so last_validate_commit will not be updated
+        and no scripts will be called.
+
+        Update can be in strict or no-strict mode. Strict mode is set by specifying --strict, which will raise errors
+        during update if any/all warnings are found. By default, --strict is disabled.
+        """
+        if path is None and library_dir is None:
+            raise click.UsageError('Must specify either authentication repository path or library directory!')
+
+        if profile:
+            start_profiling()
 
         try:
             update_repository(
                 url,
                 path,
-                clients_library_dir,
+                library_dir,
                 from_fs,
                 UpdateType(expected_repo_type),
                 scripts_root_dir=scripts_root_dir,

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -19,6 +19,7 @@ def common_update_options(f):
     f = click.option("--strict", is_flag=True, default=False, help="Enable/disable strict mode - return an error if warnings are raised.")(f)
     return f
 
+
 def start_profiling():
     import cProfile
     import atexit
@@ -107,7 +108,7 @@ def attach_to_group(group):
     @catch_cli_exception(handle=UpdateFailedError)
     @common_update_options
     def clone(path, url, library_dir, from_fs, expected_repo_type,
-               scripts_root_dir, profile, format_output, exclude_target, strict):
+              scripts_root_dir, profile, format_output, exclude_target, strict):
         """
         Update and validate local authentication repository and target repositories. Remote
         authentication's repository url needs to be specified when calling this command when

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -114,8 +114,8 @@ def attach_to_group(group):
         Validate and clone the authentication repository and target repositories. URL of the
         remote authentication repository must be specified when calling this command. If the remote repository's URL is a file system path, the --from-fs flag must be used.
 
-        The path to the authentication repository directory either read from targets/info.json
-        or specified using the --path option. If target/info.json does not exist and path is not
+        The path to the authentication repository directory either read from targets/protected/info.json
+        or specified using the --path option. If targets/protected/info.json does not exist and path is not
         defined, an error will be raised.
 
         If the authentication repository and the target repositories are in the same root directory,

--- a/taf/updater/types/update.py
+++ b/taf/updater/types/update.py
@@ -17,6 +17,7 @@ class UpdateType(enum.Enum):
     OFFICIAL = "official"
     EITHER = "either"
 
+
 class OperationType(enum.Enum):
     CLONE = "clone"
     UPDATE = "update"

--- a/taf/updater/types/update.py
+++ b/taf/updater/types/update.py
@@ -16,3 +16,7 @@ class UpdateType(enum.Enum):
     TEST = "test"
     OFFICIAL = "official"
     EITHER = "either"
+
+class OperationType(enum.Enum):
+    CLONE = "clone"
+    UPDATE = "update"

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -2,6 +2,7 @@ import json
 from logging import ERROR
 
 from typing import Dict, Tuple, Any
+from attr import define, field
 from logdecorator import log_on_error
 from taf.git import GitRepository
 from taf.updater.types.update import UpdateType
@@ -13,7 +14,7 @@ from taf.updater.updater_pipeline import (
 from pathlib import Path
 from taf.log import taf_logger, disable_tuf_console_logging
 import taf.repositoriesdb as repositoriesdb
-from taf.utils import timed_run
+from taf.utils import is_non_empty_directory, timed_run
 import taf.settings as settings
 from taf.exceptions import (
     ScriptExecutionError,
@@ -124,6 +125,124 @@ def _reset_to_commits_before_pull(auth_repo, commits_data, targets_data):
             _reset_repository(repo, branch_data)
 
 
+@define
+class RepositoryConfig:
+    url: str = field(metadata={"docs": "URL of the remote authentication repository"})
+    path: Path = field(
+        default=None,
+        converter=lambda p: Path(p).resolve() if p else None,
+        metadata={"docs": "Client's authentication repository's full path"},
+    )
+    library_dir: Path = field(
+        default=None,
+        metadata={
+            "docs": "Directory where client's target repositories are located. Optional."
+        },
+    )
+    update_from_filesystem: bool = field(
+        default=False,
+        metadata={
+            "docs": "A flag indicating if the URL is actually a file system path. Optional."
+        },
+    )
+    expected_repo_type: UpdateType = field(
+        default=UpdateType.EITHER,
+        metadata={
+            "docs": "Indicates if the repository is a test, official, or any type. Optional."
+        },
+    )
+    target_repo_classes: object = field(
+        default=None,
+        metadata={
+            "docs": "A class or dictionary used for instantiating target repositories. Optional."
+        },
+    )
+    target_factory: object = field(
+        default=None,
+        metadata={
+            "docs": "A git repositories factory used for instantiating target repositories. Optional."
+        },
+    )
+    only_validate: bool = field(
+        default=False,
+        metadata={
+            "docs": "Specifies if repositories should only be validated without being updated. Optional."
+        },
+    )
+    validate_from_commit: str = field(
+        default=None,
+        metadata={"docs": "Commit from which validation should start. Optional."},
+    )
+    out_of_band_authentication: str = field(
+        default=None,
+        metadata={"docs": "Out-of-band authentication commit's SHA. Optional."},
+    )
+    scripts_root_dir: Path = field(
+        default=None,
+        metadata={
+            "docs": "Local directory for script testing, not in the authentication repository. Optional."
+        },
+    )
+    checkout: bool = field(
+        default=True,
+        metadata={
+            "docs": "Whether to checkout last validated commits after update. Optional."
+        },
+    )
+    excluded_target_globs: list = field(
+        default=None,
+        metadata={
+            "docs": "Globs specifying target repositories to exclude from validation and update. Optional."
+        },
+    )
+    strict: bool = field(
+        default=False,
+        metadata={"docs": "Whether update fails if a warning is raised. Optional."},
+    )
+
+    def __attrs_post_init__(self):
+        if self.library_dir is None:
+            if self.path:
+                self.library_dir = self.path.parent.parent
+            else:
+                self.library_dir = Path(".").resolve()
+
+@log_on_error(
+    ERROR,
+    "{e}",
+    logger=taf_logger,
+    on_exceptions=UpdateFailedError,
+    reraise=True,
+)
+@timed_run("Cloning repositories")
+def clone_repository(
+   config: RepositoryConfig
+):
+    """
+    Validate and clone an authentication repository and its target repositories, as well
+    as its dependencies (linked authentication repositories and their targets) recursively.
+    Arguments:
+        config: RepositoryConfig instance containing all configurations.
+
+    Side Effects:
+        If only_validate is not set to True, updates authentication repository (pulls new changes) and its target
+        repositories and dependencies
+
+    Returns:
+        None
+    """
+    settings.strict = config.strict
+
+    if config.url is None:
+        raise UpdateFailedError("URL has to be specified when cloning repositories")
+
+    print(config.library_dir)
+    if is_non_empty_directory(config.path):
+        raise UpdateFailedError(f"Destination path {config.path} already exists and is not an empty directory. Run `taf repo update` to update it.")
+
+    return _update_or_clone_repository(config)
+
+
 @log_on_error(
     ERROR,
     "{e}",
@@ -133,49 +252,14 @@ def _reset_to_commits_before_pull(auth_repo, commits_data, targets_data):
 )
 @timed_run("Updating repository")
 def update_repository(
-    url,
-    clients_auth_path,
-    clients_library_dir=None,
-    update_from_filesystem=False,
-    expected_repo_type=UpdateType.EITHER,
-    target_repo_classes=None,
-    target_factory=None,
-    only_validate=False,
-    validate_from_commit=None,
-    conf_directory_root=None,
-    config_path=None,
-    out_of_band_authentication=None,
-    scripts_root_dir=None,
-    checkout=True,
-    excluded_target_globs=None,
-    strict=False,
+    config: RepositoryConfig
 ):
     """
-    Validate and update an authentication repository and it's target repositories, as well
+    Validate and update an authentication repository and its target repositories, as well
     as its dependencies (linked authentication repositories and their targets) recursively.
 
     Arguments:
-        url: URL of the remote authentication repository
-        clients_auth_path: Client's authentication repository's full path
-        clients_library_dir (optional): Directory where client's target repositories are located.
-        update_from_filesystem (optional): A flag which indicates if the URL is actually a file system path
-        expected_repo_type (optional): Indicates if the authentication repository which needs to be updated is
-            a test repository, official repository, or if the type is not important
-            and should not be validated
-        target_repo_classes (optional): A class or a dictionary used when instantiating target repositories.
-            See repositoriesdb load_repositories for more details
-        target_factory: A git repositories factory used when instantiating target repositories.
-            See repositoriesdb load_repositories for more details
-        only_validate (optional): a flag that specifies if the repositories should only be validated without
-            being updated
-        validate_from_commit (optional): commit from which the validation should start, allowing shorter
-            execution time
-        out_of_band_authentication (optional): out-of-band authentication commit's sha
-        scripts_root_dir (optional): local directory which does not have to be contained by the authentication
-            repository. Used for testing purposes while developing the scripts
-        checkout (optional): Whether to checkout last validated commits after update is done
-        excluded_target_globs (options): globs specifying target repositories which should not get validated and updated.
-        strict (optional): Whether or not update fails if a warning is raised
+        config: RepositoryConfig instance containing all configurations.
 
     Side Effects:
         If only_validate is not set to True, updates authentication repository (pulls new changes) and its target
@@ -184,72 +268,63 @@ def update_repository(
     Returns:
         None
     """
-    settings.strict = strict
-    # if the repository's name is not provided, divide it in parent directory
-    # and repository name, since TUF's updater expects a name
-    # but set the validate_repo_name setting to False
-    if clients_auth_path is not None:
-        clients_auth_path = Path(clients_auth_path).resolve()
+    settings.strict = config.strict
 
-    if clients_library_dir is None:
-        clients_library_dir = clients_auth_path.parent.parent
-    else:
-        clients_library_dir = Path(clients_library_dir).resolve()
+    # if path is not specified, name should be read from info.json
+    # which is available after the remote repository is cloned and validated
 
-    auth_repo_name = (
-        f"{clients_auth_path.parent.name}/{clients_auth_path.name}"
-        if clients_auth_path is not None
-        else None
-    )
+    auth_repo = GitRepository(path=config.path)
+    if not config.path.is_dir() or not auth_repo.is_git_repository:
+        raise UpdateFailedError(
+            f"{config.path} is not a Git repository. Run `taf repo clone` instead"
+        )
 
-    taf_logger.info(f"Updating repository {auth_repo_name}")
-    clients_auth_library_dir = clients_library_dir
-    repos_update_data = {}
-    transient_data = {}
-    root_error = None
+    taf_logger.info(f"Updating repository {auth_repo.name}")
 
     if url is None:
-        # if the authentication repository already exists on disk, determine
-        # the urls based on its remote
-        auth_repo = GitRepository(clients_auth_library_dir, auth_repo_name)
-        if not auth_repo.path.is_dir() or not auth_repo.is_git_repository:
-            raise UpdateFailedError(
-                "URL needs to be provided when running the updater for the first time"
-            )
         url = auth_repo.get_remote_url()
         if url is None:
             raise UpdateFailedError("URL cannot be determined. Please specify it")
 
+    return _update_or_clone_repository(config)
+
+
+def _update_or_clone_repository(
+  config: RepositoryConfig
+):
+    repos_update_data = {}
+    transient_data = {}
+    root_error = None
+    auth_repo_name = None
     try:
         auth_repo_name = _update_named_repository(
-            url,
-            clients_auth_library_dir,
-            clients_library_dir,
-            auth_repo_name,
-            update_from_filesystem,
-            expected_repo_type,
-            target_repo_classes,
-            target_factory,
-            only_validate,
-            validate_from_commit,
-            conf_directory_root,
+            config.url,
+            config.path,
+            config.library_dir,
+            config.update_from_filesystem,
+            config.expected_repo_type,
+            config.target_repo_classes,
+            config.target_factory,
+            config.only_validate,
+            config.validate_from_commit,
+            None,
             repos_update_data=repos_update_data,
             transient_data=transient_data,
-            out_of_band_authentication=out_of_band_authentication,
-            scripts_root_dir=scripts_root_dir,
-            checkout=checkout,
-            excluded_target_globs=excluded_target_globs,
+            out_of_band_authentication=config.out_of_band_authentication,
+            scripts_root_dir=config.scripts_root_dir,
+            checkout=config.checkout,
+            excluded_target_globs=config.excluded_target_globs,
         )
     except Exception as e:
         root_error = UpdateFailedError(
-            f"Update of {auth_repo_name} failed due to error: {e}"
+            f"Update of failed due to error: {e}"
         )
 
     update_data = {}
-    if not excluded_target_globs:
+    if not config.excluded_target_globs:
         # after all repositories have been updated
         # update information is in repos_update_data
-        if auth_repo_name not in repos_update_data:
+        if auth_repo_name is None or auth_repo_name not in repos_update_data:
             # this must mean that an error occurred
             if root_error is not None:
                 raise root_error
@@ -266,7 +341,7 @@ def update_repository(
             update_status,
             update_transient_data,
             root_auth_repo.library_dir,
-            scripts_root_dir,
+            config.scripts_root_dir,
             repos_update_data,
             errors,
             root_auth_repo,
@@ -279,9 +354,8 @@ def update_repository(
 
 def _update_named_repository(
     url,
-    clients_auth_library_dir,
-    targets_library_dir,
-    auth_repo_name,
+    auth_path,
+    library_dir,
     update_from_filesystem,
     expected_repo_type,
     target_repo_classes=None,
@@ -352,9 +426,9 @@ def _update_named_repository(
     if visited is None:
         visited = []
     # if there is a recursive dependency
-    if auth_repo_name in visited:
+    if url in visited:
         return
-    visited.append(auth_repo_name)
+    visited.append(url)
     # at the moment, we assume that the initial commit is valid and that it contains at least root.json
     (
         update_status,
@@ -365,9 +439,8 @@ def _update_named_repository(
         targets_data,
     ) = _update_current_repository(
         url,
-        clients_auth_library_dir,
-        targets_library_dir,
-        auth_repo_name,
+        auth_path,
+        library_dir,
         update_from_filesystem,
         expected_repo_type,
         target_repo_classes,
@@ -402,7 +475,7 @@ def _update_named_repository(
         # latest_commit = commits[-1::]
         repositoriesdb.load_dependencies(
             auth_repo,
-            library_dir=targets_library_dir,
+            library_dir=library_dir,
             commits=commits,
         )
 
@@ -416,8 +489,8 @@ def _update_named_repository(
                 try:
                     _update_named_repository(
                         child_auth_repo.urls[0],
-                        clients_auth_library_dir,
-                        targets_library_dir,
+                        child_auth_repo.path,
+                        library_dir,
                         child_auth_repo.name,
                         update_from_filesystem,
                         expected_repo_type,
@@ -499,9 +572,8 @@ def _update_named_repository(
 
 def _update_current_repository(
     url,
-    clients_auth_library_dir,
-    targets_library_dir,
-    auth_repo_name,
+    auth_path,
+    library_dir,
     update_from_filesystem,
     expected_repo_type,
     target_repo_classes,
@@ -515,9 +587,8 @@ def _update_current_repository(
 ):
     updater_pipeline = AuthenticationRepositoryUpdatePipeline(
         url,
-        clients_auth_library_dir,
-        targets_library_dir,
-        auth_repo_name,
+        auth_path,
+        library_dir,
         update_from_filesystem,
         expected_repo_type,
         target_repo_classes,

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -298,8 +298,8 @@ def update_repository(config: RepositoryConfig):
 
 
 def _update_or_clone_repository(config: RepositoryConfig):
-    repos_update_data = {}
-    transient_data = {}
+    repos_update_data: Dict = {}
+    transient_data: Dict = {}
     root_error = None
     auth_repo_name = None
     try:

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -215,6 +215,7 @@ class RepositoryConfig:
             if self.library_dir is None:
                 self.library_dir = self.path.parent.parent
 
+
 @log_on_error(
     ERROR,
     "{e}",
@@ -223,9 +224,7 @@ class RepositoryConfig:
     reraise=True,
 )
 @timed_run("Cloning repositories")
-def clone_repository(
-   config: RepositoryConfig
-):
+def clone_repository(config: RepositoryConfig):
     """
     Validate and clone an authentication repository and its target repositories, as well
     as its dependencies (linked authentication repositories and their targets) recursively.
@@ -246,8 +245,11 @@ def clone_repository(
 
     # TODO if path is not known, need to check if empty in pipeline after cloning the auth repo and reading from info.json
     if config.path and is_non_empty_directory(config.path):
-        raise UpdateFailedError(f"Destination path {config.path} already exists and is not an empty directory. Run `taf repo update` to update it.")
+        raise UpdateFailedError(
+            f"Destination path {config.path} already exists and is not an empty directory. Run `taf repo update` to update it."
+        )
 
+    config.operation = OperationType.CLONE
     return _update_or_clone_repository(config)
 
 
@@ -259,9 +261,7 @@ def clone_repository(
     reraise=True,
 )
 @timed_run("Updating repository")
-def update_repository(
-    config: RepositoryConfig
-):
+def update_repository(config: RepositoryConfig):
     """
     Validate and update an authentication repository and its target repositories, as well
     as its dependencies (linked authentication repositories and their targets) recursively.
@@ -297,9 +297,7 @@ def update_repository(
     return _update_or_clone_repository(config)
 
 
-def _update_or_clone_repository(
-  config: RepositoryConfig
-):
+def _update_or_clone_repository(config: RepositoryConfig):
     repos_update_data = {}
     transient_data = {}
     root_error = None
@@ -325,9 +323,7 @@ def _update_or_clone_repository(
             excluded_target_globs=config.excluded_target_globs,
         )
     except Exception as e:
-        root_error = UpdateFailedError(
-            f"Update of failed due to error: {e}"
-        )
+        root_error = UpdateFailedError(f"Update of failed due to error: {e}")
 
     update_data = {}
     if not config.excluded_target_globs:

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -640,37 +640,36 @@ def _update_transient_data(
 
 @timed_run("Validating repository")
 def validate_repository(
-    clients_auth_path,
-    clients_library_dir=None,
+    auth_path,
+    library_dir=None,
     validate_from_commit=None,
     excluded_target_globs=None,
     strict=False,
 ):
     settings.strict = strict
 
-    clients_auth_path = Path(clients_auth_path).resolve()
+    auth_path = Path(auth_path).resolve()
 
-    if clients_library_dir is None:
-        clients_library_dir = clients_auth_path.parent.parent
+    if library_dir is None:
+        library_dir = auth_path.parent.parent
     else:
-        clients_library_dir = Path(clients_library_dir).resolve()
+        library_dir = Path(library_dir).resolve()
 
-    auth_repo_name = f"{clients_auth_path.parent.name}/{clients_auth_path.name}"
-    clients_auth_library_dir = clients_auth_path.parent.parent
     expected_repo_type = (
         UpdateType.TEST
-        if (clients_auth_path / "targets" / "test-auth-repo").exists()
+        if (auth_path / "targets" / "test-auth-repo").exists()
         else UpdateType.OFFICIAL
     )
     settings.overwrite_last_validated_commit = True
     settings.last_validated_commit = validate_from_commit
     try:
-        _, error = _update_named_repository(
-            str(clients_auth_path),
-            clients_auth_library_dir,
-            clients_library_dir,
-            auth_repo_name,
-            True,
+
+        auth_repo_name, error = _update_named_repository(
+            operation=OperationType.UPDATE,
+            url=str(auth_path),
+            auth_path=str(auth_path),
+            library_dir=library_dir,
+            update_from_filesystem=True,
             expected_repo_type=expected_repo_type,
             only_validate=True,
             validate_from_commit=validate_from_commit,

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -128,7 +128,9 @@ def _reset_to_commits_before_pull(auth_repo, commits_data, targets_data):
 @define
 class RepositoryConfig:
     operation: OperationType = field(converter=OperationType)
-    url: str = field(metadata={"docs": "URL of the remote authentication repository"})
+    url: str = field(
+        metadata={"docs": "URL of the remote authentication repository"}, default=None
+    )
     path: Path = field(
         default=None,
         converter=lambda p: Path(p).resolve() if p else None,
@@ -243,7 +245,6 @@ def clone_repository(config: RepositoryConfig):
     if config.url is None:
         raise UpdateFailedError("URL has to be specified when cloning repositories")
 
-    # TODO if path is not known, need to check if empty in pipeline after cloning the auth repo and reading from info.json
     if config.path and is_non_empty_directory(config.path):
         raise UpdateFailedError(
             f"Destination path {config.path} already exists and is not an empty directory. Run `taf repo update` to update it."
@@ -536,10 +537,7 @@ def _update_named_repository(
                     f"Update of {auth_repo.name} failed. One or more referenced authentication repositories could not be validated:\n {errors}"
                 )
                 update_status = Event.FAILED
-        # TODO which commit to load if the commit top commit does not match the last validated commit
-        # use last validated commit - if the repository contains it
 
-        # all repositories that can be updated will be updated
         if (
             not only_validate
             and len(commits)

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -133,6 +133,7 @@ class Pipeline:
 class AuthenticationRepositoryUpdatePipeline(Pipeline):
     def __init__(
         self,
+        operation,
         url,
         auth_path,
         library_dir,
@@ -171,6 +172,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
             run_mode=RunMode.LOCAL_VALIDATION if only_validate else RunMode.UPDATE,
         )
 
+        self.operation = operation
         self.url = url
         self.library_dir = library_dir
         self.auth_path = auth_path

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -17,7 +17,7 @@ from taf.auth_repo import AuthenticationRepository
 from taf.exceptions import RepositoryNotCleanError, UpdateFailedError
 from taf.updater.handlers import GitUpdater
 from taf.updater.lifecycle_handlers import Event
-from taf.updater.types.update import UpdateType
+from taf.updater.types.update import OperationType, UpdateType
 from taf.utils import on_rm_error
 from taf.log import taf_logger
 from tuf.ngclient.updater import Updater
@@ -107,6 +107,10 @@ class Pipeline:
                 if step_run_mode == RunMode.ALL or step_run_mode == self.run_mode:
                     self.current_step = step
                     update_status = step()
+                    if self.state.error:
+                        import pdb
+
+                        pdb.set_trace()
                     if update_status == UpdateStatus.FAILED:
                         raise UpdateFailedError(self.state.error)
                     self.state.update_status = update_status
@@ -186,8 +190,6 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
         self.out_of_band_authentication = out_of_band_authentication
         self.checkout = checkout
         self.excluded_target_globs = excluded_target_globs
-
-
         self.state = UpdateState()
         self.state.targets_data = {}
         if self.auth_path:
@@ -209,25 +211,62 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
     def clone_remote_and_run_tuf_updater(self):
         settings.update_from_filesystem = self.update_from_filesystem
         settings.conf_directory_root = self.conf_directory_root
+
+        # set last validated commit before running the updater
+        # this last validated commit is read from the settings
+        if self.operation == OperationType.CLONE:
+            settings.last_validated_commit = None
+        elif not settings.overwrite_last_validated_commit:
+            users_auth_repo = AuthenticationRepository(path=self.auth_path)
+            last_validated_commit = users_auth_repo.last_validated_commit
+            settings.last_validated_commit = last_validated_commit
+
         git_updater = None
         try:
             self.state.auth_commits_since_last_validated = None
 
-            # Clone the validation repository in temp.
-            self.state.auth_repo_name = _clone_validation_repo(
-                self.url, self.state.auth_repo_name
+            validation_repo = _clone_validation_repo(self.url)
+
+            git_updater = GitUpdater(self.url, self.library_dir, validation_repo.name)
+            last_validated_remote_commit = _run_tuf_updater(git_updater)
+
+            try:
+                self.state.auth_repo_name = _get_repository_name_from_info_json(
+                    validation_repo, last_validated_remote_commit
+                )
+            except UpdateFailedError:
+                if self.auth_path:
+                    self.auth_repo_name = GitRepository(path=self.auth_path).name
+                else:
+                    raise
+            taf_logger.info(
+                "Successfully validated authentication repository {}",
+                self.state.auth_repo_name,
             )
 
-            git_updater = GitUpdater(
-                self.url, self.library_dir, self.state.auth_repo_name
+            self.state.users_auth_repo = AuthenticationRepository(
+                self.library_dir,
+                self.state.auth_repo_name,
+                urls=[self.url],
             )
-            self.state.users_auth_repo = git_updater.users_auth_repo
-            _run_tuf_updater(git_updater)
 
             self.state.existing_repo = self.state.users_auth_repo.is_git_repository_root
+            if self.operation == OperationType.CLONE and self.state.existing_repo:
+                raise UpdateFailedError(
+                    f"Destination path {self.state.users_auth_repo.path} already exists and is not an empty directory. Run `taf repo update` to update it."
+                )
+            elif (
+                self.operation == OperationType.UPDATE and not self.state.existing_repo
+            ):
+                raise UpdateFailedError(
+                    f"{self.state.users_auth_repo.path} is not a Git repository. Run `taf repo clone` instead"
+                )
+
             self.state.validation_auth_repo = git_updater.validation_auth_repo
             self.state.auth_commits_since_last_validated = list(git_updater.commits)
             self._validate_out_of_band_and_update_type()
+            if self.operation == OperationType.UPDATE:
+                self._validate_last_validated_commit(settings.last_validated_commit)
 
             self.state.event = (
                 Event.CHANGED
@@ -299,6 +338,24 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                     f"Repository {self.state.users_auth_repo.name} is not a test repository,"
                     ' but update was called with the "--expected-repo-type" test'
                 )
+
+    def _validate_last_validated_commit(self, last_validated_commit):
+        users_head_sha = self.state.users_auth_repo.top_commit_of_branch(
+            self.state.users_auth_repo.default_branch
+        )
+        if last_validated_commit != users_head_sha:
+            # if a user committed something to the repo or manually pulled the changes
+            # last_validated_commit will no longer match the top commit, but the repository
+            # might still be completely valid
+            # committing without pushing is not valid
+            # user_head_sha should be newer than last validated commit
+            commits_since = self.state.users_auth_repo.all_commits_since_commit(
+                last_validated_commit
+            )
+            if users_head_sha not in commits_since:
+                msg = f"Top commit of repository {self.state.users_auth_repo.name} {users_head_sha} and is not equal to or newer than last successful commit"
+                taf_logger.error(msg)
+                raise UpdateFailedError(msg)
 
     @log_on_start(
         INFO,
@@ -960,7 +1017,7 @@ but commit not on branch {current_branch}"
         )
 
 
-def _clone_validation_repo(url, repository_name):
+def _clone_validation_repo(url):
     """
     Clones the authentication repository based on the url specified using the
     mirrors parameter. The repository is cloned as a bare repository
@@ -978,21 +1035,18 @@ def _clone_validation_repo(url, repository_name):
 
     settings.validation_repo_path = validation_auth_repo.path
 
-    validation_head_sha = validation_auth_repo.top_commit_of_branch(
-        validation_auth_repo.default_branch
-    )
-
-    if repository_name is None:
-        try:
-            info = validation_auth_repo.get_json(validation_head_sha, INFO_JSON_PATH)
-            repository_name = f'{info["namespace"]}/{info["name"]}'
-        except Exception:
-            raise UpdateFailedError(
-                "Error during info.json parse. When specifying --clients-library-dir check if info.json metadata exists in targets/protected or provide full path to auth repo"
-            )
-
     validation_auth_repo.cleanup()
-    return repository_name
+    return validation_auth_repo
+
+
+def _get_repository_name_from_info_json(auth_repo, commit_sha):
+    try:
+        info = auth_repo.get_json(commit_sha, INFO_JSON_PATH)
+        return f'{info["namespace"]}/{info["name"]}'
+    except Exception:
+        raise UpdateFailedError(
+            "Error during info.json parse. If the authentication repository's path is not specified, info.json metadata is expected to be in targets/protected"
+        )
 
 
 def _is_unauthenticated_allowed(repository):
@@ -1041,33 +1095,32 @@ def _run_tuf_updater(git_updater):
                     target_filepath,
                     current_commit,
                 )
+            return current_commit
         except Exception as e:
             metadata_expired = EXPIRED_METADATA_ERROR in type(
                 e
             ).__name__ or EXPIRED_METADATA_ERROR in str(e)
             if not metadata_expired or settings.strict:
                 taf_logger.error(
-                    "Validation of authentication repository {} failed at revision {} due to error: {}",
-                    git_updater.users_auth_repo.name,
+                    "Validation of authentication repository failed at revision {} due to error: {}",
                     current_commit,
                     e,
                 )
                 raise UpdateFailedError(
-                    f"Validation of authentication repository {git_updater.users_auth_repo.name}"
+                    f"Validation of authentication repository"
                     f" failed at revision {current_commit} due to error: {e}"
                 )
             taf_logger.warning(
-                f"WARNING: Could not validate authentication repository {git_updater.users_auth_repo.name} at revision {current_commit} due to error: {e}"
+                f"WARNING: Could not validate authentication repository at revision {current_commit} due to error: {e}"
             )
 
+    current_commit = None
     while not git_updater.update_done():
         updater = _init_updater()
-        _update_tuf_current_revision()
+        current_commit = _update_tuf_current_revision()
+        # TODO handle partial validation
 
-    taf_logger.info(
-        "Successfully validated authentication repository {}",
-        git_updater.users_auth_repo.name,
-    )
+    return current_commit
 
 
 def _find_next_value(value, values_list):

--- a/taf/utils.py
+++ b/taf/utils.py
@@ -125,6 +125,12 @@ def extract_json_objects_from_trusted_stdout(text, decoder=JSONDecoder()):
             pos = match + 1
 
 
+def is_non_empty_directory(path: Path):
+    if path.is_dir():
+        return any(path.iterdir())
+    return False
+
+
 def read_input_dict(value):
     if value is None:
         return {}


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Separated clone and update commands: This separation mirrors Git, where cloning and pulling are separate operations.

The clone command is used for the initial setup of repositories.
If the `--path` option is not provided during cloning, the updater automatically reads from `protected/info.json` to determine the repository's location. `library-dir`, if nor provided, is set to the current directory and the namespace and name read from `info.json` are appended to this path to determine authentication repository's location.

The update command is designed to pull changes into an already cloned repository.
When updating, the URL of the repository is automatically determined and is not expected to be specified.
If the --path option is not provided, the command defaults to using the current directory as the repository's location.

Updated docs.

So, to clone, run for example:

```git clone https://github.com/oll-test-repos/sanipueblo-law```

This repository contains `protected/info.json`, so it is not necessary to use the `--path` option

```git clone https://github.com/sanipueblo/law --path sanipueblo/law```

This repository does not contain `info.json`, so path needs to be specified.

Update was not modified, but it can only be run if a repository already exists. An error will be raised if that is not the case.

Closes  #378

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
