### PR TITLE
Check if repositories are clean before running the updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,10 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- Check if repositories are clean before running the updater ([416])
 - Only show merging commits messages if actually merging commits. Rework logic for checking if a commits should be merged ([404], [415])
 
+[416]: https://github.com/openlawlibrary/taf/pull/416
 [415]: https://github.com/openlawlibrary/taf/pull/415
 [404]: https://github.com/openlawlibrary/taf/pull/404
 

--- a/taf/git.py
+++ b/taf/git.py
@@ -787,6 +787,9 @@ class GitRepository:
             )
 
         local_branch = repo.branches.get(branch_name)
+        if local_branch is None:
+            # local branch does not exist
+            return False
         upstream_full_name = local_branch.upstream_name
         if not upstream_full_name:
             # no upstream branch - not pushed

--- a/taf/git.py
+++ b/taf/git.py
@@ -800,12 +800,14 @@ class GitRepository:
         merge_base = repo.merge_base(local_branch.target, remote_branch.target)
 
         # Check for commits in local branch since the merge base that are not in the remote branch
-        unpushed_commits = [
-            commit
-            for commit in repo.walk(local_branch.target, pygit2.GIT_SORT_TOPOLOGICAL)
-            if commit.id != merge_base
-            and not repo.descendant_of(remote_branch.target, commit.id)
-        ]
+        unpushed_commits = []
+        for commit in repo.walk(local_branch.target, pygit2.GIT_SORT_TOPOLOGICAL):
+            if commit.id != merge_base and not repo.descendant_of(
+                remote_branch.target, commit.id
+            ):
+                unpushed_commits.append(commit)
+            else:
+                break
 
         return bool(unpushed_commits)
 

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -204,20 +204,20 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
 
         super().__init__(
             steps=[
+                (self.set_existing_repositories, RunMode.UPDATE),
+                (self.check_if_local_repositories_clean, RunMode.UPDATE),
                 (self.clone_remote_and_run_tuf_updater, RunMode.ALL),
                 (self.validate_out_of_band_and_update_type, RunMode.ALL),
-                (self.check_if_local_auth_repo_clean, RunMode.UPDATE),
                 (self.clone_or_fetch_users_auth_repo, RunMode.UPDATE),
                 (self.load_target_repositories, RunMode.ALL),
                 (self.check_if_repositories_on_disk, RunMode.LOCAL_VALIDATION),
-                (self.check_if_local_target_repositories_clean, RunMode.UPDATE),
+                (self.clone_target_repositories_to_temp, RunMode.UPDATE),
+                (self.determine_start_commits, RunMode.ALL),
+                (self.get_targets_data_from_auth_repo, RunMode.ALL),
                 (
                     self.check_if_local_repositories_contain_unpushed_commits,
                     RunMode.UPDATE,
                 ),
-                (self.clone_target_repositories_to_temp, RunMode.UPDATE),
-                (self.determine_start_commits, RunMode.ALL),
-                (self.get_targets_data_from_auth_repo, RunMode.ALL),
                 (self.get_target_repositories_commits, RunMode.ALL),
                 (self.validate_target_repositories, RunMode.ALL),
                 (
@@ -258,6 +258,74 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                 "Pipeline has not been run yet. Please run the pipeline first."
             )
         return self._output
+
+    @log_on_start(
+        DEBUG, "Checking which repositories are already on disk...", logger=taf_logger
+    )
+    def set_existing_repositories(self):
+        self.state.existing_repo = False
+        self.state.repos_on_disk = []
+        if self.auth_path is not None:
+            auth_repo = AuthenticationRepository(path=self.auth_path)
+            if auth_repo.is_git_repository:
+                self.state.existing_repo = True
+                # load target repositories in order to check if they are clean or synced
+                # after updating the authentication repotiory, we need to load them again
+                # since repositories.json could've changed
+                repositoriesdb.load_repositories(
+                    auth_repo,
+                    library_dir=self.library_dir,
+                    only_load_targets=True,
+                    excluded_target_globs=self.excluded_target_globs,
+                )
+                target_repositories = repositoriesdb.get_deduplicated_repositories(
+                    auth_repo,
+                )
+                self.state.repos_on_disk = [
+                    target_repo
+                    for target_repo in target_repositories.values()
+                    if target_repo.is_git_repository
+                ]
+                repositoriesdb.clear_repositories_db()
+        return UpdateStatus.SUCCESS
+
+    @log_on_start(
+        INFO,
+        "Checking if local repositories are clean...",
+        logger=taf_logger,
+    )
+    def check_if_local_repositories_clean(self):
+        try:
+            # check if the auth repo is clean first
+            if self.state.existing_repo:
+                auth_repo = AuthenticationRepository(path=self.auth_path)
+                if auth_repo.something_to_commit():
+                    raise RepositoryNotCleanError(auth_repo.name)
+                if auth_repo.is_branch_with_unpushed_commits(auth_repo.default_branch):
+                    raise UnpushedCommitsError(
+                        auth_repo.name,
+                        auth_repo.default_branch,
+                    )
+                # check target repositories which are on disk
+                for repository in self.state.repos_on_disk:
+                    if repository.something_to_commit():
+                        raise RepositoryNotCleanError(repository.name)
+
+                    # read the branch from the most recent target files (before the update)
+                    # and check if it contains unpushed commits
+                    # after the update, check if there are unpushed commits on any of the
+                    # other branches
+                    target = auth_repo.get_target(repository.name)
+                    if not target or not "branch" in target:
+                        continue
+                    branch = target["branch"]
+                    if repository.is_branch_with_unpushed_commits(branch):
+                        raise UnpushedCommitsError(repository.name, branch)
+        except Exception as e:
+            self.state.errors.append(e)
+            self.state.event = Event.FAILED
+            return UpdateStatus.FAILED
+        return UpdateStatus.SUCCESS
 
     @log_on_start(
         INFO, "Cloning repository and running TUF updater...", logger=taf_logger
@@ -469,29 +537,6 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
 
     @log_on_start(
         INFO,
-        "Checking if local auth repo is clean...",
-        logger=taf_logger,
-    )
-    def check_if_local_auth_repo_clean(self):
-        try:
-            if self.state.existing_repo:
-                if self.state.users_auth_repo.something_to_commit():
-                    raise RepositoryNotCleanError(self.state.users_auth_repo.name)
-                if self.state.users_auth_repo.is_branch_with_unpushed_commits(
-                    self.state.users_auth_repo.default_branch
-                ):
-                    raise UnpushedCommitsError(
-                        self.state.users_auth_repo.name,
-                        self.state.users_auth_repo.default_branch,
-                    )
-        except Exception as e:
-            self.state.errors.append(e)
-            self.state.event = Event.FAILED
-            return UpdateStatus.FAILED
-        return UpdateStatus.SUCCESS
-
-    @log_on_start(
-        INFO,
         "Cloning or updating user's authentication repository...",
         logger=taf_logger,
     )
@@ -564,23 +609,6 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                             msg = f"{repository.name} not on disk. Please run update to clone the repositories."
                             taf_logger.error(msg)
                             raise UpdateFailedError(msg)
-            return UpdateStatus.SUCCESS
-        except Exception as e:
-            self.state.errors.append(e)
-            self.state.event = Event.FAILED
-            return UpdateStatus.FAILED
-
-    @log_on_start(
-        INFO,
-        "Checking if all existing target repositories are clean...",
-        logger=taf_logger,
-    )
-    def check_if_local_target_repositories_clean(self):
-        try:
-            for repository in self.state.users_target_repositories.values():
-                if repository.is_git_repository_root:
-                    if repository.something_to_commit():
-                        raise RepositoryNotCleanError(repository.name)
             return UpdateStatus.SUCCESS
         except Exception as e:
             self.state.errors.append(e)
@@ -726,17 +754,6 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
         self.state.target_branches_data_from_auth_repo = repo_branches
         return UpdateStatus.SUCCESS
 
-    def check_if_local_repositories_contain_unpushed_commits(self):
-        for repository in self.state.users_target_repositories.values():
-            if repository.name not in self.state.target_branches_data_from_auth_repo:
-                # exists in repositories.json, not target files
-                continue
-            for branch in self.state.target_branches_data_from_auth_repo[
-                repository.name
-            ]:
-                if repository.is_branch_with_unpushed_commits(branch):
-                    raise UnpushedCommitsError(repository.name, branch)
-
     @log_on_start(DEBUG, "Fetching commits of target repositories", logger=taf_logger)
     def get_target_repositories_commits(self):
         """Returns a list of newly fetched commits belonging to the specified branch."""
@@ -818,6 +835,31 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                 self.state.fetched_commits_per_target_repos_branches[repository.name][
                     branch
                 ] = fetched_commits_on_target_repo_branch
+        return UpdateStatus.SUCCESS
+
+    @log_on_start(
+        DEBUG,
+        "Checking if target repositories contain unpushed commits...",
+        logger=taf_logger,
+    )
+    def check_if_local_repositories_contain_unpushed_commits(self):
+        try:
+            for repository in self.state.users_target_repositories.values():
+                if (
+                    repository.name
+                    not in self.state.target_branches_data_from_auth_repo
+                ):
+                    # exists in repositories.json, not target files
+                    continue
+                for branch in self.state.target_branches_data_from_auth_repo[
+                    repository.name
+                ]:
+                    if repository.is_branch_with_unpushed_commits(branch):
+                        raise UnpushedCommitsError(repository.name, branch)
+        except Exception as e:
+            self.state.errors.append(e)
+            self.state.event = Event.FAILED
+            return UpdateStatus.FAILED
         return UpdateStatus.SUCCESS
 
     @log_on_start(INFO, "Validating target repositories...", logger=taf_logger)

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -316,7 +316,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                     # after the update, check if there are unpushed commits on any of the
                     # other branches
                     target = auth_repo.get_target(repository.name)
-                    if not target or not "branch" in target:
+                    if not target or "branch" not in target:
                         continue
                     branch = target["branch"]
                     if repository.is_branch_with_unpushed_commits(branch):

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -66,12 +66,12 @@ class UpdateState:
     temp_target_repositories: Dict[str, "GitRepository"] = field(factory=dict)
     # permanent repositories inside the user's local direcotry
     users_target_repositories: Dict[str, "GitRepository"] = field(factory=dict)
-    # a list of repositories which are already present inside a user's local
+    # a dictionary of repositories which are already present inside a user's local and
     # directory when the update is started
-    repos_on_disk: List[str] = field(factory=list)
-    # a list of repositories which are not present inside a user's local
+    repos_on_disk: Dict[str, GitRepository] = field(factory=dict)
+    # a dictionary of repositories which are not present inside a user's local
     # directory when the update is started
-    repos_not_on_disk: List[str] = field(factory=list)
+    repos_not_on_disk: Dict[str, GitRepository] = field(factory=dict)
     target_branches_data_from_auth_repo: Dict = field(factory=dict)
     targets_data_by_auth_commits: Dict = field(factory=dict)
     old_heads_per_target_repos_branches: Dict[str, Dict[str, str]] = field(factory=dict)
@@ -264,10 +264,10 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
     )
     def set_existing_repositories(self):
         self.state.existing_repo = False
-        self.state.repos_on_disk = []
+        self.state.repos_on_disk = {}
         if self.auth_path is not None:
             auth_repo = AuthenticationRepository(path=self.auth_path)
-            if auth_repo.is_git_repository:
+            if auth_repo.is_git_repository_root:
                 self.state.existing_repo = True
                 # load target repositories in order to check if they are clean or synced
                 # after updating the authentication repotiory, we need to load them again
@@ -281,11 +281,11 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                 target_repositories = repositoriesdb.get_deduplicated_repositories(
                     auth_repo,
                 )
-                self.state.repos_on_disk = [
-                    target_repo
+                self.state.repos_on_disk = {
+                    target_repo.name: target_repo
                     for target_repo in target_repositories.values()
-                    if target_repo.is_git_repository
-                ]
+                    if target_repo.is_git_repository_root
+                }
                 repositoriesdb.clear_repositories_db()
         return UpdateStatus.SUCCESS
 
@@ -307,7 +307,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                         auth_repo.default_branch,
                     )
                 # check target repositories which are on disk
-                for repository in self.state.repos_on_disk:
+                for repository in self.state.repos_on_disk.values():
                     if repository.something_to_commit():
                         raise RepositoryNotCleanError(repository.name)
 
@@ -338,7 +338,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
         if self.operation == OperationType.CLONE_OR_UPDATE:
             if (
                 self.auth_path is not None
-                and AuthenticationRepository(path=self.auth_path).is_git_repository
+                and AuthenticationRepository(path=self.auth_path).is_git_repository_root
             ):
                 self.operation = OperationType.UPDATE
             else:
@@ -619,8 +619,8 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
     @log_on_end(INFO, "Finished cloning target repositories", logger=taf_logger)
     def clone_target_repositories_to_temp(self):
         try:
-            self.state.repos_on_disk = []
-            self.state.repos_not_on_disk = []
+            self.state.repos_on_disk = {}
+            self.state.repos_not_on_disk = {}
             for temp_repo in self.state.temp_target_repositories.values():
                 users_repo = self.state.users_target_repositories[temp_repo.name]
                 is_git_repository = users_repo.is_git_repository_root
@@ -630,10 +630,10 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                         users_repo.get_remote_url(),
                         is_bare=True,
                     )
-                    self.state.repos_on_disk.append(users_repo)
+                    self.state.repos_on_disk[users_repo.name] = users_repo
                 else:
                     temp_repo.clone(bare=True)
-                    self.state.repos_not_on_disk.append(users_repo)
+                    self.state.repos_not_on_disk[users_repo.name] = users_repo
             return UpdateStatus.SUCCESS
         except Exception as e:
             self.state.errors.append(e)
@@ -844,7 +844,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
     )
     def check_if_local_target_repositories_clean(self):
         try:
-            for repository in self.state.repos_on_disk:
+            for repository in self.state.repos_on_disk.values():
                 if repository.something_to_commit():
                     raise RepositoryNotCleanError(repository.name)
                 for branch in self.state.target_branches_data_from_auth_repo[
@@ -1078,20 +1078,18 @@ but commit not on branch {current_branch}"
         if self.state.update_status == UpdateStatus.FAILED:
             return self.state.update_status
         try:
-            for repository in self.state.repos_not_on_disk:
+            for repository_name in self.state.repos_not_on_disk:
                 users_target_repo = self.state.users_target_repositories[
-                    repository.name
+                    repository_name
                 ]
-                temp_target_repo = self.state.temp_target_repositories[repository.name]
+                temp_target_repo = self.state.temp_target_repositories[repository_name]
                 users_target_repo.clone_from_disk(
                     temp_target_repo.path, temp_target_repo.get_remote_url()
                 )
 
-            for repository in self.state.repos_on_disk:
-                users_target_repo = self.state.users_target_repositories[
-                    repository.name
-                ]
-                temp_target_repo = self.state.temp_target_repositories[repository.name]
+            for repo_name in self.state.repos_on_disk:
+                users_target_repo = self.state.users_target_repositories[repo_name]
+                temp_target_repo = self.state.temp_target_repositories[repo_name]
                 users_target_repo.fetch_from_disk(temp_target_repo.path)
             return self.state.update_status
         except Exception as e:


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

The idea is for the update process to fail early if the auth repo or one of the existing target repositories is not clean (index is dirty or if there are unpushed commits). After updating the authentication repository, we can check other branches.

Closes #390

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
