### PR TITLE
fix: update temp local branch before fetching from it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
-- Clone target repositories to temp ([412])
+- Clone target repositories to temp ([412, 418])
 - Add architecture overview documentation ([405])
 
 [412]: https://github.com/openlawlibrary/taf/pull/412
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning][semver].
 - Check if repositories are clean before running the updater ([416])
 - Only show merging commits messages if actually merging commits. Rework logic for checking if a commits should be merged ([404], [415])
 
+[418]: https://github.com/openlawlibrary/taf/pull/418
 [416]: https://github.com/openlawlibrary/taf/pull/416
 [415]: https://github.com/openlawlibrary/taf/pull/415
 [404]: https://github.com/openlawlibrary/taf/pull/404

--- a/taf/git.py
+++ b/taf/git.py
@@ -1501,6 +1501,23 @@ class GitRepository:
         except Exception:
             return None
 
+    def update_local_branch(self, branch, remote_name="origin"):
+        """
+        Updates ref of a local branch of a bare repository where merging is not possible
+        """
+        repo = self.pygit_repo
+        if repo is None:
+            raise GitError(
+                self,
+                message="Could not find top commit. pygit repository could not be instantiated.",
+            )
+        remote_branch_ref = f"refs/remotes/{remote_name}/{branch}"
+        remote_branch_commit = repo.lookup_reference(remote_branch_ref).target
+
+        # Update the local branch to point to the latest commit from the remote branch
+        local_branch_ref = f"refs/heads/{branch}"
+        repo.references.create(local_branch_ref, remote_branch_commit, force=True)
+
     def _determine_default_branch(self) -> Optional[str]:
         """Determine the default branch of the repository"""
         # try to get the default branch from the local repository

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -769,7 +769,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                     branch, include_remotes=False
                 )
                 branch_exists = repository.branch_exists(branch, include_remotes=True)
-                if repository.name in self.state.repos_not_on_disk:
+                if repository.name in self.state.repos_on_disk:
                     if self.only_validate:
                         if not branch_exists:
                             self.state.targets_data = {}
@@ -1090,6 +1090,10 @@ but commit not on branch {current_branch}"
             for repo_name in self.state.repos_on_disk:
                 users_target_repo = self.state.users_target_repositories[repo_name]
                 temp_target_repo = self.state.temp_target_repositories[repo_name]
+                for branch in self.state.validated_commits_per_target_repos_branches[
+                    repo_name
+                ]:
+                    temp_target_repo.update_local_branch(branch=branch)
                 users_target_repo.fetch_from_disk(temp_target_repo.path)
             return self.state.update_status
         except Exception as e:


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

If a commit is on the remote tracking branch and the local branch is not updated, it will not be fetched when fetching from that temp repo. This resulted in an error during the merge commits step.
Discovered this issue while running integration tests. That testing framework is a lot different than this one. We should keep this in mind when we start reworking this testing framework.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
