### PR TITLE
fix is_branch_with_unpushed_commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
-- Only show merging commits messages if actually merging commits. Rework logic for checking if a commits should be merged (404)
+- Only show merging commits messages if actually merging commits. Rework logic for checking if a commits should be merged ([404], [415])
 
+[415]: https://github.com/openlawlibrary/taf/pull/415
 [404]: https://github.com/openlawlibrary/taf/pull/404
 
 ### Fixed

--- a/taf/git.py
+++ b/taf/git.py
@@ -644,7 +644,11 @@ class GitRepository:
             self.default_branch = self._determine_default_branch()
 
     def clone_from_disk(
-        self, local_path: Path, remote_url: Optional[str] = None, is_bare: bool = False
+        self,
+        local_path: Path,
+        remote_url: Optional[str] = None,
+        is_bare: bool = False,
+        keep_remote=False,
     ) -> None:
         self.path.mkdir(parents=True, exist_ok=True)
         pygit2.clone_repository(local_path, self.path, bare=is_bare)
@@ -655,13 +659,14 @@ class GitRepository:
             raise GitError(
                 "Cloning from disk could not be completed. pygit repo could not be instantiated"
             )
-        self.remove_remote("origin")
-        if remote_url is not None:
-            self.add_remote("origin", remote_url)
-            self.fetch()
-            if repo is not None:
-                for branch in repo.branches.local:
-                    self.set_upstream(str(branch))
+        if not keep_remote:
+            self.remove_remote("origin")
+            if remote_url is not None:
+                self.add_remote("origin", remote_url)
+                self.fetch()
+                if repo is not None:
+                    for branch in repo.branches.local:
+                        self.set_upstream(str(branch))
 
     def clone_or_pull(
         self,

--- a/taf/git.py
+++ b/taf/git.py
@@ -787,7 +787,6 @@ class GitRepository:
             )
 
         local_branch = repo.branches.get(branch_name)
-
         upstream_full_name = local_branch.upstream_name
         if not upstream_full_name:
             # no upstream branch - not pushed

--- a/taf/tests/test_git/conftest.py
+++ b/taf/tests/test_git/conftest.py
@@ -12,23 +12,28 @@ REPO_NAME = "repository"
 CLONE_REPO_NAME = "repository2"
 
 
-@fixture(scope="session", autouse=True)
+@fixture
 def repository():
     path = TEST_DIR / REPO_NAME
     path.mkdir(exist_ok=True, parents=True)
     repo = GitRepository(path=path)
     repo.init_repo()
-    (path / "test.txt").write_text("Some example text")
     try:
-        repo.commit(message="Add test.txt")
+        (path / "test1.txt").write_text("Some example text 1")
+        repo.commit(message="Add test1.txt")
+        (path / "test2.txt").write_text("Some example text 2")
+        repo.commit(message="Add test2.txt")
+        (path / "test3.txt").write_text("Some example text 3")
+        repo.commit(message="Add test3.txt")
     except NothingToCommitError:
         pass  # this can happen if cleanup was not successful
+
     yield repo
     repo.cleanup()
     shutil.rmtree(path, onerror=on_rm_error)
 
 
-@fixture(scope="session", autouse=True)
+@fixture
 def clone_repository():
     path = TEST_DIR / CLONE_REPO_NAME
     path.mkdir(exist_ok=True, parents=True)

--- a/taf/tests/test_git/test_git.py
+++ b/taf/tests/test_git/test_git.py
@@ -7,7 +7,7 @@ def test_clone_from_local(repository, clone_repository):
 
 def test_is_branch_with_unpushed_commits(repository, clone_repository):
     clone_repository.clone_from_disk(repository.path, keep_remote=True)
-    branch = clone_repository.default_branch
+    branch = clone_repository.branches()[0]
     clone_repository.reset_num_of_commits(1, True)
     assert not clone_repository.is_branch_with_unpushed_commits(branch)
     (clone_repository.path / "test3.txt").write_text("Updated test3")

--- a/taf/tests/test_git/test_git.py
+++ b/taf/tests/test_git/test_git.py
@@ -3,3 +3,13 @@ def test_clone_from_local(repository, clone_repository):
     assert clone_repository.is_git_repository
     commits = clone_repository.all_commits_on_branch()
     assert len(commits)
+
+
+def test_is_branch_with_unpushed_commits(repository, clone_repository):
+    clone_repository.clone_from_disk(repository.path, keep_remote=True)
+    branch = clone_repository.default_branch
+    clone_repository.reset_num_of_commits(1, True)
+    assert not clone_repository.is_branch_with_unpushed_commits(branch)
+    (clone_repository.path / "test3.txt").write_text("Updated test3")
+    clone_repository.commit(message="Update test3.txt")
+    assert clone_repository.is_branch_with_unpushed_commits(branch)


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

This bug was introduced by unreleased changes, which made it impossible to run update after cloning in cases where
there are authenticated commits that do not get merged. The check needs to be more complex than just checking if
top commits are the same.

Fix #414

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
