### PR TITLE
Add a command for adding delegated paths to a role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
+- Add a command for adding delegated paths to a role ([391])
 - Check if metadata files at revision match those downloaded by TUF updater ([389])
 
 ### Changed
 
 ### Fixed
 
+[391]: https://github.com/openlawlibrary/taf/pull/391
 [389]: https://github.com/openlawlibrary/taf/pull/389
 
 ## [0.29.1] - 02/07/2024

--- a/taf/tools/roles/__init__.py
+++ b/taf/tools/roles/__init__.py
@@ -4,6 +4,8 @@ from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
 from taf.exceptions import TAFError
 from taf.tools.cli import catch_cli_exception
 
+from taf.api.roles import add_role_paths as _add_role_paths
+
 
 def attach_to_group(group):
 
@@ -99,6 +101,35 @@ def attach_to_group(group):
             scheme=scheme,
             prompt_for_keys=prompt_for_keys,
             commit=not no_commit,
+        )
+
+    @roles.command()
+    @catch_cli_exception(handle=TAFError)
+    @click.argument("role")
+    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
+    @click.option("--delegated-path", multiple=True, help="Paths associated with the delegated role")
+    @click.option("--keystore", default=None, help="Location of the keystore files")
+    @click.option("--no-commit", is_flag=True, default=False, help="Indicates that the changes should not be "
+                  "committed automatically")
+    @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not "
+                  "located inside the keystore directory")
+    def add_role_paths(role, path, delegated_path, keystore, no_commit, prompt_for_keys):
+        """Add a new delegated target role, specifying which paths are delegated to the new role.
+        Its parent role, number of signing keys and signatures threshold can also be defined.
+        Update and sign all metadata files and commit.
+        """
+        if not delegated_path:
+            print("Specify at least one path")
+            return
+
+        _add_role_paths(
+            paths=delegated_path,
+            delegated_role=role,
+            keystore=keystore,
+            commit=not no_commit,
+            auth_path=path,
+            prompt_for_keys=prompt_for_keys,
+            push=not no_commit,
         )
 
     @roles.command()


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Invocation:

`taf roles add-role-paths rdf --delegated-path missing-path-1 --delegated-path missin-path-2 --keystore keystore-path`

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
