### PR TITLE
Partially update authentication repository in case it cannot be fully validated and clone and unauthenticated commits fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- Only clone repositories if target files exists ([381])
+- Do not merge unauthenticated commits which are newer than the last authenticated commit if a repository can contain unauthenticated commits ([381])
+- Partially update authentication repositories up to the last valid commit ([381])
 - Check if there are uncommitted changes when running the updater ([377])
 - Implement updater pipeline ([374])
 - Improve error messages and error logging ([374])
@@ -24,6 +27,7 @@ and this project adheres to [Semantic Versioning][semver].
 - Fix imports, do not require installation of yubikey-manager prior to running the update ([376])
 - Git: fix the commit method so that it raises an error if nothing is committed ([375])
 
+[381]: https://github.com/openlawlibrary/taf/pull/381
 [377]: https://github.com/openlawlibrary/taf/pull/377
 [376]: https://github.com/openlawlibrary/taf/pull/376
 [375]: https://github.com/openlawlibrary/taf/pull/375

--- a/taf/exceptions.py
+++ b/taf/exceptions.py
@@ -40,7 +40,7 @@ class GitError(TAFError):
                 message = str(error)
             else:
                 message = "error occurred"
-        self.message = f"{repo.log_prefix}{message}"
+        self.message = f"{repo.log_prefix}{message}" if repo is not None else message
         self.repo = repo
         self.command = command
         self.error = error

--- a/taf/tests/test_updater/test_repo_update/test_updater.py
+++ b/taf/tests/test_updater/test_repo_update/test_updater.py
@@ -279,8 +279,8 @@ def test_no_update_necessary(
             True,
             True,
         ),
-        ("test-updater-wrong-key", INVALID_KEYS_PATTERN, True, True, False),
-        ("test-updater-invalid-version-number", REPLAYED_METADATA, True, True, False),
+        ("test-updater-wrong-key", INVALID_KEYS_PATTERN, True, True, True),
+        ("test-updater-invalid-version-number", REPLAYED_METADATA, True, True, True),
         (
             "test-updater-delegated-roles-wrong-sha",
             TARGET_MISSMATCH_PATTERN,
@@ -293,7 +293,7 @@ def test_no_update_necessary(
             INVALID_KEYS_PATTERN,
             True,
             True,
-            False,
+            True,
         ),
         ("test-updater-info-missing", NO_REPOSITORY_INFO_JSON, False, True, False),
         (
@@ -301,7 +301,7 @@ def test_no_update_necessary(
             METADATA_FIELD_MISSING,
             False,
             True,
-            False,
+            True,
         ),
     ],
 )
@@ -365,12 +365,12 @@ def test_updater_expired_metadata(updater_repositories, origin_dir, client_dir):
         client_dir,
         repositories,
         ROOT_EXPIRED,
-        False,
+        True,
         set_time=False,
         strict=True,
     )
     # make sure that the last validated commit does not exist
-    _check_if_last_validated_commit_exists(clients_auth_repo_path, False)
+    _check_if_last_validated_commit_exists(clients_auth_repo_path, True)
 
 
 @pytest.mark.parametrize(

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -984,7 +984,7 @@ but commit not on branch {current_branch}"
                             commit_to_merge,
                             branch,
                         )
-                        _merge_commit(repository, branch, commit_to_merge)
+                        _merge_commit(repository, branch, commit_to_merge, force_revert=True)
                 return self.state.update_status
         except Exception as e:
             self.state.errors.append(e)
@@ -1173,6 +1173,7 @@ def _run_tuf_updater(git_updater):
                 )
             return current_commit
         except Exception as e:
+            import pdb; pdb.set_trace()
             metadata_expired = EXPIRED_METADATA_ERROR in type(
                 e
             ).__name__ or EXPIRED_METADATA_ERROR in str(e)
@@ -1258,7 +1259,7 @@ def _merge_commit(
             commit_to_merge
         )
         if len(commits_since_last_validated):
-            repository.reset_to_commit(commit_to_merge)
+            repository.reset_to_commit(commit_to_merge, hard=True)
             commit_merged = True
 
     if not commit_merged:


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

- If the authentication repository contains an invalid commit, it will be partially updated, up until the last valid commit
- If multiple errors occur, print them all
- Do not merge unauthenticated commits which are newer than the last authenticated commit if a repository can contain unauthenticated commits
- Only clone repositories if target files exists
- Print additional commits of repositories which allow unauthenticated commits at the end of the update process
- Revert merged commit if invalid

Closes #281 

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
