### PR TITLE
Fix generation of keys when they should be printed to the command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning][semver].
 ## [Unreleased]
 
 ### Added
+
+- Fix generation of keys when they should be printed to the command line ([435])
 - Fixes repeating error messages in taf repo create and manual entry of keys-description ([432])
 - Fix add_target_repo when signing role is the top-level targets role ([431])
 - New git hook that validates repo before push ([423])
@@ -17,7 +19,7 @@ and this project adheres to [Semantic Versioning][semver].
 - Clone target repositories to temp ([412, 418])
 - Add architecture overview documentation ([405])
 
-
+[435]: https://github.com/openlawlibrary/taf/pull/435
 [432]: https://github.com/openlawlibrary/taf/pull/432
 [431]: https://github.com/openlawlibrary/taf/pull/431
 [423]: https://github.com/openlawlibrary/taf/pull/423

--- a/taf/api/roles.py
+++ b/taf/api/roles.py
@@ -542,7 +542,7 @@ def _initialize_roles_and_keystore(
     roles_key_infos: Optional[str],
     keystore: Optional[str],
     enter_info: Optional[bool] = True,
-) -> Tuple[Dict, str, bool]:
+) -> Tuple[Dict, Optional[str], bool]:
     """
     Read information about roles and keys from a json file or ask the user to enter
     this information if not specified through a json file and enter_info is True.
@@ -592,14 +592,11 @@ def _initialize_roles_and_keystore(
                 if use_keystore in ["y", "n"]:
                     break
             if use_keystore == "y":
-                keystore = input(
-                    "Enter keystore path (default ./keystore): "
-                ).strip()
+                keystore = input("Enter keystore path (default ./keystore): ").strip()
             else:
                 print(
                     "Keys will be entered using the command line and saved to ./keystore"
                 )
-
 
     if keystore is not None:
         keystore = resolve_keystore_path(keystore, roles_key_infos)

--- a/taf/api/roles.py
+++ b/taf/api/roles.py
@@ -597,7 +597,9 @@ def _initialize_roles_and_keystore(
                     or "./keystore"
                 )
             else:
-                taf_logger.info("Keys will be entered and then printed from the command line...")
+                taf_logger.info(
+                    "Keys will be entered and then printed from the command line..."
+                )
 
     if keystore is not None:
         keystore = resolve_keystore_path(keystore, roles_key_infos)
@@ -622,7 +624,9 @@ def _initialize_roles_and_keystore(
                 break
             else:
                 enter_new_path = (
-                    input("Do you want to enter a different path to the keystore? [y/N]: ")
+                    input(
+                        "Do you want to enter a different path to the keystore? [y/N]: "
+                    )
                     .strip()
                     .lower()
                 )

--- a/taf/api/roles.py
+++ b/taf/api/roles.py
@@ -597,7 +597,7 @@ def _initialize_roles_and_keystore(
                     or "./keystore"
                 )
             else:
-                taf_logger.info("Keys will be entered/printed from/to command line")
+                taf_logger.info("Keys will be entered and then printed from the command line...")
 
     if keystore is not None:
         keystore = resolve_keystore_path(keystore, roles_key_infos)
@@ -622,12 +622,12 @@ def _initialize_roles_and_keystore(
                 break
             else:
                 enter_new_path = (
-                    input("Do you want to enter a different path? [y/N]: ")
+                    input("Do you want to enter a different path to the keystore? [y/N]: ")
                     .strip()
                     .lower()
                 )
                 if enter_new_path == "y":
-                    keystore = input("Enter a different keystore path: ").strip()
+                    keystore = input("New keystore path: ").strip()
                     keystore = resolve_keystore_path(keystore, roles_key_infos)
                     roles_key_infos_dict["keystore"] = keystore
                 else:

--- a/taf/api/roles.py
+++ b/taf/api/roles.py
@@ -11,7 +11,7 @@ from taf.api.utils._roles import _role_obj, create_delegations
 from taf.messages import git_commit_message
 from tuf.repository_tool import Targets
 from taf.api.utils._git import check_if_clean, commit_and_push
-from taf.exceptions import TAFError
+from taf.exceptions import KeystoreError, TAFError
 from taf.models.converter import from_dict
 from taf.models.types import RolesIterator, TargetsRole
 from taf.repositoriesdb import REPOSITORIES_JSON_PATH
@@ -580,64 +580,60 @@ def _initialize_roles_and_keystore(
         role_info.get("yubikey", False) for role_info in roles_key_infos_dict.values()
     )
 
-    if not use_yubikeys:
+    if not use_yubikeys and not keystore:
+        keystore = roles_key_infos_dict.get("keystore")
         if not keystore:
-            keystore = roles_key_infos_dict.get("keystore")
-            if not keystore:
-                while True:
-                    use_keystore = (
-                        input(
-                            "Do you want to save/load keys from keystore files? [y/N]: "
-                        )
-                        .strip()
-                        .lower()
-                    )
-                    if use_keystore in ["y", "n"]:
-                        break
-                if use_keystore == "y":
-                    keystore = input(
-                        "Enter keystore path (default ./keystore): "
-                    ).strip()
-                else:
-                    print(
-                        "Keys will be entered using the command line and saved to ./keystore"
-                    )
-                    keystore = "./keystore"
-
-    keystore = resolve_keystore_path(keystore, roles_key_infos)
-    roles_key_infos_dict["keystore"] = keystore
-    while True:
-        keystore_path = Path(keystore)
-        if keystore_path.exists():
-            break
-        create_keystore = (
-            input(
-                f"Keystore directory {keystore_path} does not exist. Do you want to create it? [y/N]: "
-            )
-            .strip()
-            .lower()
-        )
-        if create_keystore == "y":
-            keystore_path.mkdir(parents=True, exist_ok=True)
-            roles_key_infos_dict["keystore"] = keystore
-            print(f"Created keystore directory at {keystore}")
-            skip_prompt = True
-            break
-        else:
-            enter_new_path = (
-                input("Do you want to enter a different path? [y/N]: ").strip().lower()
-            )
-            if enter_new_path == "y":
-                keystore = input("Enter a different keystore path: ").strip()
-                keystore = resolve_keystore_path(keystore, roles_key_infos)
-                roles_key_infos_dict["keystore"] = keystore
+            while True:
+                use_keystore = (
+                    input("Do you want to save/load keys from keystore files? [y/N]: ")
+                    .strip()
+                    .lower()
+                )
+                if use_keystore in ["y", "n"]:
+                    break
+            if use_keystore == "y":
+                keystore = input(
+                    "Enter keystore path (default ./keystore): "
+                ).strip()
             else:
                 print(
-                    "Assuming the keys will be entered using and printed to the command line."
+                    "Keys will be entered using the command line and saved to ./keystore"
                 )
-                keystore = "."
+
+
+    if keystore is not None:
+        keystore = resolve_keystore_path(keystore, roles_key_infos)
+        roles_key_infos_dict["keystore"] = keystore
+
+        while True:
+            keystore_path = Path(keystore)
+            if keystore_path.exists():
+                break
+            create_keystore = (
+                input(
+                    f"Keystore directory {keystore_path} does not exist. Do you want to create it? [y/N]: "
+                )
+                .strip()
+                .lower()
+            )
+            if create_keystore == "y":
+                keystore_path.mkdir(parents=True, exist_ok=True)
+                roles_key_infos_dict["keystore"] = keystore
+                print(f"Created keystore directory at {keystore}")
                 skip_prompt = True
                 break
+            else:
+                enter_new_path = (
+                    input("Do you want to enter a different path? [y/N]: ")
+                    .strip()
+                    .lower()
+                )
+                if enter_new_path == "y":
+                    keystore = input("Enter a different keystore path: ").strip()
+                    keystore = resolve_keystore_path(keystore, roles_key_infos)
+                    roles_key_infos_dict["keystore"] = keystore
+                else:
+                    raise KeystoreError("Keystore not found")
 
     return roles_key_infos_dict, keystore, skip_prompt
 

--- a/taf/api/roles.py
+++ b/taf/api/roles.py
@@ -592,11 +592,12 @@ def _initialize_roles_and_keystore(
                 if use_keystore in ["y", "n"]:
                     break
             if use_keystore == "y":
-                keystore = input("Enter keystore path (default ./keystore): ").strip()
-            else:
-                print(
-                    "Keys will be entered using the command line and saved to ./keystore"
+                keystore = (
+                    input("Enter keystore path (default ./keystore): ").strip()
+                    or "./keystore"
                 )
+            else:
+                taf_logger.info("Keys will be entered/printed from/to command line")
 
     if keystore is not None:
         keystore = resolve_keystore_path(keystore, roles_key_infos)
@@ -913,7 +914,7 @@ def _remove_path_from_role_info(
 def _update_role(
     auth_repo: AuthenticationRepository,
     role: str,
-    keystore: str,
+    keystore: Optional[str],
     scheme: Optional[str] = DEFAULT_RSA_SIGNATURE_SCHEME,
     prompt_for_keys: Optional[bool] = False,
 ) -> None:

--- a/taf/keys.py
+++ b/taf/keys.py
@@ -88,7 +88,7 @@ def load_sorted_keys_of_new_roles(
     auth_repo: AuthenticationRepository,
     roles: Union[MainRoles, TargetsRole],
     yubikeys_data: Optional[Dict[str, UserKeyData]],
-    keystore: str,
+    keystore: Optional[str],
     yubikeys: Optional[Dict[str, Dict]] = None,
     existing_roles: Optional[List[str]] = None,
     skip_prompt: Optional[bool] = False,
@@ -211,7 +211,7 @@ def load_signing_keys(
     if keystore is not None:
         keystore_path = Path(keystore).expanduser().resolve()
     else:
-        print("Keystore location not provided")
+        taf_logger.info("Keystore location not provided")
 
     def _load_and_append_yubikeys(
         key_name, role, retry_on_failure, hide_already_loaded_message
@@ -226,7 +226,7 @@ def load_signing_keys(
         )
         if public_key is not None and public_key not in yubikeys:
             yubikeys.append(public_key)
-            print(f"Successfully loaded {key_name} from inserted YubiKey")
+            taf_logger.info(f"Successfully loaded {key_name} from inserted YubiKey")
             return True
         return False
 

--- a/taf/keys.py
+++ b/taf/keys.py
@@ -468,9 +468,10 @@ def _setup_keystore_key(
             )
         else:
             rsa_key = keys.generate_rsa_key(bits=length)
-            public_key = rsa_key["keyval"]["public"]
-            private_key = rsa_key["keyval"]["private"]
-            print(f"{role_name} key:\n\n{private_key}\n\n")
+            private_key_val = rsa_key["keyval"]["private"]
+            print(f"{role_name} key:\n\n{private_key_val}\n\n")
+            public_key = rsa_key
+            private_key = rsa_key
 
     return public_key, private_key
 


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

A feature that we rarely use, but still want to support is printing keys to the command line instead of storing them to the keystore files. This enables the users to copy them to a secure key manager. 

Fix #433

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
