### PR TITLE
fix: use provided url or get remote url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,15 @@ and this project adheres to [Semantic Versioning][semver].
 - Check if repositories are clean before running the updater ([416])
 - Only show merging commits messages if actually merging commits. Rework logic for checking if a commits should be merged ([404], [415])
 
+### Fixed
+
+- When checking if branch is synced, find first remote that works, instead of only trying the last remote url ([419])
+
+[419]: https://github.com/openlawlibrary/taf/pull/419
 [418]: https://github.com/openlawlibrary/taf/pull/418
 [416]: https://github.com/openlawlibrary/taf/pull/416
 [415]: https://github.com/openlawlibrary/taf/pull/415
 [404]: https://github.com/openlawlibrary/taf/pull/404
-
-### Fixed
 
 ## [0.29.3] - 03/15/2024
 


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

`self.urls` is not deterministic between OSs, so on Windows it returns remote repositories last, and on macOS it returns them first. This commit makes it so we don't rely on `self.urls`.

Also, since the for loop doesn't access or use url variable, I've removed it.

Closes: #372

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
