### PR TITLE
Fix: Update to repository addition order

### DIFF
--- a/taf/api/targets.py
+++ b/taf/api/targets.py
@@ -87,10 +87,10 @@ def add_target_repo(
     if library_dir is None:
         library_dir = str(auth_repo.path.parent.parent)
 
-    if target_name is not None:
-        target_repo = GitRepository(library_dir, target_name)
-    elif target_path is not None:
+    if target_path is not None:
         target_repo = GitRepository(path=target_path)
+    elif target_name is not None:
+        target_repo = GitRepository(library_dir, target_name)
     else:
         raise TAFError(
             "Cannot add new target repository. Specify either target name (and library dir) or target path"

--- a/taf/tools/targets/__init__.py
+++ b/taf/tools/targets/__init__.py
@@ -42,7 +42,7 @@ def add_repo_command():
         `namespace1\\repo1`, the target's path will be set to `E:\\examples\\root\\namespace1\\repo1`.""")
     @catch_cli_exception(handle=TAFError)
     @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--target-name", required=True, default=None, help="Namespace prefixed name of the target repository")
+    @click.argument("target-name")
     @click.option("--target-path", default=None, help="Target repository's filesystem path")
     @click.option("--role", default="targets", help="Signing role of the corresponding target file. Can be a new role, in which case it will be necessary to enter its information when prompted")
     @click.option("--keystore", default=None, help="Location of the keystore files")

--- a/taf/tools/targets/__init__.py
+++ b/taf/tools/targets/__init__.py
@@ -42,7 +42,7 @@ def add_repo_command():
         `namespace1\\repo1`, the target's path will be set to `E:\\examples\\root\\namespace1\\repo1`.""")
     @catch_cli_exception(handle=TAFError)
     @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--target-name", default=None, help="Namespace prefixed name of the target repository")
+    @click.option("--target-name", required=True, default=None, help="Namespace prefixed name of the target repository")
     @click.option("--target-path", default=None, help="Target repository's filesystem path")
     @click.option("--role", default="targets", help="Signing role of the corresponding target file. Can be a new role, in which case it will be necessary to enter its information when prompted")
     @click.option("--keystore", default=None, help="Location of the keystore files")


### PR DESCRIPTION
## Description
fixes: #430

Updated the order of adding repository based on target_path if provided, else based on target_name if target_path is empty. Completely making target_name mandatory might break the functionality of updater based repository additions, so did not completely remove the target_path based repository addition.

Updated the `--target-name` option as required in the CLI. However, I have maintained the default assignment as `None` because the API function relies on `None` to determine if the `target-name` was provided or not.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
