### PR TITLE
Add test for updating a repositories which references other authentication repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,15 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
+- Add a test for updating a repositories which references other authentication repositories. Test repositories are set up programmatically ([386])
+
 ### Changed
 
 ### Fixed
+
+- Fix a minor bug where update status was incorrectly being set in case when a repository with only one commit is cloned
+
+[386]: https://github.com/openlawlibrary/taf/pull/386
 
 ## [0.29.0] - 01/24/2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
-- Fix a minor bug where update status was incorrectly being set in case when a repository with only one commit is cloned
+- Fix a minor bug where update status was incorrectly being set in case when a repository with only one commit is cloned ([386])
 
 [386]: https://github.com/openlawlibrary/taf/pull/386
 

--- a/taf/repositoriesdb.py
+++ b/taf/repositoriesdb.py
@@ -111,7 +111,7 @@ def load_dependencies(
 
         for name, repo_data in dependencies.items():
             try:
-                if not settings.update_from_filesystem:
+                if mirrors:
                     urls = _get_urls(mirrors, name, repo_data)
                 else:
                     urls = [name]

--- a/taf/repositoriesdb.py
+++ b/taf/repositoriesdb.py
@@ -1,6 +1,5 @@
 import json
 from typing import Callable, Dict, List, Optional, Type
-import taf.settings as settings
 import fnmatch
 from pathlib import Path
 from tuf.repository_tool import TARGETS_DIRECTORY_NAME

--- a/taf/tests/conftest.py
+++ b/taf/tests/conftest.py
@@ -1,4 +1,3 @@
-import json
 import os
 import shutil
 from contextlib import contextmanager
@@ -6,9 +5,6 @@ from pathlib import Path
 
 
 from pytest import fixture
-from taf.api.repository import create_repository
-from taf.api.targets import update_target_repos_from_repositories_json
-from taf.git import GitRepository
 from taf.tests import TEST_WITH_REAL_YK
 from taf.utils import on_rm_error
 
@@ -98,46 +94,3 @@ def keystore():
 def wrong_keystore():
     """Path of the wrong keystore"""
     return str(WRONG_KEYSTORE_PATH)
-
-
-@fixture
-def test_namespace1_auth_repo():
-    repo_path = CLIENT_DIR_PATH / NAMESPACE1 / AUTH_NAME
-    repo_path.mkdir(parents=True, exist_ok=True)
-    repo = GitRepository(path=repo_path)
-    repositories_json = {
-        "repositories": {
-            "namespace1/TargetRepo1": {
-                "custom": {
-                    "allow-unauthenticated-commits": True,
-                    "type":"type1"
-                }
-            },
-            "namespace1/TargetRepo2": {
-                "custom": {
-                    "type": "type2"
-                }
-            },
-            "namespace1/TargetRepo3": {
-                "custom": {
-                    "type": "type3"
-                }
-            }
-        }
-    }
-    targets_dir = repo_path / "targets"
-    targets_dir.mkdir(exist_ok=True)
-    repositories_json_path = targets_dir / "repositories.json"
-    repositories_json_path.write_text(json.dumps(repositories_json))
-    keys_description = str(TEST_INIT_DATA_PATH / "keys.json")
-    repo.init_repo()
-    create_repository(str(repo_path), str(KEYSTORE_PATH), keys_description)
-    repo.commit("Initial commit")
-    update_target_repos_from_repositories_json(
-        str(repo_path), str(CLIENT_DIR_PATH), str(KEYSTORE_PATH), scheme="rsa-pkcs1v15-sha256",
-    )
-    yield repo
-
-
-# def test_namespace1_auth():
-#     repo_path = CLIENT_DIR_PATH / NAMESPACE1 / REPO_NAME

--- a/taf/tests/conftest.py
+++ b/taf/tests/conftest.py
@@ -24,13 +24,6 @@ CLIENT_DIR_PATH = TEST_DATA_REPOS_PATH / "client"
 HANDLERS_DATA_INPUT_DIR = TEST_DATA_PATH / "handler_inputs"
 TEST_INIT_DATA_PATH = Path(__file__).parent / "init_data"
 
-NAMESPACE1 = "namespace1"
-NAMESPACE2 = "namespace2"
-TARGET1_NAME = "TargetRepo1"
-TARGET2_NAME = "TargetRepo2"
-TARGET3_NAME = "TargetRepo3"
-AUTH_NAME = "auth"
-
 
 def pytest_generate_tests(metafunc):
     if "repositories" in metafunc.fixturenames:
@@ -105,50 +98,6 @@ def keystore():
 def wrong_keystore():
     """Path of the wrong keystore"""
     return str(WRONG_KEYSTORE_PATH)
-
-
-def _initialize_target_repo(namespace, repo_name):
-    repo_path = CLIENT_DIR_PATH / namespace / repo_name
-    repo_path.mkdir(parents=True, exist_ok=True)
-    repo = GitRepository(path=repo_path)
-    repo.init_repo()
-    # create some files
-    (repo_path / "test1.txt").write_text("Test file 1")
-    (repo_path / "test2.txt").write_text("Test file 2")
-    repo.commit("Initial commit")
-    return repo
-
-
-@fixture
-def test_namespace1_target_repo1():
-    repo = _initialize_target_repo(NAMESPACE1, TARGET1_NAME)
-    yield repo
-
-
-@fixture
-def test_namespace1_target_repo2():
-    repo = _initialize_target_repo(NAMESPACE1, TARGET2_NAME)
-    yield repo
-
-@fixture
-def test_namespace1_target_repo3():
-    repo = _initialize_target_repo(NAMESPACE1, TARGET3_NAME)
-    yield repo
-
-@fixture
-def test_namespace2_target_repo1():
-    repo = _initialize_target_repo(NAMESPACE2, TARGET1_NAME)
-    yield repo
-
-@fixture
-def test_namespace2_target_repo2():
-    repo = _initialize_target_repo(NAMESPACE2, TARGET2_NAME)
-    yield repo
-
-@fixture
-def test_namespace2_target_repo3():
-    repo = _initialize_target_repo(NAMESPACE2, TARGET3_NAME)
-    yield repo
 
 
 @fixture

--- a/taf/tests/init_data/dependencies.json
+++ b/taf/tests/init_data/dependencies.json
@@ -1,0 +1,10 @@
+{
+    "dependencies": {
+        "namespace1/auth": {
+            "out-of-band-authentication": "{commit1}"
+        },
+        "namespace2/auth": {
+            "out-of-band-authentication": "{commit2}"
+        }
+    }
+}

--- a/taf/tests/init_data/keys.json
+++ b/taf/tests/init_data/keys.json
@@ -1,12 +1,14 @@
 {
-  "root": {
-    "number": 2,
-    "length": 2048,
-	"threshold": 1
-  },
-  "targets": {
-    "length": 2048
-  },
-  "snapshot": {},
-  "timestamp": {}
+  "roles": {
+    "root": {
+      "number": 2,
+      "length": 2048,
+    "threshold": 1
+    },
+    "targets": {
+      "length": 2048
+    },
+    "snapshot": {},
+    "timestamp": {}
+  }
 }

--- a/taf/tests/test_updater/test_repo_update/conftest.py
+++ b/taf/tests/test_updater/test_repo_update/conftest.py
@@ -116,24 +116,20 @@ def library_with_dependencies():
     namespaces = [NAMESPACE1, NAMESPACE2]
     target_names = [TARGET1_NAME, TARGET2_NAME, TARGET3_NAME]
 
+    initial_commits = []
     for namespace in namespaces:
         auth_repo = create_auth_repo_with_repositories_json_and_mirrors(
             namespace, TEST_INIT_DATA_PATH / "repositories.json", TEST_DATA_ORIGIN_PATH
         )
+        initial_commits.append(auth_repo.head_commit_sha())
         target_repos = create_target_repos(namespace, target_names, auth_repo.path)
         library[auth_repo.name] = {"auth_repo": auth_repo, "target_repos": target_repos}
 
     root_auth_repo = initialize_repo(ROOT_REPO_NAMESPACE, AUTH_NAME)
-    auth_commit1 = library[f"{NAMESPACE1}/{AUTH_NAME}"][
-        "auth_repo"
-    ].get_first_commit_on_branch()
-    auth_commit2 = library[f"{NAMESPACE2}/{AUTH_NAME}"][
-        "auth_repo"
-    ].get_first_commit_on_branch()
     (root_auth_repo.path / "targets").mkdir(parents=True, exist_ok=True)
     create_and_write_json(
         TEST_INIT_DATA_PATH / "dependencies.json",
-        {"commit1": auth_commit1, "commit2": auth_commit2},
+        {"commit1": initial_commits[0], "commit2": initial_commits[1]},
         root_auth_repo.path / "targets" / "dependencies.json",
     )
     create_mirrors(root_auth_repo)

--- a/taf/tests/test_updater/test_repo_update/conftest.py
+++ b/taf/tests/test_updater/test_repo_update/conftest.py
@@ -1,9 +1,15 @@
 import json
+from pathlib import Path
 import re
 from taf.api.repository import create_repository
 from taf.api.targets import update_target_repos_from_repositories_json
 from taf.git import GitRepository
-from taf.tests.conftest import CLIENT_DIR_PATH, KEYSTORE_PATH, TEST_INIT_DATA_PATH, origin_repos_group
+from taf.tests.conftest import (
+    CLIENT_DIR_PATH,
+    KEYSTORE_PATH,
+    TEST_INIT_DATA_PATH,
+    origin_repos_group,
+)
 from tuf.ngclient._internal import trusted_metadata_set
 from pytest import fixture
 
@@ -15,6 +21,7 @@ TARGET1_NAME = "target1"
 TARGET2_NAME = "target2"
 TARGET3_NAME = "target3"
 AUTH_NAME = "auth"
+ROOT_REPO_NAMESPACE = "root"
 
 
 @fixture(scope="session", autouse=True)
@@ -24,60 +31,102 @@ def updater_repositories():
         yield origins
 
 
-def _initialize_target_repo(namespace, repo_name):
+def initialize_repo(namespace, repo_name):
     repo_path = CLIENT_DIR_PATH / namespace / repo_name
     repo_path.mkdir(parents=True, exist_ok=True)
     repo = GitRepository(path=repo_path)
     repo.init_repo()
+    return repo
+
+
+def initialize_target_repo(namespace, repo_name):
+    repo = initialize_repo(namespace, repo_name)
     # create some files
-    (repo_path / "test1.txt").write_text("Test file 1")
-    (repo_path / "test2.txt").write_text("Test file 2")
+    for i in range(1, 3):
+        (repo.path / f"test{i}.txt").write_text(f"Test file {i}")
     repo.commit("Initial commit")
     return repo
 
 
-@fixture
-def library():
+def update_target_files(target_repo, commit_message):
+    text_to_add = "Some text to add"
+    # Iterate over all files in the repository directory
+    for file_path in target_repo.path.iterdir():
+        if file_path.is_file():
+            existing_content = file_path.read_text(encoding="utf-8")
+            new_content = existing_content + "\n" + text_to_add
+            file_path.write_text(new_content, encoding="utf-8")
+    target_repo.commit(commit_message)
 
+
+def create_and_write_json(template_path, substitutions, output_path):
+    template = template_path.read_text()
+    for key, value in substitutions.items():
+        template = re.sub(rf"\{{{key}\}}", value, template)
+    output_path.write_text(template)
+
+
+def create_auth_repo_with_repositories_json(
+    namespace, json_template_path, json_output_dir
+):
+    auth_repo = initialize_repo(namespace, AUTH_NAME)
+    (auth_repo.path / "targets").mkdir(parents=True, exist_ok=True)
+    create_and_write_json(
+        json_template_path,
+        {"namespace": namespace},
+        json_output_dir / auth_repo.path / "targets" / "repositories.json",
+    )
+    keys_description = str(TEST_INIT_DATA_PATH / "keys.json")
+    create_repository(
+        str(auth_repo.path), str(KEYSTORE_PATH), keys_description, commit=True
+    )
+    return auth_repo
+
+
+def update_target_repos(namespace, target_names, auth_repo_path, num_updates=2):
+    target_repos = [initialize_target_repo(namespace, name) for name in target_names]
+    for _ in range(num_updates):
+        for target_repo in target_repos:
+            update_target_files(target_repo, "Update target files")
+        update_target_repos_from_repositories_json(
+            str(auth_repo_path),
+            str(CLIENT_DIR_PATH),
+            str(KEYSTORE_PATH),
+        )
+    return target_repos
+
+
+@fixture
+def library_with_dependencies():
     library = {}
 
     namespaces = [NAMESPACE1, NAMESPACE2]
+    target_names = [TARGET1_NAME, TARGET2_NAME, TARGET3_NAME]
+
     for namespace in namespaces:
-        # Initialize auth repository for the namespace
-        auth_repo_path = CLIENT_DIR_PATH / namespace / AUTH_NAME
-        auth_repo_path.mkdir(parents=True, exist_ok=True)
-        auth_repo = GitRepository(path=auth_repo_path)
-        auth_repo.init_repo()
-        repositories_path_template = (TEST_INIT_DATA_PATH / "repositories.json").read_text()
-        repositories_json_str = re.sub(r'\{namespace\}', namespace, repositories_path_template)
-        repositories_json = json.loads(repositories_json_str)
-
-        # Write repositories JSON to file
-        targets_dir = auth_repo_path / "targets"
-        targets_dir.mkdir(exist_ok=True)
-        repositories_json_path = targets_dir / "repositories.json"
-        repositories_json_path.write_text(json.dumps(repositories_json))
-
-        # Create auth repository
-        keys_description = str(TEST_INIT_DATA_PATH / "keys.json")
-        create_repository(str(auth_repo_path), str(KEYSTORE_PATH), keys_description)
-        auth_repo.commit("Initial commit")
-        target_names = [TARGET1_NAME, TARGET2_NAME, TARGET3_NAME]
-        target_repos = []
-
-        target_repos = []
-        for target_name in target_names:
-            repo = _initialize_target_repo(namespace, target_name)
-            target_repos.append(repo)
-        update_target_repos_from_repositories_json(
-            str(auth_repo_path), str(CLIENT_DIR_PATH), str(KEYSTORE_PATH),
+        auth_repo = create_auth_repo_with_repositories_json(
+            namespace, TEST_INIT_DATA_PATH / "repositories.json", CLIENT_DIR_PATH
         )
-        library[auth_repo.name] = {
-            "auth_repo": auth_repo,
-            "target_repos": target_repos
-        }
+        target_repos = update_target_repos(namespace, target_names, auth_repo.path)
+        library[auth_repo.name] = {"auth_repo": auth_repo, "target_repos": target_repos}
+
+    root_auth_repo = initialize_repo(ROOT_REPO_NAMESPACE, AUTH_NAME)
+    auth_commit1 = library[f"{NAMESPACE1}/{AUTH_NAME}"][
+        "auth_repo"
+    ].get_first_commit_on_branch()
+    auth_commit2 = library[f"{NAMESPACE2}/{AUTH_NAME}"][
+        "auth_repo"
+    ].get_first_commit_on_branch()
+    (root_auth_repo.path / "targets").mkdir(parents=True, exist_ok=True)
+    create_and_write_json(
+        TEST_INIT_DATA_PATH / "dependencies.json",
+        {"commit1": auth_commit1, "commit2": auth_commit2},
+        root_auth_repo.path / "targets" / "dependencies.json",
+    )
+    keys_description = str(TEST_INIT_DATA_PATH / "keys.json")
+    create_repository(
+        str(root_auth_repo.path), str(KEYSTORE_PATH), keys_description, commit=True
+    )
+    library[root_auth_repo.name] = {"auth_repo": root_auth_repo, "target_repos": []}
 
     yield library
-
-
-CLIENT_DIR_PATH

--- a/taf/tests/test_updater/test_repo_update/conftest.py
+++ b/taf/tests/test_updater/test_repo_update/conftest.py
@@ -1,8 +1,20 @@
-from taf.tests.conftest import origin_repos_group
+import json
+import re
+from taf.api.repository import create_repository
+from taf.api.targets import update_target_repos_from_repositories_json
+from taf.git import GitRepository
+from taf.tests.conftest import CLIENT_DIR_PATH, KEYSTORE_PATH, TEST_INIT_DATA_PATH, origin_repos_group
 from tuf.ngclient._internal import trusted_metadata_set
 from pytest import fixture
 
 original_tuf_trusted_metadata_set = trusted_metadata_set.TrustedMetadataSet
+
+NAMESPACE1 = "namespace1"
+NAMESPACE2 = "namespace2"
+TARGET1_NAME = "target1"
+TARGET2_NAME = "target2"
+TARGET3_NAME = "target3"
+AUTH_NAME = "auth"
 
 
 @fixture(scope="session", autouse=True)
@@ -10,3 +22,62 @@ def updater_repositories():
     test_dir = "test-updater"
     with origin_repos_group(test_dir) as origins:
         yield origins
+
+
+def _initialize_target_repo(namespace, repo_name):
+    repo_path = CLIENT_DIR_PATH / namespace / repo_name
+    repo_path.mkdir(parents=True, exist_ok=True)
+    repo = GitRepository(path=repo_path)
+    repo.init_repo()
+    # create some files
+    (repo_path / "test1.txt").write_text("Test file 1")
+    (repo_path / "test2.txt").write_text("Test file 2")
+    repo.commit("Initial commit")
+    return repo
+
+
+@fixture
+def library():
+
+    library = {}
+
+    namespaces = [NAMESPACE1, NAMESPACE2]
+    for namespace in namespaces:
+        # Initialize auth repository for the namespace
+        auth_repo_path = CLIENT_DIR_PATH / namespace / AUTH_NAME
+        auth_repo_path.mkdir(parents=True, exist_ok=True)
+        auth_repo = GitRepository(path=auth_repo_path)
+        auth_repo.init_repo()
+        repositories_path_template = (TEST_INIT_DATA_PATH / "repositories.json").read_text()
+        repositories_json_str = re.sub(r'\{namespace\}', namespace, repositories_path_template)
+        repositories_json = json.loads(repositories_json_str)
+
+        # Write repositories JSON to file
+        targets_dir = auth_repo_path / "targets"
+        targets_dir.mkdir(exist_ok=True)
+        repositories_json_path = targets_dir / "repositories.json"
+        repositories_json_path.write_text(json.dumps(repositories_json))
+
+        # Create auth repository
+        keys_description = str(TEST_INIT_DATA_PATH / "keys.json")
+        create_repository(str(auth_repo_path), str(KEYSTORE_PATH), keys_description)
+        auth_repo.commit("Initial commit")
+        target_names = [TARGET1_NAME, TARGET2_NAME, TARGET3_NAME]
+        target_repos = []
+
+        target_repos = []
+        for target_name in target_names:
+            repo = _initialize_target_repo(namespace, target_name)
+            target_repos.append(repo)
+        update_target_repos_from_repositories_json(
+            str(auth_repo_path), str(CLIENT_DIR_PATH), str(KEYSTORE_PATH),
+        )
+        library[auth_repo.name] = {
+            "auth_repo": auth_repo,
+            "target_repos": target_repos
+        }
+
+    yield library
+
+
+CLIENT_DIR_PATH

--- a/taf/tests/test_updater/test_repo_update/conftest.py
+++ b/taf/tests/test_updater/test_repo_update/conftest.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 import re
 import shutil
 from taf.api.repository import create_repository

--- a/taf/tests/test_updater/test_repo_update/test_updater.py
+++ b/taf/tests/test_updater/test_repo_update/test_updater.py
@@ -114,392 +114,396 @@ def run_around_tests(client_dir):
         for dir_name in dirs:
             shutil.rmtree(str(Path(root) / dir_name), onerror=on_rm_error)
 
+def test_something(library_with_dependencies):
+    assert library_with_dependencies['namespace1/auth']
 
-@pytest.mark.parametrize(
-    "test_name, test_repo, auth_repo_name_exists",
-    [
-        ("test-updater-valid", UpdateType.OFFICIAL, True),
-        ("test-updater-valid", UpdateType.OFFICIAL, False),
-        ("test-updater-valid-with-updated-expiration-dates", UpdateType.OFFICIAL, True),
-        ("test-updater-allow-unauthenticated-commits", UpdateType.OFFICIAL, True),
-        ("test-updater-test-repo", UpdateType.TEST, True),
-        ("test-updater-multiple-branches", UpdateType.OFFICIAL, True),
-        ("test-updater-delegated-roles", UpdateType.OFFICIAL, True),
-        ("test-updater-updated-root", UpdateType.OFFICIAL, True),
-        ("test-updater-updated-root-old-snapshot", UpdateType.OFFICIAL, True),
-        ("test-updater-updated-root-version-skipped", UpdateType.OFFICIAL, True),
-        ("test-updater-updated-root-version-skipped", UpdateType.OFFICIAL, True),
-        ("test-updater-expired-metadata", UpdateType.OFFICIAL, True),
-    ],
-)
-def test_valid_update_no_client_repo(
-    test_name,
-    test_repo,
-    auth_repo_name_exists,
-    updater_repositories,
-    origin_dir,
-    client_dir,
-):
-    repositories = updater_repositories[test_name]
-    origin_dir = origin_dir / test_name
-    _update_and_check_commit_shas(
-        OperationType.CLONE,
-        None,
-        repositories,
-        origin_dir,
-        client_dir,
-        test_repo,
-        auth_repo_name_exists,
-    )
-
-
-def test_excluded_targets_update_no_client_repo(
-    updater_repositories,
-    origin_dir,
-    client_dir,
-):
-    repositories = updater_repositories["test-updater-valid"]
-    origin_dir = origin_dir / "test-updater-valid"
-    excluded_target_globs = ["*/TargetRepo1"]
-    _update_and_check_commit_shas(
-        OperationType.CLONE,
-        None,
-        repositories,
-        origin_dir,
-        client_dir,
-        UpdateType.OFFICIAL,
-        True,
-        excluded_target_globs,
-    )
-    for repository_rel_path in repositories:
-        for excluded_target_glob in excluded_target_globs:
-            if fnmatch.fnmatch(repository_rel_path, excluded_target_glob):
-                assert not Path(client_dir, repository_rel_path).is_dir()
-                break
+# @pytest.mark.parametrize(
+#     "test_name, test_repo, auth_repo_name_exists",
+#     [
+#         ("test-updater-valid", UpdateType.OFFICIAL, True),
+#         ("test-updater-valid", UpdateType.OFFICIAL, False),
+#         ("test-updater-valid-with-updated-expiration-dates", UpdateType.OFFICIAL, True),
+#         ("test-updater-allow-unauthenticated-commits", UpdateType.OFFICIAL, True),
+#         ("test-updater-test-repo", UpdateType.TEST, True),
+#         ("test-updater-multiple-branches", UpdateType.OFFICIAL, True),
+#         ("test-updater-delegated-roles", UpdateType.OFFICIAL, True),
+#         ("test-updater-updated-root", UpdateType.OFFICIAL, True),
+#         ("test-updater-updated-root-old-snapshot", UpdateType.OFFICIAL, True),
+#         ("test-updater-updated-root-version-skipped", UpdateType.OFFICIAL, True),
+#         ("test-updater-updated-root-version-skipped", UpdateType.OFFICIAL, True),
+#         ("test-updater-expired-metadata", UpdateType.OFFICIAL, True),
+#     ],
+# )
+# def test_valid_update_no_client_repo(
+#     test_name,
+#     test_repo,
+#     auth_repo_name_exists,
+#     updater_repositories,
+#     origin_dir,
+#     client_dir,
+# ):
+#     repositories = updater_repositories[test_name]
+#     origin_dir = origin_dir / test_name
+#     _update_and_check_commit_shas(
+#         OperationType.CLONE,
+#         None,
+#         repositories,
+#         origin_dir,
+#         client_dir,
+#         test_repo,
+#         auth_repo_name_exists,
+#     )
 
 
-@pytest.mark.parametrize(
-    "test_name, test_repo",
-    [
-        ("test-updater-valid", UpdateType.OFFICIAL),
-        ("test-updater-allow-unauthenticated-commits", UpdateType.OFFICIAL),
-        ("test-updater-multiple-branches", UpdateType.OFFICIAL),
-        ("test-updater-delegated-roles", UpdateType.OFFICIAL),
-    ],
-)
-def test_valid_update_no_auth_repo_one_target_repo_exists(
-    test_name, test_repo, updater_repositories, origin_dir, client_dir
-):
-    repositories = updater_repositories[test_name]
-    origin_dir = origin_dir / test_name
-    _clone_client_repo(TARGET_REPO_REL_PATH, origin_dir, client_dir)
-    _update_and_check_commit_shas(
-        OperationType.CLONE, None, repositories, origin_dir, client_dir, test_repo
-    )
 
 
-@pytest.mark.parametrize(
-    "test_name, num_of_commits_to_revert",
-    [
-        ("test-updater-valid", 3),
-        ("test-updater-allow-unauthenticated-commits", 1),
-        ("test-updater-multiple-branches", 5),
-        ("test-updater-delegated-roles", 1),
-        ("test-updater-updated-root", 1),
-        ("test-updater-updated-root-old-snapshot", 1),
-        ("test-updater-updated-root-version-skipped", 1),
-    ],
-)
-def test_valid_update_existing_client_repos(
-    test_name, num_of_commits_to_revert, updater_repositories, origin_dir, client_dir
-):
-    # clone the origin repositories
-    # revert them to an older commit
-    repositories = updater_repositories[test_name]
-    origin_dir = origin_dir / test_name
-    client_repos = _clone_and_revert_client_repositories(
-        repositories, origin_dir, client_dir, num_of_commits_to_revert
-    )
-    # create valid last validated commit file
-    _create_last_validated_commit(
-        client_dir, client_repos[AUTH_REPO_REL_PATH].head_commit_sha()
-    )
-    _update_and_check_commit_shas(
-        OperationType.UPDATE, client_repos, repositories, origin_dir, client_dir
-    )
+# def test_excluded_targets_update_no_client_repo(
+#     updater_repositories,
+#     origin_dir,
+#     client_dir,
+# ):
+#     repositories = updater_repositories["test-updater-valid"]
+#     origin_dir = origin_dir / "test-updater-valid"
+#     excluded_target_globs = ["*/TargetRepo1"]
+#     _update_and_check_commit_shas(
+#         OperationType.CLONE,
+#         None,
+#         repositories,
+#         origin_dir,
+#         client_dir,
+#         UpdateType.OFFICIAL,
+#         True,
+#         excluded_target_globs,
+#     )
+#     for repository_rel_path in repositories:
+#         for excluded_target_glob in excluded_target_globs:
+#             if fnmatch.fnmatch(repository_rel_path, excluded_target_glob):
+#                 assert not Path(client_dir, repository_rel_path).is_dir()
+#                 break
 
 
-@pytest.mark.parametrize(
-    "test_name, test_repo",
-    [
-        ("test-updater-valid", UpdateType.OFFICIAL),
-        ("test-updater-allow-unauthenticated-commits", UpdateType.OFFICIAL),
-        ("test-updater-test-repo", UpdateType.TEST),
-        ("test-updater-multiple-branches", UpdateType.OFFICIAL),
-        ("test-updater-delegated-roles", UpdateType.OFFICIAL),
-    ],
-)
-def test_no_update_necessary(
-    test_name, test_repo, updater_repositories, origin_dir, client_dir
-):
-    # clone the origin repositories
-    # revert them to an older commit
-    repositories = updater_repositories[test_name]
-    origin_dir = origin_dir / test_name
-    client_repos = _clone_client_repositories(repositories, origin_dir, client_dir)
-    # create valid last validated commit file
-    _create_last_validated_commit(
-        client_dir, client_repos[AUTH_REPO_REL_PATH].head_commit_sha()
-    )
-    _update_and_check_commit_shas(
-        OperationType.UPDATE,
-        client_repos,
-        repositories,
-        origin_dir,
-        client_dir,
-        test_repo,
-    )
+# @pytest.mark.parametrize(
+#     "test_name, test_repo",
+#     [
+#         ("test-updater-valid", UpdateType.OFFICIAL),
+#         ("test-updater-allow-unauthenticated-commits", UpdateType.OFFICIAL),
+#         ("test-updater-multiple-branches", UpdateType.OFFICIAL),
+#         ("test-updater-delegated-roles", UpdateType.OFFICIAL),
+#     ],
+# )
+# def test_valid_update_no_auth_repo_one_target_repo_exists(
+#     test_name, test_repo, updater_repositories, origin_dir, client_dir
+# ):
+#     repositories = updater_repositories[test_name]
+#     origin_dir = origin_dir / test_name
+#     _clone_client_repo(TARGET_REPO_REL_PATH, origin_dir, client_dir)
+#     _update_and_check_commit_shas(
+#         OperationType.CLONE, None, repositories, origin_dir, client_dir, test_repo
+#     )
 
 
-@pytest.mark.parametrize(
-    "test_name, expected_error, auth_repo_name_exists, expect_partial_update, should_last_validated_exist",
-    [
-        ("test-updater-invalid-target-sha", TARGET_MISSMATCH_PATTERN, True, True, True),
-        (
-            "test-updater-additional-target-commit",
-            TARGET_COMMIT_AFTER_LAST_VALIDATED_PATTERN,
-            True,
-            True,
-            True,
-        ),
-        (
-            "test-updater-missing-target-commit",
-            TARGET_ADDITIONAL_COMMIT_PATTERN,
-            True,
-            True,
-            True,
-        ),
-        ("test-updater-wrong-key", INVALID_KEYS_PATTERN, True, True, True),
-        ("test-updater-invalid-version-number", REPLAYED_METADATA, True, True, True),
-        (
-            "test-updater-delegated-roles-wrong-sha",
-            TARGET_MISSMATCH_PATTERN,
-            True,
-            True,
-            True,
-        ),
-        (
-            "test-updater-updated-root-invalid-metadata",
-            INVALID_KEYS_PATTERN,
-            True,
-            True,
-            True,
-        ),
-        ("test-updater-info-missing", NO_REPOSITORY_INFO_JSON, False, True, False),
-        (
-            "test-updater-invalid-snapshot-meta-field-missing",
-            METADATA_FIELD_MISSING,
-            False,
-            True,
-            True,
-        ),
-    ],
-)
-def test_updater_invalid_update(
-    test_name,
-    expected_error,
-    auth_repo_name_exists,
-    updater_repositories,
-    client_dir,
-    expect_partial_update,
-    should_last_validated_exist,
-):
-    repositories = updater_repositories[test_name]
-    clients_auth_repo_path = client_dir / AUTH_REPO_REL_PATH
-
-    _update_invalid_repos_and_check_if_repos_exist(
-        OperationType.CLONE,
-        client_dir,
-        repositories,
-        expected_error,
-        expect_partial_update,
-        auth_repo_name_exists=auth_repo_name_exists,
-    )
-    # make sure that the last validated commit does not exist
-    _check_if_last_validated_commit_exists(
-        clients_auth_repo_path, should_last_validated_exist
-    )
+# @pytest.mark.parametrize(
+#     "test_name, num_of_commits_to_revert",
+#     [
+#         ("test-updater-valid", 3),
+#         ("test-updater-allow-unauthenticated-commits", 1),
+#         ("test-updater-multiple-branches", 5),
+#         ("test-updater-delegated-roles", 1),
+#         ("test-updater-updated-root", 1),
+#         ("test-updater-updated-root-old-snapshot", 1),
+#         ("test-updater-updated-root-version-skipped", 1),
+#     ],
+# )
+# def test_valid_update_existing_client_repos(
+#     test_name, num_of_commits_to_revert, updater_repositories, origin_dir, client_dir
+# ):
+#     # clone the origin repositories
+#     # revert them to an older commit
+#     repositories = updater_repositories[test_name]
+#     origin_dir = origin_dir / test_name
+#     client_repos = _clone_and_revert_client_repositories(
+#         repositories, origin_dir, client_dir, num_of_commits_to_revert
+#     )
+#     # create valid last validated commit file
+#     _create_last_validated_commit(
+#         client_dir, client_repos[AUTH_REPO_REL_PATH].head_commit_sha()
+#     )
+#     _update_and_check_commit_shas(
+#         OperationType.UPDATE, client_repos, repositories, origin_dir, client_dir
+#     )
 
 
-@pytest.mark.parametrize(
-    "test_name, expected_error",
-    [
-        ("test-updater-invalid-target-sha", TARGET_MISSMATCH_PATTERN),
-        ("test-updater-missing-target-commit", TARGET_MISSING_COMMIT_PATTERN),
-    ],
-)
-def test_valid_update_no_auth_repo_one_invalid_target_repo_exists(
-    test_name, expected_error, updater_repositories, client_dir, origin_dir
-):
-    repositories = updater_repositories[test_name]
-    clients_auth_repo_path = client_dir / AUTH_REPO_REL_PATH
-    origin_dir = origin_dir / test_name
-    _clone_client_repo(TARGET_REPO_REL_PATH, origin_dir, client_dir)
-    _update_invalid_repos_and_check_if_repos_exist(
-        OperationType.CLONE, client_dir, repositories, expected_error, True
-    )
-    # make sure that the last validated commit does not exist
-    _check_if_last_validated_commit_exists(clients_auth_repo_path, True)
+# @pytest.mark.parametrize(
+#     "test_name, test_repo",
+#     [
+#         ("test-updater-valid", UpdateType.OFFICIAL),
+#         ("test-updater-allow-unauthenticated-commits", UpdateType.OFFICIAL),
+#         ("test-updater-test-repo", UpdateType.TEST),
+#         ("test-updater-multiple-branches", UpdateType.OFFICIAL),
+#         ("test-updater-delegated-roles", UpdateType.OFFICIAL),
+#     ],
+# )
+# def test_no_update_necessary(
+#     test_name, test_repo, updater_repositories, origin_dir, client_dir
+# ):
+#     # clone the origin repositories
+#     # revert them to an older commit
+#     repositories = updater_repositories[test_name]
+#     origin_dir = origin_dir / test_name
+#     client_repos = _clone_client_repositories(repositories, origin_dir, client_dir)
+#     # create valid last validated commit file
+#     _create_last_validated_commit(
+#         client_dir, client_repos[AUTH_REPO_REL_PATH].head_commit_sha()
+#     )
+#     _update_and_check_commit_shas(
+#         OperationType.UPDATE,
+#         client_repos,
+#         repositories,
+#         origin_dir,
+#         client_dir,
+#         test_repo,
+#     )
 
 
-def test_updater_expired_metadata(updater_repositories, origin_dir, client_dir):
-    # tuf patch state is shared between tests
-    # so we manually revert to original tuf implementation
-    trusted_metadata_set.TrustedMetadataSet = original_tuf_trusted_metadata_set
+# @pytest.mark.parametrize(
+#     "test_name, expected_error, auth_repo_name_exists, expect_partial_update, should_last_validated_exist",
+#     [
+#         ("test-updater-invalid-target-sha", TARGET_MISSMATCH_PATTERN, True, True, True),
+#         (
+#             "test-updater-additional-target-commit",
+#             TARGET_COMMIT_AFTER_LAST_VALIDATED_PATTERN,
+#             True,
+#             True,
+#             True,
+#         ),
+#         (
+#             "test-updater-missing-target-commit",
+#             TARGET_ADDITIONAL_COMMIT_PATTERN,
+#             True,
+#             True,
+#             True,
+#         ),
+#         ("test-updater-wrong-key", INVALID_KEYS_PATTERN, True, True, True),
+#         ("test-updater-invalid-version-number", REPLAYED_METADATA, True, True, True),
+#         (
+#             "test-updater-delegated-roles-wrong-sha",
+#             TARGET_MISSMATCH_PATTERN,
+#             True,
+#             True,
+#             True,
+#         ),
+#         (
+#             "test-updater-updated-root-invalid-metadata",
+#             INVALID_KEYS_PATTERN,
+#             True,
+#             True,
+#             True,
+#         ),
+#         ("test-updater-info-missing", NO_REPOSITORY_INFO_JSON, False, True, False),
+#         (
+#             "test-updater-invalid-snapshot-meta-field-missing",
+#             METADATA_FIELD_MISSING,
+#             False,
+#             True,
+#             True,
+#         ),
+#     ],
+# )
+# def test_updater_invalid_update(
+#     test_name,
+#     expected_error,
+#     auth_repo_name_exists,
+#     updater_repositories,
+#     client_dir,
+#     expect_partial_update,
+#     should_last_validated_exist,
+# ):
+#     repositories = updater_repositories[test_name]
+#     clients_auth_repo_path = client_dir / AUTH_REPO_REL_PATH
 
-    # without using freeze_time, we expect to get metadata expired error
-    repositories = updater_repositories["test-updater-expired-metadata"]
-    clients_auth_repo_path = client_dir / AUTH_REPO_REL_PATH
-    _update_invalid_repos_and_check_if_repos_exist(
-        OperationType.CLONE,
-        client_dir,
-        repositories,
-        ROOT_EXPIRED,
-        True,
-        set_time=False,
-        strict=True,
-    )
-    # make sure that the last validated commit does not exist
-    _check_if_last_validated_commit_exists(clients_auth_repo_path, True)
-
-
-@pytest.mark.parametrize(
-    "test_name, num_of_commits_to_revert, expected_error",
-    [
-        ("test-updater-invalid-target-sha", 1, TARGET_MISSMATCH_PATTERN),
-        ("test-updater-delegated-roles-wrong-sha", 4, TARGET_MISSMATCH_PATTERN),
-    ],
-)
-def test_updater_invalid_target_sha_existing_client_repos(
-    test_name,
-    num_of_commits_to_revert,
-    expected_error,
-    updater_repositories,
-    origin_dir,
-    client_dir,
-):
-    repositories = updater_repositories[test_name]
-    clients_auth_repo_path = client_dir / AUTH_REPO_REL_PATH
-    origin_dir = origin_dir / test_name
-    client_repos = _clone_and_revert_client_repositories(
-        repositories, origin_dir, client_dir, num_of_commits_to_revert
-    )
-    _create_last_validated_commit(
-        client_dir, client_repos[AUTH_REPO_REL_PATH].head_commit_sha()
-    )
-    _update_invalid_repos_and_check_if_remained_same(
-        client_repos, client_dir, repositories, expected_error
-    )
-    _check_last_validated_commit(clients_auth_repo_path)
-
-
-def test_no_target_repositories(updater_repositories, origin_dir, client_dir):
-    repositories = updater_repositories["test-updater-valid"]
-    origin_dir = origin_dir / "test-updater-valid"
-    client_auth_repo = _clone_client_repo(AUTH_REPO_REL_PATH, origin_dir, client_dir)
-    _create_last_validated_commit(client_dir, client_auth_repo.head_commit_sha())
-    _update_and_check_commit_shas(
-        OperationType.UPDATE, None, repositories, origin_dir, client_dir, False
-    )
-
-
-def test_no_last_validated_commit(updater_repositories, origin_dir, client_dir):
-    # clone the origin repositories
-    # revert them to an older commit
-    repositories = updater_repositories["test-updater-valid"]
-    origin_dir = origin_dir / "test-updater-valid"
-    client_repos = _clone_and_revert_client_repositories(
-        repositories, origin_dir, client_dir, 3
-    )
-    # update without setting the last validated commit
-    # update should start from the beginning and be successful
-    _update_and_check_commit_shas(
-        OperationType.UPDATE, client_repos, repositories, origin_dir, client_dir
-    )
+#     _update_invalid_repos_and_check_if_repos_exist(
+#         OperationType.CLONE,
+#         client_dir,
+#         repositories,
+#         expected_error,
+#         expect_partial_update,
+#         auth_repo_name_exists=auth_repo_name_exists,
+#     )
+#     # make sure that the last validated commit does not exist
+#     _check_if_last_validated_commit_exists(
+#         clients_auth_repo_path, should_last_validated_exist
+#     )
 
 
-def test_older_last_validated_commit(updater_repositories, origin_dir, client_dir):
-    # clone the origin repositories
-    # revert them to an older commit
-    repositories = updater_repositories["test-updater-valid"]
-    origin_dir = origin_dir / "test-updater-valid"
-    client_repos = _clone_and_revert_client_repositories(
-        repositories, origin_dir, client_dir, 3
-    )
-    all_commits = client_repos[AUTH_REPO_REL_PATH].all_commits_on_branch()
-    first_commit = all_commits[0]
-
-    _create_last_validated_commit(client_dir, first_commit)
-    # try to update without setting the last validated commit
-    _update_and_check_commit_shas(
-        OperationType.UPDATE, client_repos, repositories, origin_dir, client_dir
-    )
-
-
-def test_update_test_repo_no_flag(updater_repositories, origin_dir, client_dir):
-    repositories = updater_repositories["test-updater-test-repo"]
-    origin_dir = origin_dir / "test-updater-test-repo"
-    # try to update a test repo, set update type to official
-    _update_invalid_repos_and_check_if_repos_exist(
-        OperationType.CLONE,
-        client_dir,
-        repositories,
-        IS_A_TEST_REPO,
-        False,
-        UpdateType.OFFICIAL,
-    )
+# @pytest.mark.parametrize(
+#     "test_name, expected_error",
+#     [
+#         ("test-updater-invalid-target-sha", TARGET_MISSMATCH_PATTERN),
+#         ("test-updater-missing-target-commit", TARGET_MISSING_COMMIT_PATTERN),
+#     ],
+# )
+# def test_valid_update_no_auth_repo_one_invalid_target_repo_exists(
+#     test_name, expected_error, updater_repositories, client_dir, origin_dir
+# ):
+#     repositories = updater_repositories[test_name]
+#     clients_auth_repo_path = client_dir / AUTH_REPO_REL_PATH
+#     origin_dir = origin_dir / test_name
+#     _clone_client_repo(TARGET_REPO_REL_PATH, origin_dir, client_dir)
+#     _update_invalid_repos_and_check_if_repos_exist(
+#         OperationType.CLONE, client_dir, repositories, expected_error, True
+#     )
+#     # make sure that the last validated commit does not exist
+#     _check_if_last_validated_commit_exists(clients_auth_repo_path, True)
 
 
-def test_update_repo_wrong_flag(updater_repositories, origin_dir, client_dir):
-    repositories = updater_repositories["test-updater-valid"]
-    origin_dir = origin_dir / "test-updater-valid"
-    # try to update without setting the last validated commit
-    _update_invalid_repos_and_check_if_repos_exist(
-        OperationType.CLONE,
-        client_dir,
-        repositories,
-        NOT_A_TEST_REPO,
-        False,
-        UpdateType.TEST,
-    )
+# def test_updater_expired_metadata(updater_repositories, origin_dir, client_dir):
+#     # tuf patch state is shared between tests
+#     # so we manually revert to original tuf implementation
+#     trusted_metadata_set.TrustedMetadataSet = original_tuf_trusted_metadata_set
+
+#     # without using freeze_time, we expect to get metadata expired error
+#     repositories = updater_repositories["test-updater-expired-metadata"]
+#     clients_auth_repo_path = client_dir / AUTH_REPO_REL_PATH
+#     _update_invalid_repos_and_check_if_repos_exist(
+#         OperationType.CLONE,
+#         client_dir,
+#         repositories,
+#         ROOT_EXPIRED,
+#         True,
+#         set_time=False,
+#         strict=True,
+#     )
+#     # make sure that the last validated commit does not exist
+#     _check_if_last_validated_commit_exists(clients_auth_repo_path, True)
 
 
-def test_update_repo_target_in_indeterminate_state(
-    updater_repositories, origin_dir, client_dir
-):
-    repositories = updater_repositories[
-        "test-updater-target-repository-has-indeterminate-state"
-    ]
-    origin_dir = origin_dir / "test-updater-target-repository-has-indeterminate-state"
+# @pytest.mark.parametrize(
+#     "test_name, num_of_commits_to_revert, expected_error",
+#     [
+#         ("test-updater-invalid-target-sha", 1, TARGET_MISSMATCH_PATTERN),
+#         ("test-updater-delegated-roles-wrong-sha", 4, TARGET_MISSMATCH_PATTERN),
+#     ],
+# )
+# def test_updater_invalid_target_sha_existing_client_repos(
+#     test_name,
+#     num_of_commits_to_revert,
+#     expected_error,
+#     updater_repositories,
+#     origin_dir,
+#     client_dir,
+# ):
+#     repositories = updater_repositories[test_name]
+#     clients_auth_repo_path = client_dir / AUTH_REPO_REL_PATH
+#     origin_dir = origin_dir / test_name
+#     client_repos = _clone_and_revert_client_repositories(
+#         repositories, origin_dir, client_dir, num_of_commits_to_revert
+#     )
+#     _create_last_validated_commit(
+#         client_dir, client_repos[AUTH_REPO_REL_PATH].head_commit_sha()
+#     )
+#     _update_invalid_repos_and_check_if_remained_same(
+#         client_repos, client_dir, repositories, expected_error
+#     )
+#     _check_last_validated_commit(clients_auth_repo_path)
 
-    targets_repo_path = client_dir / TARGET_REPO_REL_PATH
 
-    _update_and_check_commit_shas(
-        OperationType.CLONE,
-        None,
-        repositories,
-        origin_dir,
-        client_dir,
-        UpdateType.OFFICIAL,
-    )
-    # Create an `index.lock` file, indicating that an incomplete git operation took place
-    # index.lock is created by git when a git operation is interrupted.
-    index_lock = Path(targets_repo_path, ".git", "index.lock")
-    index_lock.touch()
+# def test_no_target_repositories(updater_repositories, origin_dir, client_dir):
+#     repositories = updater_repositories["test-updater-valid"]
+#     origin_dir = origin_dir / "test-updater-valid"
+#     client_auth_repo = _clone_client_repo(AUTH_REPO_REL_PATH, origin_dir, client_dir)
+#     _create_last_validated_commit(client_dir, client_auth_repo.head_commit_sha())
+#     _update_and_check_commit_shas(
+#         OperationType.UPDATE, None, repositories, origin_dir, client_dir, False
+#     )
 
-    _update_invalid_repos_and_check_if_repos_exist(
-        OperationType.UPDATE, client_dir, repositories, NOT_CLEAN_PATTERN, True
-    )
+
+# def test_no_last_validated_commit(updater_repositories, origin_dir, client_dir):
+#     # clone the origin repositories
+#     # revert them to an older commit
+#     repositories = updater_repositories["test-updater-valid"]
+#     origin_dir = origin_dir / "test-updater-valid"
+#     client_repos = _clone_and_revert_client_repositories(
+#         repositories, origin_dir, client_dir, 3
+#     )
+#     # update without setting the last validated commit
+#     # update should start from the beginning and be successful
+#     _update_and_check_commit_shas(
+#         OperationType.UPDATE, client_repos, repositories, origin_dir, client_dir
+#     )
+
+
+# def test_older_last_validated_commit(updater_repositories, origin_dir, client_dir):
+#     # clone the origin repositories
+#     # revert them to an older commit
+#     repositories = updater_repositories["test-updater-valid"]
+#     origin_dir = origin_dir / "test-updater-valid"
+#     client_repos = _clone_and_revert_client_repositories(
+#         repositories, origin_dir, client_dir, 3
+#     )
+#     all_commits = client_repos[AUTH_REPO_REL_PATH].all_commits_on_branch()
+#     first_commit = all_commits[0]
+
+#     _create_last_validated_commit(client_dir, first_commit)
+#     # try to update without setting the last validated commit
+#     _update_and_check_commit_shas(
+#         OperationType.UPDATE, client_repos, repositories, origin_dir, client_dir
+#     )
+
+
+# def test_update_test_repo_no_flag(updater_repositories, origin_dir, client_dir):
+#     repositories = updater_repositories["test-updater-test-repo"]
+#     origin_dir = origin_dir / "test-updater-test-repo"
+#     # try to update a test repo, set update type to official
+#     _update_invalid_repos_and_check_if_repos_exist(
+#         OperationType.CLONE,
+#         client_dir,
+#         repositories,
+#         IS_A_TEST_REPO,
+#         False,
+#         UpdateType.OFFICIAL,
+#     )
+
+
+# def test_update_repo_wrong_flag(updater_repositories, origin_dir, client_dir):
+#     repositories = updater_repositories["test-updater-valid"]
+#     origin_dir = origin_dir / "test-updater-valid"
+#     # try to update without setting the last validated commit
+#     _update_invalid_repos_and_check_if_repos_exist(
+#         OperationType.CLONE,
+#         client_dir,
+#         repositories,
+#         NOT_A_TEST_REPO,
+#         False,
+#         UpdateType.TEST,
+#     )
+
+
+# def test_update_repo_target_in_indeterminate_state(
+#     updater_repositories, origin_dir, client_dir
+# ):
+#     repositories = updater_repositories[
+#         "test-updater-target-repository-has-indeterminate-state"
+#     ]
+#     origin_dir = origin_dir / "test-updater-target-repository-has-indeterminate-state"
+
+#     targets_repo_path = client_dir / TARGET_REPO_REL_PATH
+
+#     _update_and_check_commit_shas(
+#         OperationType.CLONE,
+#         None,
+#         repositories,
+#         origin_dir,
+#         client_dir,
+#         UpdateType.OFFICIAL,
+#     )
+#     # Create an `index.lock` file, indicating that an incomplete git operation took place
+#     # index.lock is created by git when a git operation is interrupted.
+#     index_lock = Path(targets_repo_path, ".git", "index.lock")
+#     index_lock.touch()
+
+#     _update_invalid_repos_and_check_if_repos_exist(
+#         OperationType.UPDATE, client_dir, repositories, NOT_CLEAN_PATTERN, True
+#     )
 
 
 def _check_last_validated_commit(clients_auth_repo_path):

--- a/taf/tests/test_updater/test_repo_update/test_updater.py
+++ b/taf/tests/test_updater/test_repo_update/test_updater.py
@@ -114,396 +114,408 @@ def run_around_tests(client_dir):
         for dir_name in dirs:
             shutil.rmtree(str(Path(root) / dir_name), onerror=on_rm_error)
 
-def test_something(library_with_dependencies):
-    assert library_with_dependencies['namespace1/auth']
 
-# @pytest.mark.parametrize(
-#     "test_name, test_repo, auth_repo_name_exists",
-#     [
-#         ("test-updater-valid", UpdateType.OFFICIAL, True),
-#         ("test-updater-valid", UpdateType.OFFICIAL, False),
-#         ("test-updater-valid-with-updated-expiration-dates", UpdateType.OFFICIAL, True),
-#         ("test-updater-allow-unauthenticated-commits", UpdateType.OFFICIAL, True),
-#         ("test-updater-test-repo", UpdateType.TEST, True),
-#         ("test-updater-multiple-branches", UpdateType.OFFICIAL, True),
-#         ("test-updater-delegated-roles", UpdateType.OFFICIAL, True),
-#         ("test-updater-updated-root", UpdateType.OFFICIAL, True),
-#         ("test-updater-updated-root-old-snapshot", UpdateType.OFFICIAL, True),
-#         ("test-updater-updated-root-version-skipped", UpdateType.OFFICIAL, True),
-#         ("test-updater-updated-root-version-skipped", UpdateType.OFFICIAL, True),
-#         ("test-updater-expired-metadata", UpdateType.OFFICIAL, True),
-#     ],
-# )
-# def test_valid_update_no_client_repo(
-#     test_name,
-#     test_repo,
-#     auth_repo_name_exists,
-#     updater_repositories,
-#     origin_dir,
-#     client_dir,
-# ):
-#     repositories = updater_repositories[test_name]
-#     origin_dir = origin_dir / test_name
-#     _update_and_check_commit_shas(
-#         OperationType.CLONE,
-#         None,
-#         repositories,
-#         origin_dir,
-#         client_dir,
-#         test_repo,
-#         auth_repo_name_exists,
-#     )
+@pytest.mark.parametrize(
+    "test_name, test_repo, auth_repo_name_exists",
+    [
+        ("test-updater-valid", UpdateType.OFFICIAL, True),
+        ("test-updater-valid", UpdateType.OFFICIAL, False),
+        ("test-updater-valid-with-updated-expiration-dates", UpdateType.OFFICIAL, True),
+        ("test-updater-allow-unauthenticated-commits", UpdateType.OFFICIAL, True),
+        ("test-updater-test-repo", UpdateType.TEST, True),
+        ("test-updater-multiple-branches", UpdateType.OFFICIAL, True),
+        ("test-updater-delegated-roles", UpdateType.OFFICIAL, True),
+        ("test-updater-updated-root", UpdateType.OFFICIAL, True),
+        ("test-updater-updated-root-old-snapshot", UpdateType.OFFICIAL, True),
+        ("test-updater-updated-root-version-skipped", UpdateType.OFFICIAL, True),
+        ("test-updater-updated-root-version-skipped", UpdateType.OFFICIAL, True),
+        ("test-updater-expired-metadata", UpdateType.OFFICIAL, True),
+    ],
+)
+def test_valid_update_no_client_repo(
+    test_name,
+    test_repo,
+    auth_repo_name_exists,
+    updater_repositories,
+    origin_dir,
+    client_dir,
+):
+    repositories = updater_repositories[test_name]
+    origin_dir = origin_dir / test_name
+    _update_and_check_commit_shas(
+        OperationType.CLONE,
+        None,
+        repositories,
+        origin_dir,
+        client_dir,
+        test_repo,
+        auth_repo_name_exists,
+    )
 
 
+def test_excluded_targets_update_no_client_repo(
+    updater_repositories,
+    origin_dir,
+    client_dir,
+):
+    repositories = updater_repositories["test-updater-valid"]
+    origin_dir = origin_dir / "test-updater-valid"
+    excluded_target_globs = ["*/TargetRepo1"]
+    _update_and_check_commit_shas(
+        OperationType.CLONE,
+        None,
+        repositories,
+        origin_dir,
+        client_dir,
+        UpdateType.OFFICIAL,
+        True,
+        excluded_target_globs,
+    )
+    for repository_rel_path in repositories:
+        for excluded_target_glob in excluded_target_globs:
+            if fnmatch.fnmatch(repository_rel_path, excluded_target_glob):
+                assert not Path(client_dir, repository_rel_path).is_dir()
+                break
 
 
-# def test_excluded_targets_update_no_client_repo(
-#     updater_repositories,
-#     origin_dir,
-#     client_dir,
-# ):
-#     repositories = updater_repositories["test-updater-valid"]
-#     origin_dir = origin_dir / "test-updater-valid"
-#     excluded_target_globs = ["*/TargetRepo1"]
-#     _update_and_check_commit_shas(
-#         OperationType.CLONE,
-#         None,
-#         repositories,
-#         origin_dir,
-#         client_dir,
-#         UpdateType.OFFICIAL,
-#         True,
-#         excluded_target_globs,
-#     )
-#     for repository_rel_path in repositories:
-#         for excluded_target_glob in excluded_target_globs:
-#             if fnmatch.fnmatch(repository_rel_path, excluded_target_glob):
-#                 assert not Path(client_dir, repository_rel_path).is_dir()
-#                 break
+@pytest.mark.parametrize(
+    "test_name, test_repo",
+    [
+        ("test-updater-valid", UpdateType.OFFICIAL),
+        ("test-updater-allow-unauthenticated-commits", UpdateType.OFFICIAL),
+        ("test-updater-multiple-branches", UpdateType.OFFICIAL),
+        ("test-updater-delegated-roles", UpdateType.OFFICIAL),
+    ],
+)
+def test_valid_update_no_auth_repo_one_target_repo_exists(
+    test_name, test_repo, updater_repositories, origin_dir, client_dir
+):
+    repositories = updater_repositories[test_name]
+    origin_dir = origin_dir / test_name
+    _clone_client_repo(TARGET_REPO_REL_PATH, origin_dir, client_dir)
+    _update_and_check_commit_shas(
+        OperationType.CLONE, None, repositories, origin_dir, client_dir, test_repo
+    )
 
 
-# @pytest.mark.parametrize(
-#     "test_name, test_repo",
-#     [
-#         ("test-updater-valid", UpdateType.OFFICIAL),
-#         ("test-updater-allow-unauthenticated-commits", UpdateType.OFFICIAL),
-#         ("test-updater-multiple-branches", UpdateType.OFFICIAL),
-#         ("test-updater-delegated-roles", UpdateType.OFFICIAL),
-#     ],
-# )
-# def test_valid_update_no_auth_repo_one_target_repo_exists(
-#     test_name, test_repo, updater_repositories, origin_dir, client_dir
-# ):
-#     repositories = updater_repositories[test_name]
-#     origin_dir = origin_dir / test_name
-#     _clone_client_repo(TARGET_REPO_REL_PATH, origin_dir, client_dir)
-#     _update_and_check_commit_shas(
-#         OperationType.CLONE, None, repositories, origin_dir, client_dir, test_repo
-#     )
+@pytest.mark.parametrize(
+    "test_name, num_of_commits_to_revert",
+    [
+        ("test-updater-valid", 3),
+        ("test-updater-allow-unauthenticated-commits", 1),
+        ("test-updater-multiple-branches", 5),
+        ("test-updater-delegated-roles", 1),
+        ("test-updater-updated-root", 1),
+        ("test-updater-updated-root-old-snapshot", 1),
+        ("test-updater-updated-root-version-skipped", 1),
+    ],
+)
+def test_valid_update_existing_client_repos(
+    test_name, num_of_commits_to_revert, updater_repositories, origin_dir, client_dir
+):
+    # clone the origin repositories
+    # revert them to an older commit
+    repositories = updater_repositories[test_name]
+    origin_dir = origin_dir / test_name
+    client_repos = _clone_and_revert_client_repositories(
+        repositories, origin_dir, client_dir, num_of_commits_to_revert
+    )
+    # create valid last validated commit file
+    _create_last_validated_commit(
+        client_dir, client_repos[AUTH_REPO_REL_PATH].head_commit_sha()
+    )
+    _update_and_check_commit_shas(
+        OperationType.UPDATE, client_repos, repositories, origin_dir, client_dir
+    )
 
 
-# @pytest.mark.parametrize(
-#     "test_name, num_of_commits_to_revert",
-#     [
-#         ("test-updater-valid", 3),
-#         ("test-updater-allow-unauthenticated-commits", 1),
-#         ("test-updater-multiple-branches", 5),
-#         ("test-updater-delegated-roles", 1),
-#         ("test-updater-updated-root", 1),
-#         ("test-updater-updated-root-old-snapshot", 1),
-#         ("test-updater-updated-root-version-skipped", 1),
-#     ],
-# )
-# def test_valid_update_existing_client_repos(
-#     test_name, num_of_commits_to_revert, updater_repositories, origin_dir, client_dir
-# ):
-#     # clone the origin repositories
-#     # revert them to an older commit
-#     repositories = updater_repositories[test_name]
-#     origin_dir = origin_dir / test_name
-#     client_repos = _clone_and_revert_client_repositories(
-#         repositories, origin_dir, client_dir, num_of_commits_to_revert
-#     )
-#     # create valid last validated commit file
-#     _create_last_validated_commit(
-#         client_dir, client_repos[AUTH_REPO_REL_PATH].head_commit_sha()
-#     )
-#     _update_and_check_commit_shas(
-#         OperationType.UPDATE, client_repos, repositories, origin_dir, client_dir
-#     )
+@pytest.mark.parametrize(
+    "test_name, test_repo",
+    [
+        ("test-updater-valid", UpdateType.OFFICIAL),
+        ("test-updater-allow-unauthenticated-commits", UpdateType.OFFICIAL),
+        ("test-updater-test-repo", UpdateType.TEST),
+        ("test-updater-multiple-branches", UpdateType.OFFICIAL),
+        ("test-updater-delegated-roles", UpdateType.OFFICIAL),
+    ],
+)
+def test_no_update_necessary(
+    test_name, test_repo, updater_repositories, origin_dir, client_dir
+):
+    # clone the origin repositories
+    # revert them to an older commit
+    repositories = updater_repositories[test_name]
+    origin_dir = origin_dir / test_name
+    client_repos = _clone_client_repositories(repositories, origin_dir, client_dir)
+    # create valid last validated commit file
+    _create_last_validated_commit(
+        client_dir, client_repos[AUTH_REPO_REL_PATH].head_commit_sha()
+    )
+    _update_and_check_commit_shas(
+        OperationType.UPDATE,
+        client_repos,
+        repositories,
+        origin_dir,
+        client_dir,
+        test_repo,
+    )
 
 
-# @pytest.mark.parametrize(
-#     "test_name, test_repo",
-#     [
-#         ("test-updater-valid", UpdateType.OFFICIAL),
-#         ("test-updater-allow-unauthenticated-commits", UpdateType.OFFICIAL),
-#         ("test-updater-test-repo", UpdateType.TEST),
-#         ("test-updater-multiple-branches", UpdateType.OFFICIAL),
-#         ("test-updater-delegated-roles", UpdateType.OFFICIAL),
-#     ],
-# )
-# def test_no_update_necessary(
-#     test_name, test_repo, updater_repositories, origin_dir, client_dir
-# ):
-#     # clone the origin repositories
-#     # revert them to an older commit
-#     repositories = updater_repositories[test_name]
-#     origin_dir = origin_dir / test_name
-#     client_repos = _clone_client_repositories(repositories, origin_dir, client_dir)
-#     # create valid last validated commit file
-#     _create_last_validated_commit(
-#         client_dir, client_repos[AUTH_REPO_REL_PATH].head_commit_sha()
-#     )
-#     _update_and_check_commit_shas(
-#         OperationType.UPDATE,
-#         client_repos,
-#         repositories,
-#         origin_dir,
-#         client_dir,
-#         test_repo,
-#     )
+@pytest.mark.parametrize(
+    "test_name, expected_error, auth_repo_name_exists, expect_partial_update, should_last_validated_exist",
+    [
+        ("test-updater-invalid-target-sha", TARGET_MISSMATCH_PATTERN, True, True, True),
+        (
+            "test-updater-additional-target-commit",
+            TARGET_COMMIT_AFTER_LAST_VALIDATED_PATTERN,
+            True,
+            True,
+            True,
+        ),
+        (
+            "test-updater-missing-target-commit",
+            TARGET_ADDITIONAL_COMMIT_PATTERN,
+            True,
+            True,
+            True,
+        ),
+        ("test-updater-wrong-key", INVALID_KEYS_PATTERN, True, True, True),
+        ("test-updater-invalid-version-number", REPLAYED_METADATA, True, True, True),
+        (
+            "test-updater-delegated-roles-wrong-sha",
+            TARGET_MISSMATCH_PATTERN,
+            True,
+            True,
+            True,
+        ),
+        (
+            "test-updater-updated-root-invalid-metadata",
+            INVALID_KEYS_PATTERN,
+            True,
+            True,
+            True,
+        ),
+        ("test-updater-info-missing", NO_REPOSITORY_INFO_JSON, False, True, False),
+        (
+            "test-updater-invalid-snapshot-meta-field-missing",
+            METADATA_FIELD_MISSING,
+            False,
+            True,
+            True,
+        ),
+    ],
+)
+def test_updater_invalid_update(
+    test_name,
+    expected_error,
+    auth_repo_name_exists,
+    updater_repositories,
+    client_dir,
+    expect_partial_update,
+    should_last_validated_exist,
+):
+    repositories = updater_repositories[test_name]
+    clients_auth_repo_path = client_dir / AUTH_REPO_REL_PATH
+
+    _update_invalid_repos_and_check_if_repos_exist(
+        OperationType.CLONE,
+        client_dir,
+        repositories,
+        expected_error,
+        expect_partial_update,
+        auth_repo_name_exists=auth_repo_name_exists,
+    )
+    # make sure that the last validated commit does not exist
+    _check_if_last_validated_commit_exists(
+        clients_auth_repo_path, should_last_validated_exist
+    )
 
 
-# @pytest.mark.parametrize(
-#     "test_name, expected_error, auth_repo_name_exists, expect_partial_update, should_last_validated_exist",
-#     [
-#         ("test-updater-invalid-target-sha", TARGET_MISSMATCH_PATTERN, True, True, True),
-#         (
-#             "test-updater-additional-target-commit",
-#             TARGET_COMMIT_AFTER_LAST_VALIDATED_PATTERN,
-#             True,
-#             True,
-#             True,
-#         ),
-#         (
-#             "test-updater-missing-target-commit",
-#             TARGET_ADDITIONAL_COMMIT_PATTERN,
-#             True,
-#             True,
-#             True,
-#         ),
-#         ("test-updater-wrong-key", INVALID_KEYS_PATTERN, True, True, True),
-#         ("test-updater-invalid-version-number", REPLAYED_METADATA, True, True, True),
-#         (
-#             "test-updater-delegated-roles-wrong-sha",
-#             TARGET_MISSMATCH_PATTERN,
-#             True,
-#             True,
-#             True,
-#         ),
-#         (
-#             "test-updater-updated-root-invalid-metadata",
-#             INVALID_KEYS_PATTERN,
-#             True,
-#             True,
-#             True,
-#         ),
-#         ("test-updater-info-missing", NO_REPOSITORY_INFO_JSON, False, True, False),
-#         (
-#             "test-updater-invalid-snapshot-meta-field-missing",
-#             METADATA_FIELD_MISSING,
-#             False,
-#             True,
-#             True,
-#         ),
-#     ],
-# )
-# def test_updater_invalid_update(
-#     test_name,
-#     expected_error,
-#     auth_repo_name_exists,
-#     updater_repositories,
-#     client_dir,
-#     expect_partial_update,
-#     should_last_validated_exist,
-# ):
-#     repositories = updater_repositories[test_name]
-#     clients_auth_repo_path = client_dir / AUTH_REPO_REL_PATH
-
-#     _update_invalid_repos_and_check_if_repos_exist(
-#         OperationType.CLONE,
-#         client_dir,
-#         repositories,
-#         expected_error,
-#         expect_partial_update,
-#         auth_repo_name_exists=auth_repo_name_exists,
-#     )
-#     # make sure that the last validated commit does not exist
-#     _check_if_last_validated_commit_exists(
-#         clients_auth_repo_path, should_last_validated_exist
-#     )
+@pytest.mark.parametrize(
+    "test_name, expected_error",
+    [
+        ("test-updater-invalid-target-sha", TARGET_MISSMATCH_PATTERN),
+        ("test-updater-missing-target-commit", TARGET_MISSING_COMMIT_PATTERN),
+    ],
+)
+def test_valid_update_no_auth_repo_one_invalid_target_repo_exists(
+    test_name, expected_error, updater_repositories, client_dir, origin_dir
+):
+    repositories = updater_repositories[test_name]
+    clients_auth_repo_path = client_dir / AUTH_REPO_REL_PATH
+    origin_dir = origin_dir / test_name
+    _clone_client_repo(TARGET_REPO_REL_PATH, origin_dir, client_dir)
+    _update_invalid_repos_and_check_if_repos_exist(
+        OperationType.CLONE, client_dir, repositories, expected_error, True
+    )
+    # make sure that the last validated commit does not exist
+    _check_if_last_validated_commit_exists(clients_auth_repo_path, True)
 
 
-# @pytest.mark.parametrize(
-#     "test_name, expected_error",
-#     [
-#         ("test-updater-invalid-target-sha", TARGET_MISSMATCH_PATTERN),
-#         ("test-updater-missing-target-commit", TARGET_MISSING_COMMIT_PATTERN),
-#     ],
-# )
-# def test_valid_update_no_auth_repo_one_invalid_target_repo_exists(
-#     test_name, expected_error, updater_repositories, client_dir, origin_dir
-# ):
-#     repositories = updater_repositories[test_name]
-#     clients_auth_repo_path = client_dir / AUTH_REPO_REL_PATH
-#     origin_dir = origin_dir / test_name
-#     _clone_client_repo(TARGET_REPO_REL_PATH, origin_dir, client_dir)
-#     _update_invalid_repos_and_check_if_repos_exist(
-#         OperationType.CLONE, client_dir, repositories, expected_error, True
-#     )
-#     # make sure that the last validated commit does not exist
-#     _check_if_last_validated_commit_exists(clients_auth_repo_path, True)
+def test_updater_expired_metadata(updater_repositories, origin_dir, client_dir):
+    # tuf patch state is shared between tests
+    # so we manually revert to original tuf implementation
+    trusted_metadata_set.TrustedMetadataSet = original_tuf_trusted_metadata_set
+
+    # without using freeze_time, we expect to get metadata expired error
+    repositories = updater_repositories["test-updater-expired-metadata"]
+    clients_auth_repo_path = client_dir / AUTH_REPO_REL_PATH
+    _update_invalid_repos_and_check_if_repos_exist(
+        OperationType.CLONE,
+        client_dir,
+        repositories,
+        ROOT_EXPIRED,
+        True,
+        set_time=False,
+        strict=True,
+    )
+    # make sure that the last validated commit does not exist
+    _check_if_last_validated_commit_exists(clients_auth_repo_path, True)
 
 
-# def test_updater_expired_metadata(updater_repositories, origin_dir, client_dir):
-#     # tuf patch state is shared between tests
-#     # so we manually revert to original tuf implementation
-#     trusted_metadata_set.TrustedMetadataSet = original_tuf_trusted_metadata_set
-
-#     # without using freeze_time, we expect to get metadata expired error
-#     repositories = updater_repositories["test-updater-expired-metadata"]
-#     clients_auth_repo_path = client_dir / AUTH_REPO_REL_PATH
-#     _update_invalid_repos_and_check_if_repos_exist(
-#         OperationType.CLONE,
-#         client_dir,
-#         repositories,
-#         ROOT_EXPIRED,
-#         True,
-#         set_time=False,
-#         strict=True,
-#     )
-#     # make sure that the last validated commit does not exist
-#     _check_if_last_validated_commit_exists(clients_auth_repo_path, True)
-
-
-# @pytest.mark.parametrize(
-#     "test_name, num_of_commits_to_revert, expected_error",
-#     [
-#         ("test-updater-invalid-target-sha", 1, TARGET_MISSMATCH_PATTERN),
-#         ("test-updater-delegated-roles-wrong-sha", 4, TARGET_MISSMATCH_PATTERN),
-#     ],
-# )
-# def test_updater_invalid_target_sha_existing_client_repos(
-#     test_name,
-#     num_of_commits_to_revert,
-#     expected_error,
-#     updater_repositories,
-#     origin_dir,
-#     client_dir,
-# ):
-#     repositories = updater_repositories[test_name]
-#     clients_auth_repo_path = client_dir / AUTH_REPO_REL_PATH
-#     origin_dir = origin_dir / test_name
-#     client_repos = _clone_and_revert_client_repositories(
-#         repositories, origin_dir, client_dir, num_of_commits_to_revert
-#     )
-#     _create_last_validated_commit(
-#         client_dir, client_repos[AUTH_REPO_REL_PATH].head_commit_sha()
-#     )
-#     _update_invalid_repos_and_check_if_remained_same(
-#         client_repos, client_dir, repositories, expected_error
-#     )
-#     _check_last_validated_commit(clients_auth_repo_path)
+@pytest.mark.parametrize(
+    "test_name, num_of_commits_to_revert, expected_error",
+    [
+        ("test-updater-invalid-target-sha", 1, TARGET_MISSMATCH_PATTERN),
+        ("test-updater-delegated-roles-wrong-sha", 4, TARGET_MISSMATCH_PATTERN),
+    ],
+)
+def test_updater_invalid_target_sha_existing_client_repos(
+    test_name,
+    num_of_commits_to_revert,
+    expected_error,
+    updater_repositories,
+    origin_dir,
+    client_dir,
+):
+    repositories = updater_repositories[test_name]
+    clients_auth_repo_path = client_dir / AUTH_REPO_REL_PATH
+    origin_dir = origin_dir / test_name
+    client_repos = _clone_and_revert_client_repositories(
+        repositories, origin_dir, client_dir, num_of_commits_to_revert
+    )
+    _create_last_validated_commit(
+        client_dir, client_repos[AUTH_REPO_REL_PATH].head_commit_sha()
+    )
+    _update_invalid_repos_and_check_if_remained_same(
+        client_repos, client_dir, repositories, expected_error
+    )
+    _check_last_validated_commit(clients_auth_repo_path)
 
 
-# def test_no_target_repositories(updater_repositories, origin_dir, client_dir):
-#     repositories = updater_repositories["test-updater-valid"]
-#     origin_dir = origin_dir / "test-updater-valid"
-#     client_auth_repo = _clone_client_repo(AUTH_REPO_REL_PATH, origin_dir, client_dir)
-#     _create_last_validated_commit(client_dir, client_auth_repo.head_commit_sha())
-#     _update_and_check_commit_shas(
-#         OperationType.UPDATE, None, repositories, origin_dir, client_dir, False
-#     )
+def test_no_target_repositories(updater_repositories, origin_dir, client_dir):
+    repositories = updater_repositories["test-updater-valid"]
+    origin_dir = origin_dir / "test-updater-valid"
+    client_auth_repo = _clone_client_repo(AUTH_REPO_REL_PATH, origin_dir, client_dir)
+    _create_last_validated_commit(client_dir, client_auth_repo.head_commit_sha())
+    _update_and_check_commit_shas(
+        OperationType.UPDATE, None, repositories, origin_dir, client_dir, False
+    )
 
 
-# def test_no_last_validated_commit(updater_repositories, origin_dir, client_dir):
-#     # clone the origin repositories
-#     # revert them to an older commit
-#     repositories = updater_repositories["test-updater-valid"]
-#     origin_dir = origin_dir / "test-updater-valid"
-#     client_repos = _clone_and_revert_client_repositories(
-#         repositories, origin_dir, client_dir, 3
-#     )
-#     # update without setting the last validated commit
-#     # update should start from the beginning and be successful
-#     _update_and_check_commit_shas(
-#         OperationType.UPDATE, client_repos, repositories, origin_dir, client_dir
-#     )
+def test_no_last_validated_commit(updater_repositories, origin_dir, client_dir):
+    # clone the origin repositories
+    # revert them to an older commit
+    repositories = updater_repositories["test-updater-valid"]
+    origin_dir = origin_dir / "test-updater-valid"
+    client_repos = _clone_and_revert_client_repositories(
+        repositories, origin_dir, client_dir, 3
+    )
+    # update without setting the last validated commit
+    # update should start from the beginning and be successful
+    _update_and_check_commit_shas(
+        OperationType.UPDATE, client_repos, repositories, origin_dir, client_dir
+    )
 
 
-# def test_older_last_validated_commit(updater_repositories, origin_dir, client_dir):
-#     # clone the origin repositories
-#     # revert them to an older commit
-#     repositories = updater_repositories["test-updater-valid"]
-#     origin_dir = origin_dir / "test-updater-valid"
-#     client_repos = _clone_and_revert_client_repositories(
-#         repositories, origin_dir, client_dir, 3
-#     )
-#     all_commits = client_repos[AUTH_REPO_REL_PATH].all_commits_on_branch()
-#     first_commit = all_commits[0]
+def test_older_last_validated_commit(updater_repositories, origin_dir, client_dir):
+    # clone the origin repositories
+    # revert them to an older commit
+    repositories = updater_repositories["test-updater-valid"]
+    origin_dir = origin_dir / "test-updater-valid"
+    client_repos = _clone_and_revert_client_repositories(
+        repositories, origin_dir, client_dir, 3
+    )
+    all_commits = client_repos[AUTH_REPO_REL_PATH].all_commits_on_branch()
+    first_commit = all_commits[0]
 
-#     _create_last_validated_commit(client_dir, first_commit)
-#     # try to update without setting the last validated commit
-#     _update_and_check_commit_shas(
-#         OperationType.UPDATE, client_repos, repositories, origin_dir, client_dir
-#     )
-
-
-# def test_update_test_repo_no_flag(updater_repositories, origin_dir, client_dir):
-#     repositories = updater_repositories["test-updater-test-repo"]
-#     origin_dir = origin_dir / "test-updater-test-repo"
-#     # try to update a test repo, set update type to official
-#     _update_invalid_repos_and_check_if_repos_exist(
-#         OperationType.CLONE,
-#         client_dir,
-#         repositories,
-#         IS_A_TEST_REPO,
-#         False,
-#         UpdateType.OFFICIAL,
-#     )
+    _create_last_validated_commit(client_dir, first_commit)
+    # try to update without setting the last validated commit
+    _update_and_check_commit_shas(
+        OperationType.UPDATE, client_repos, repositories, origin_dir, client_dir
+    )
 
 
-# def test_update_repo_wrong_flag(updater_repositories, origin_dir, client_dir):
-#     repositories = updater_repositories["test-updater-valid"]
-#     origin_dir = origin_dir / "test-updater-valid"
-#     # try to update without setting the last validated commit
-#     _update_invalid_repos_and_check_if_repos_exist(
-#         OperationType.CLONE,
-#         client_dir,
-#         repositories,
-#         NOT_A_TEST_REPO,
-#         False,
-#         UpdateType.TEST,
-#     )
+def test_update_test_repo_no_flag(updater_repositories, origin_dir, client_dir):
+    repositories = updater_repositories["test-updater-test-repo"]
+    origin_dir = origin_dir / "test-updater-test-repo"
+    # try to update a test repo, set update type to official
+    _update_invalid_repos_and_check_if_repos_exist(
+        OperationType.CLONE,
+        client_dir,
+        repositories,
+        IS_A_TEST_REPO,
+        False,
+        UpdateType.OFFICIAL,
+    )
 
 
-# def test_update_repo_target_in_indeterminate_state(
-#     updater_repositories, origin_dir, client_dir
-# ):
-#     repositories = updater_repositories[
-#         "test-updater-target-repository-has-indeterminate-state"
-#     ]
-#     origin_dir = origin_dir / "test-updater-target-repository-has-indeterminate-state"
+def test_update_repo_wrong_flag(updater_repositories, origin_dir, client_dir):
+    repositories = updater_repositories["test-updater-valid"]
+    origin_dir = origin_dir / "test-updater-valid"
+    # try to update without setting the last validated commit
+    _update_invalid_repos_and_check_if_repos_exist(
+        OperationType.CLONE,
+        client_dir,
+        repositories,
+        NOT_A_TEST_REPO,
+        False,
+        UpdateType.TEST,
+    )
 
-#     targets_repo_path = client_dir / TARGET_REPO_REL_PATH
 
-#     _update_and_check_commit_shas(
-#         OperationType.CLONE,
-#         None,
-#         repositories,
-#         origin_dir,
-#         client_dir,
-#         UpdateType.OFFICIAL,
-#     )
-#     # Create an `index.lock` file, indicating that an incomplete git operation took place
-#     # index.lock is created by git when a git operation is interrupted.
-#     index_lock = Path(targets_repo_path, ".git", "index.lock")
-#     index_lock.touch()
+def test_update_repo_target_in_indeterminate_state(
+    updater_repositories, origin_dir, client_dir
+):
+    repositories = updater_repositories[
+        "test-updater-target-repository-has-indeterminate-state"
+    ]
+    origin_dir = origin_dir / "test-updater-target-repository-has-indeterminate-state"
 
-#     _update_invalid_repos_and_check_if_repos_exist(
-#         OperationType.UPDATE, client_dir, repositories, NOT_CLEAN_PATTERN, True
-#     )
+    targets_repo_path = client_dir / TARGET_REPO_REL_PATH
+
+    _update_and_check_commit_shas(
+        OperationType.CLONE,
+        None,
+        repositories,
+        origin_dir,
+        client_dir,
+        UpdateType.OFFICIAL,
+    )
+    # Create an `index.lock` file, indicating that an incomplete git operation took place
+    # index.lock is created by git when a git operation is interrupted.
+    index_lock = Path(targets_repo_path, ".git", "index.lock")
+    index_lock.touch()
+
+    _update_invalid_repos_and_check_if_repos_exist(
+        OperationType.UPDATE, client_dir, repositories, NOT_CLEAN_PATTERN, True
+    )
+
+
+def test_update_repository_with_dependencies(
+    library_with_dependencies,
+    origin_dir,
+    client_dir,
+):
+    _update_full_library(
+        OperationType.CLONE,
+        library_with_dependencies,
+        origin_dir,
+        client_dir,
+        expected_repo_type=UpdateType.EITHER,
+        auth_repo_name_exists=True,
+        excluded_target_globs=None,
+    )
 
 
 def _check_last_validated_commit(clients_auth_repo_path):
@@ -679,6 +691,59 @@ def _update_and_check_commit_shas(
     )
     if not excluded_target_globs:
         _check_last_validated_commit(clients_auth_repo_path)
+
+
+def _update_full_library(
+    operation,
+    library_dict,
+    origin_dir,
+    client_dir,
+    expected_repo_type=UpdateType.EITHER,
+    auth_repo_name_exists=True,
+    excluded_target_globs=None,
+):
+
+    all_repositories = []
+    for repo_info in library_dict.values():
+        # Add the auth repository
+        all_repositories.append(repo_info["auth_repo"])
+        # Extend the list with all target repositories
+        all_repositories.extend(repo_info["target_repos"])
+
+    start_head_shas = defaultdict(dict)
+    for repo in all_repositories:
+        for branch in repo.branches():
+            start_head_shas[repo.name][branch] = repo.top_commit_of_branch(branch)
+
+    origin_root_repo = library_dict["root/auth"]["auth_repo"]
+    clients_auth_repo_path = client_dir / "root/auth"
+    # origin_auth_repo_path = repositories[AUTH_REPO_REL_PATH]
+
+    config = RepositoryConfig(
+        operation=operation,
+        url=str(origin_root_repo.path),
+        update_from_filesystem=True,
+        path=str(clients_auth_repo_path) if auth_repo_name_exists else None,
+        library_dir=str(client_dir),
+        expected_repo_type=expected_repo_type,
+        excluded_target_globs=excluded_target_globs,
+    )
+
+    with freeze_time(_get_valid_update_time(origin_root_repo.path)):
+        if operation == OperationType.CLONE:
+            clone_repository(config)
+        else:
+            update_repository(config)
+
+    repositories = {}
+    for auth_repo_name, repos in library_dict.items():
+        repositories[auth_repo_name] = repos["auth_repo"]
+        for target_repo in repos["target_repos"]:
+            repositories[target_repo.name] = target_repo
+        _check_last_validated_commit(client_dir / repos["auth_repo"].name)
+    _check_if_commits_match(
+        repositories, origin_dir, client_dir, start_head_shas, excluded_target_globs
+    )
 
 
 def _update_invalid_repos_and_check_if_remained_same(

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -337,6 +337,10 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                 self.state.event = (
                     Event.CHANGED
                     if len(self.state.auth_commits_since_last_validated) > 1
+                    or (
+                        self.operation == OperationType.CLONE
+                        and len(self.state.auth_commits_since_last_validated) == 1
+                    )
                     else Event.UNCHANGED
                 )
                 return UpdateStatus.SUCCESS


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

This test programmatically sets up repositories instead of adding a previously created repository with .git folder renamed to git
Also fixed a minor bug where update status was incorrectly being set in case when a repository with only one commit is cloned

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
