### PR TITLE
Always load latest mirrors.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,29 @@ and this project adheres to [Semantic Versioning][semver].
 ## [Unreleased]
 
 ### Added
+
+
 - Support for Python 3.11 and 3.12 ([440])
-- Fix generation of keys when they should be printed to the command line ([435])
-- Made Updater faster through parallelization ([434])
-- Fixes repeating error messages in taf repo create and manual entry of keys-description ([432])
 - Fix add_target_repo when signing role is the top-level targets role ([431])
 - New git hook that validates repo before push ([423])
 - New function taf repo status that prints the state of whole library ([422])
 - New function taf roles list that lists all roles in an authentication repository ([421])
-- Reimplemented get_file_details function to not rely on old securesystemslib functions ([420])
-- Clone target repositories to temp ([412, 418])
+- Clone target repositories to temp ([412], [418])
 - Add architecture overview documentation ([405])
+
+### Changed
+
+- Only load the latest mirrors.jon ([441])
+- Fix generation of keys when they should be printed to the command line ([435])
+- Made Updater faster through parallelization ([434])
+- Reimplemented get_file_details function to not rely on old securesystemslib functions ([420])
+- Check if repositories are clean before running the updater ([416])
+- Only show merging commits messages if actually merging commits. Rework logic for checking if a commits should be merged ([404], [415])
+
+### Fixed
+
+- Fixes repeating error messages in taf repo create and manual entry of keys-description ([432])
+- When checking if branch is synced, find first remote that works, instead of only trying the last remote url ([419])
 
 [440]: https://github.com/openlawlibrary/taf/pull/440
 [435]: https://github.com/openlawlibrary/taf/pull/435
@@ -29,23 +41,12 @@ and this project adheres to [Semantic Versioning][semver].
 [422]: https://github.com/openlawlibrary/taf/pull/422
 [421]: https://github.com/openlawlibrary/taf/pull/421
 [420]: https://github.com/openlawlibrary/taf/pull/420
-[412]: https://github.com/openlawlibrary/taf/pull/412
-[405]: https://github.com/openlawlibrary/taf/pull/405
-
-
-### Changed
-
-- Check if repositories are clean before running the updater ([416])
-- Only show merging commits messages if actually merging commits. Rework logic for checking if a commits should be merged ([404], [415])
-
-### Fixed
-
-- When checking if branch is synced, find first remote that works, instead of only trying the last remote url ([419])
-
 [419]: https://github.com/openlawlibrary/taf/pull/419
 [418]: https://github.com/openlawlibrary/taf/pull/418
 [416]: https://github.com/openlawlibrary/taf/pull/416
 [415]: https://github.com/openlawlibrary/taf/pull/415
+[412]: https://github.com/openlawlibrary/taf/pull/412
+[405]: https://github.com/openlawlibrary/taf/pull/405
 [404]: https://github.com/openlawlibrary/taf/pull/404
 
 ## [0.29.3] - 03/15/2024

--- a/taf/repositoriesdb.py
+++ b/taf/repositoriesdb.py
@@ -92,6 +92,7 @@ def load_dependencies(
     if library_dir is None:
         library_dir = str(Path(auth_repo.path).parent.parent)
 
+    mirrors = load_mirrors_json(auth_repo, commits[-1])
     for commit in commits:
         dependencies_dict: Dict = {}
         # check if already loaded
@@ -104,7 +105,6 @@ def load_dependencies(
         if dependencies is None:
             continue
 
-        mirrors = load_mirrors_json(auth_repo, commit)
         dependencies = dependencies["dependencies"]
         if dependencies is None:
             continue
@@ -235,6 +235,7 @@ def load_repositories(
         only_load_targets = True
 
     skipped_targets = []
+    mirrors = load_mirrors_json(auth_repo, commits[-1])
     for commit in commits:
         repositories_dict: Dict = {}
         # check if already loaded
@@ -247,7 +248,6 @@ def load_repositories(
         if repositories is None:
             continue
 
-        mirrors = load_mirrors_json(auth_repo, commit)
 
         # target repositories are defined in both repositories.json and targets.json
         repositories = repositories["repositories"]
@@ -599,21 +599,6 @@ def get_repositories_by_custom_data(
     raise RepositoriesNotFoundError(
         f"Repositories associated with custom data {custom_data} not found"
     )
-
-
-def get_repo_urls(
-    auth_repo: AuthenticationRepository, repo_name: str, commit: Optional[str] = None
-) -> Optional[List[str]]:
-    if commit is None:
-        commit = auth_repo.head_commit_sha()
-        if commit is None:
-            raise TAFError(
-                "Could not load urls. Commit is not specified and head commit could not be determined"
-            )
-    mirrors = load_mirrors_json(auth_repo, commit)
-    if mirrors is not None:
-        return _get_urls(mirrors, repo_name)
-    return None
 
 
 def _initialize_repository(

--- a/taf/repositoriesdb.py
+++ b/taf/repositoriesdb.py
@@ -248,7 +248,6 @@ def load_repositories(
         if repositories is None:
             continue
 
-
         # target repositories are defined in both repositories.json and targets.json
         repositories = repositories["repositories"]
         if repositories is None:


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Always load the latest version of mirrors.json. It does not ever make sense to attempt to download a repository from a URL which updated. This also ensures that the update can succeed if we there are commits where repositories.json existed, but mirrors was added later

Also removed a function that is no longer used

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
