### PR TITLE
Clone target repositories to temp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
+- Clone target repositories to temp ([412])
 - Add architecture overview documentation ([405])
 
-[405]: https://github.com/openlawlibrary/taf/pull/405)
+[412]: https://github.com/openlawlibrary/taf/pull/412
+[405]: https://github.com/openlawlibrary/taf/pull/405
 
 ### Changed
 

--- a/taf/git.py
+++ b/taf/git.py
@@ -644,7 +644,7 @@ class GitRepository:
             self.default_branch = self._determine_default_branch()
 
     def clone_from_disk(
-        self, local_path: Path, remote_url: str, is_bare: bool = False
+        self, local_path: Path, remote_url: Optional[str] = None, is_bare: bool = False
     ) -> None:
         self.path.mkdir(parents=True, exist_ok=True)
         pygit2.clone_repository(local_path, self.path, bare=is_bare)
@@ -656,11 +656,12 @@ class GitRepository:
                 "Cloning from disk could not be completed. pygit repo could not be instantiated"
             )
         self.remove_remote("origin")
-        self.add_remote("origin", remote_url)
-        self.fetch()
-        if repo is not None:
-            for branch in repo.branches.local:
-                self.set_upstream(str(branch))
+        if remote_url is not None:
+            self.add_remote("origin", remote_url)
+            self.fetch()
+            if repo is not None:
+                for branch in repo.branches.local:
+                    self.set_upstream(str(branch))
 
     def clone_or_pull(
         self,
@@ -1036,8 +1037,9 @@ class GitRepository:
         sort_key_func: Optional[Callable[[str], bool]] = None,
     ) -> Optional[str]:
         """
-        Fetches changes from a local repository on disk
-        and temporarily adds it as a remote to the current repository.
+        Fetches changes from a local repository on disk.
+        Temporarily adds it as a remote to the current repository
+        and removes that remote after the operation is completed.
         """
 
         branch_tips = {}

--- a/taf/git.py
+++ b/taf/git.py
@@ -642,6 +642,12 @@ class GitRepository:
         if self.default_branch is None:
             self.default_branch = self._determine_default_branch()
 
+    def clone_from_disk(self, local_path: Path):
+        urls_backup = list(self.urls)
+        self.urls = [str(local_path.resolve())]
+        self.clone()
+        self.urls = urls_backup
+
     def clone_or_pull(
         self,
         branches: Optional[List[str]] = None,

--- a/taf/git.py
+++ b/taf/git.py
@@ -652,8 +652,9 @@ class GitRepository:
         self.add_remote("origin", remote_url)
         self.fetch()
         repo = self.pygit_repo
-        for branch in repo.branches.local:
-            self.set_upstream(str(branch))
+        if repo is not None:
+            for branch in repo.branches.local:
+                self.set_upstream(str(branch))
 
     def clone_or_pull(
         self,

--- a/taf/git.py
+++ b/taf/git.py
@@ -643,11 +643,11 @@ class GitRepository:
         if self.default_branch is None:
             self.default_branch = self._determine_default_branch()
 
-    def clone_from_disk(self, local_path: Path, remote_url: str):
-        urls_backup = list(self.urls)
-        self.urls = [str(local_path.resolve())]
-        self.clone()
-        self.urls = urls_backup
+    def clone_from_disk(
+        self, local_path: Path, remote_url: str, is_bare_repository: bool = False
+    ) -> None:
+        self.path.mkdir(parents=True, exist_ok=True)
+        pygit2.clone_repository(local_path, self.path, bare=is_bare_repository)
         self.remove_remote("origin")
         self.add_remote("origin", remote_url)
         self.fetch()
@@ -1009,16 +1009,8 @@ class GitRepository:
         repo = self.pygit_repo
         temp_remote_name = f"temp_{uuid.uuid4().hex[:8]}"
         repo.remotes.create(temp_remote_name, local_repo_path)
-
-        # Fetch the main branch from the remote
         remote = repo.remotes[temp_remote_name]
         remote.fetch()
-
-        fetch_head_commit = repo.revparse_single("FETCH_HEAD")
-        import pdb
-
-        pdb.set_trace()
-        # Remove the temporary remote
         repo.remotes.delete(temp_remote_name)
 
     def find_worktree_path_by_branch(self, branch_name: str) -> Optional[Path]:

--- a/taf/git.py
+++ b/taf/git.py
@@ -1035,6 +1035,10 @@ class GitRepository:
         include_remotes: bool = False,
         sort_key_func: Optional[Callable[[str], bool]] = None,
     ) -> Optional[str]:
+        """
+        Fetches changes from a local repository on disk
+        and temporarily adds it as a remote to the current repository.
+        """
 
         branch_tips = {}
         repo: pygit2.Repository = self.pygit_repo

--- a/taf/tests/test_git/conftest.py
+++ b/taf/tests/test_git/conftest.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+import shutil
+from pytest import fixture
+from taf.git import GitRepository
+from taf.exceptions import NothingToCommitError
+from taf.utils import on_rm_error
+from taf.tests.conftest import TEST_DATA_REPOS_PATH
+
+
+TEST_DIR = Path(TEST_DATA_REPOS_PATH, "test-git")
+REPO_NAME = "repository"
+CLONE_REPO_NAME = "repository2"
+
+
+@fixture(scope="session", autouse=True)
+def repository():
+    path = TEST_DIR / REPO_NAME
+    path.mkdir(exist_ok=True, parents=True)
+    repo = GitRepository(path=path)
+    repo.init_repo()
+    (path / "test.txt").write_text("Some example text")
+    try:
+        repo.commit(message="Add test.txt")
+    except NothingToCommitError:
+        pass  # this can happen if cleanup was not successful
+    yield repo
+    repo.cleanup()
+    shutil.rmtree(path, onerror=on_rm_error)
+
+
+@fixture(scope="session", autouse=True)
+def clone_repository():
+    path = TEST_DIR / CLONE_REPO_NAME
+    path.mkdir(exist_ok=True, parents=True)
+    repo = GitRepository(path=path)
+    yield repo
+    repo.cleanup()
+    shutil.rmtree(path, onerror=on_rm_error)

--- a/taf/tests/test_git/test_git.py
+++ b/taf/tests/test_git/test_git.py
@@ -1,0 +1,9 @@
+from taf.git import GitRepository
+from taf.tests.test_git.conftest import TEST_DIR, CLONE_REPO_NAME
+
+
+def test_clone_from_local(repository, clone_repository):
+    clone_repository.clone_from_disk(repository.path)
+    assert clone_repository.is_git_repository
+    commits = clone_repository.all_commits_on_branch()
+    assert len(commits)

--- a/taf/tests/test_git/test_git.py
+++ b/taf/tests/test_git/test_git.py
@@ -1,7 +1,3 @@
-from taf.git import GitRepository
-from taf.tests.test_git.conftest import TEST_DIR, CLONE_REPO_NAME
-
-
 def test_clone_from_local(repository, clone_repository):
     clone_repository.clone_from_disk(repository.path)
     assert clone_repository.is_git_repository

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -519,16 +519,21 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                     self.state.auth_commits_since_last_validated[-1::],
                 )
             )
-            self.state.temp_target_repositories = {
-                repo.name: GitRepository(
-                    self.state.temp_dir.name,
-                    repo.name,
-                    urls=repo.urls,
-                    custom=repo.custom,
+            if self.only_validate:
+                self.state.temp_target_repositories = (
+                    self.state.users_target_repositories
                 )
-                for repo in self.state.users_target_repositories.values()
-            }
-            return UpdateStatus.SUCCESS
+            else:
+                self.state.temp_target_repositories = {
+                    repo.name: GitRepository(
+                        self.state.temp_dir.name,
+                        repo.name,
+                        urls=repo.urls,
+                        custom=repo.custom,
+                    )
+                    for repo in self.state.users_target_repositories.values()
+                }
+                return UpdateStatus.SUCCESS
         except Exception as e:
             self.state.errors.append(e)
             self.state.event = Event.FAILED

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -1061,8 +1061,6 @@ but commit not on branch {current_branch}"
 
     @log_on_start(DEBUG, "Removing temp repositories...", logger=taf_logger)
     def remove_temp_repositories(self):
-        print("removing temp repositories")
-        print(self.state.temp_dir)
         if not self.state.temp_dir:
             return self.state.update_status
         try:

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -62,9 +62,16 @@ class UpdateState:
     errors: Optional[List[Exception]] = field(default=None)
     targets_data: Dict[str, Any] = field(factory=dict)
     last_validated_commit: str = field(factory=str)
+    # repositories inside the temp folder which are created and cleaned up
+    # during the update process
     temp_target_repositories: Dict[str, "GitRepository"] = field(factory=dict)
+    # permanent repositories inside the user's local direcotry
     users_target_repositories: Dict[str, "GitRepository"] = field(factory=dict)
+    # a list of repositories which are already present inside a user's local
+    # directory when the update is started
     repos_on_disk: List[str] = field(factory=list)
+    # a list of repositories which are not present inside a user's local
+    # directory when the update is started
     repos_not_on_disk: List[str] = field(factory=list)
     target_branches_data_from_auth_repo: Dict = field(factory=dict)
     targets_data_by_auth_commits: Dict = field(factory=dict)

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -591,7 +591,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                     temp_repo.clone_from_disk(
                         users_repo.path,
                         users_repo.get_remote_url(),
-                        is_bare_repository=True,
+                        is_bare=True,
                     )
                     self.state.repos_on_disk.append(users_repo.name)
                 else:

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -1035,23 +1035,20 @@ but commit not on branch {current_branch}"
         DEBUG, "Copying or updating user's target repositories...", logger=taf_logger
     )
     def update_users_target_repositories(self):
-        def _clone_or_copy_from_disk(name, is_clone):
-            users_target_repo = self.state.users_target_repositories[name]
-            temp_target_repo = self.state.temp_target_repositories[name]
-            if is_clone:
-                users_target_repo.clone_from_disk(
-                    temp_target_repo.path, temp_target_repo.get_remote_url()
-                )
-            else:
-                users_target_repo.fetch_from_disk(temp_target_repo.path)
-
         if self.state.update_status == UpdateStatus.FAILED:
             return self.state.update_status
         try:
             for name in self.state.repos_not_on_disk:
-                _clone_or_copy_from_disk(name, True)
+                users_target_repo = self.state.users_target_repositories[name]
+                temp_target_repo = self.state.temp_target_repositories[name]
+                users_target_repo.clone_from_disk(
+                    temp_target_repo.path, temp_target_repo.get_remote_url()
+                )
+
             for name in self.state.repos_on_disk:
-                _clone_or_copy_from_disk(name, False)
+                users_target_repo = self.state.users_target_repositories[name]
+                temp_target_repo = self.state.temp_target_repositories[name]
+                users_target_repo.fetch_from_disk(temp_target_repo.path)
             return self.state.update_status
         except Exception as e:
             self.state.errors.append(e)

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -521,7 +521,10 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
             )
             self.state.temp_target_repositories = {
                 repo.name: GitRepository(
-                    self.state.temp_dir.name, repo.name, urls=repo.urls
+                    self.state.temp_dir.name,
+                    repo.name,
+                    urls=repo.urls,
+                    custom=repo.custom,
                 )
                 for repo in self.state.users_target_repositories.values()
             }
@@ -1050,8 +1053,10 @@ but commit not on branch {current_branch}"
             for repo in self.state.temp_target_repositories.values():
                 repo.cleanup()
             self.state.temp_dir.cleanup()
-        except Exception as e:
-            pass
+        except Exception:
+            taf_logger.warning(
+                f"WARNING: Could not remove clean up temp folder: {self.state.temp_dir}. Please remove it manually."
+            )
         return self.state.update_status
 
     @log_on_start(
@@ -1379,9 +1384,6 @@ def _merge_commit(repository, branch, commit_to_merge, force_revert=True):
     try:
         repository.checkout_branch(branch, raise_anyway=True)
     except GitError as e:
-        import pdb
-
-        pdb.set_trace()
         # two scenarios:
         # current git repository is in an inconsistent state:
         # - .git/index.lock exists (git partial update got applied)


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Do not clone target repositories directly to their permanent location. Clone to temp first, just like when working with authentication repositories. If a repository is already on disk, copy that to temp, update temp, then fetch changes from temp if valid.

Note: This PR does not address the issue of not cloning when running validation. That can be done in a separate PR

Closes #408 

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
