### PR TITLE
Fix for redundant printing of CLI help options

### DIFF
--- a/taf/tools/dependencies/__init__.py
+++ b/taf/tools/dependencies/__init__.py
@@ -21,7 +21,6 @@ def attach_to_group(group):
     @click.option("--out-of-band-commit", default=None, help="Out-of-band commit SHA")
     @click.option("--dependency-path", default=None, help="Dependency's filesystem path")
     @click.option("--keystore", default=None, help="Location of the keystore files")
-    @click.option("--keystore", default=None, help="Location of the keystore files")
     @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not "
                   "located inside the keystore directory")
     @click.option("--no-commit", is_flag=True, default=False, help="Indicates that the changes should not be "


### PR DESCRIPTION
Removing redundant CLI print line to fix the double print of keystore option when "taf dependencies add --help" is used.

## Description

Fixes #428
Issue: "taf dependencies add --help" lists "--keystore" twice
Changes to address the Issue: Removed redundant print lines in "taf dependencies add --help".

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
