### PR TITLE
Improve merge commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- Only show merging commits messages if actually merging commits. Rework logic for checking if a commits should be merged (404)
+
+[404]: https://github.com/openlawlibrary/taf/pull/404
+
 ### Fixed
 
 ## [0.29.3] - 03/15/2024

--- a/taf/exceptions.py
+++ b/taf/exceptions.py
@@ -89,7 +89,14 @@ class RepositoryInstantiationError(TAFError):
 
 class RepositoryNotCleanError(TAFError):
     def __init__(self, repo_name: str):
-        message = f"Repository {repo_name} has uncommitted or unpushed changes. Commit and push or revert the changes and run the command again."
+        message = f"Repository {repo_name} has uncommitted changes. Commit and push or revert the changes and run the command again."
+        super().__init__(message)
+        self.message = message
+
+
+class UnpushedCommitsError(TAFError):
+    def __init__(self, repo_name: str, branch: str):
+        message = f"Repository {repo_name} has unpushed commits on branch {branch}. Push or revert the changes and run the command again."
         super().__init__(message)
         self.message = message
 

--- a/taf/exceptions.py
+++ b/taf/exceptions.py
@@ -89,7 +89,7 @@ class RepositoryInstantiationError(TAFError):
 
 class RepositoryNotCleanError(TAFError):
     def __init__(self, repo_name: str):
-        message = f"Repository {repo_name} has uncommitted changes. Commit or revert the changes and run the command again."
+        message = f"Repository {repo_name} has uncommitted or unpushed changes. Commit and push or revert the changes and run the command again."
         super().__init__(message)
         self.message = message
 

--- a/taf/git.py
+++ b/taf/git.py
@@ -338,6 +338,8 @@ class GitRepository:
             )
         if branch:
             branch_obj = repo.branches.get(branch)
+            if branch_obj is None:
+                return []
             latest_commit_id = branch_obj.target
         else:
             latest_commit_id = repo[repo.head.target].id

--- a/taf/git.py
+++ b/taf/git.py
@@ -752,7 +752,7 @@ class GitRepository:
             reraise_error=True,
         )
 
-    def check_if_unpushed_commits(self, branch_name):
+    def is_branch_with_unpushed_commits(self, branch_name):
         repo = self.pygit_repo
         if repo is None:
             raise GitError(

--- a/taf/git.py
+++ b/taf/git.py
@@ -763,7 +763,7 @@ class GitRepository:
         # Ensure the branch exists locally.
         local_branch_ref = f"refs/heads/{branch_name}"
         if local_branch_ref not in repo.references:
-            raise GitError("{branch_name} does not exsit")
+            return False
 
         # Ensure the branch has an upstream.
         try:
@@ -1366,6 +1366,14 @@ class GitRepository:
     def reset_to_commit(self, commit: str, hard: Optional[bool] = False) -> None:
         flag = "--hard" if hard else "--soft"
         self._git(f"reset {flag} {commit}")
+
+    def reset_remote_tracking_branch(self, branch_name) -> None:
+        """
+        Set top commit of origing/branch to the top comit of the local branch
+        Used while testing the updater
+        """
+        commit_sha = self.top_commit_of_branch(branch_name)
+        self._git(f"update-ref refs/remotes/origin/{branch_name} {commit_sha}")
 
     def reset_to_head(self) -> None:
         self._git("reset --hard HEAD")

--- a/taf/git.py
+++ b/taf/git.py
@@ -763,15 +763,14 @@ class GitRepository:
         # Ensure the branch exists locally.
         local_branch_ref = f"refs/heads/{branch_name}"
         if local_branch_ref not in repo.references:
-            print(f"Branch '{branch_name}' does not exist.")
-            return unpushed_commits
+            raise GitError("{branch_name} does not exsit")
 
         # Ensure the branch has an upstream.
         try:
             upstream_branch_ref = repo.lookup_branch(branch_name).upstream.name
         except ValueError:
-            print(f"Branch '{branch_name}' does not have an upstream set.")
-            return unpushed_commits
+            # not upstream yet
+            return True
 
         local_commit = repo.lookup_reference(local_branch_ref).peel(pygit2.Commit)
         remote_commit = repo.lookup_reference(upstream_branch_ref).peel(pygit2.Commit)

--- a/taf/tests/test_updater/test_repo_update/test_updater.py
+++ b/taf/tests/test_updater/test_repo_update/test_updater.py
@@ -596,6 +596,8 @@ def _clone_and_revert_client_repositories(
         AUTH_REPO_REL_PATH, origin_dir, client_dir, repo_class=AuthenticationRepository
     )
     client_auth_repo.reset_num_of_commits(num_of_commits, True)
+    client_auth_repo.reset_remote_tracking_branch(client_auth_repo.default_branch)
+
     client_repos[AUTH_REPO_REL_PATH] = client_auth_repo
     client_auth_commits = client_auth_repo.all_commits_on_branch()
 
@@ -619,6 +621,7 @@ def _clone_and_revert_client_repositories(
         if branch in branches_commits:
             client_repo.checkout_branch(branch)
             client_repo.reset_to_commit(commit, True)
+            client_repo.reset_remote_tracking_branch(branch)
 
         for branch in client_repo.branches():
             if branch not in branches_commits:

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -532,9 +532,7 @@ def _update_named_repository(
             # so set last validated commit to this last valid commit
             last_commit = commits[-1]
             # if there were no errors, merge the last validated authentication repository commit
-            _merge_commit(
-                auth_repo, auth_repo.default_branch, last_commit, checkout, True
-            )
+            _merge_commit(auth_repo, auth_repo.default_branch, last_commit, True)
             # update the last validated commit
             if not excluded_target_globs:
                 auth_repo.set_last_validated_commit(last_commit)

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -455,7 +455,12 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
     def check_if_local_auth_repo_clean(self):
         try:
             if self.state.existing_repo:
-                if self.state.users_auth_repo.something_to_commit():
+                if (
+                    self.state.users_auth_repo.something_to_commit()
+                    or self.state.users_auth_repo.check_if_unpushed_commits(
+                        self.state.users_auth_repo.default_branch
+                    )
+                ):
                     raise RepositoryNotCleanError(self.state.users_auth_repo.name)
         except Exception as e:
             self.state.errors.append(e)

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -462,7 +462,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
             if self.state.existing_repo:
                 if self.state.users_auth_repo.something_to_commit():
                     raise RepositoryNotCleanError(self.state.users_auth_repo.name)
-                if self.state.users_auth_repo.check_if_unpushed_commits(
+                if self.state.users_auth_repo.is_branch_with_unpushed_commits(
                     self.state.users_auth_repo.default_branch
                 ):
                     raise UnpushedCommitsError(
@@ -689,7 +689,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
             for branch in self.state.target_branches_data_from_auth_repo[
                 repository.name
             ]:
-                if repository.check_if_unpushed_commits(branch):
+                if repository.is_branch_with_unpushed_commits(branch):
                     raise UnpushedCommitsError(repository.name, branch)
 
     @log_on_start(DEBUG, "Fetching commits of target repositories", logger=taf_logger)


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

- Fix logic for determining if a commits should be merged
- Remove checkout option since we were always checking out the branch. After cloning, if a branch is not checked out, the index will end up being dirty, showing that the repository's content was removed. We could potentially avoid this checkout by checking if the repository was cloned and then make sure that nothing else fails without it. This can be done later.
- Only show "Merging commits" message  if commits are actually getting merged, and not always before and after that function is called

Closes #395

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
