### PR TITLE
fix: fix setup yubikey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,11 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Fix YubiKey setup ([445])
 - Fixes repeating error messages in taf repo create and manual entry of keys-description ([432])
 - When checking if branch is synced, find first remote that works, instead of only trying the last remote url ([419])
 
+[445]: https://github.com/openlawlibrary/taf/pull/445
 [444]: https://github.com/openlawlibrary/taf/pull/444
 [440]: https://github.com/openlawlibrary/taf/pull/440
 [435]: https://github.com/openlawlibrary/taf/pull/435

--- a/taf/yubikey.py
+++ b/taf/yubikey.py
@@ -350,9 +350,8 @@ def setup(
                     private_key_pem, pem_pwd, default_backend()
                 )
 
-            ctrl.put_key(SLOT.SIGNATURE, private_key, PIN_POLICY.ALWAYS)
-            pub_key = private_key.public_key()
-
+        ctrl.put_key(SLOT.SIGNATURE, private_key, PIN_POLICY.ALWAYS)
+        pub_key = private_key.public_key()
         ctrl.authenticate(MANAGEMENT_KEY_TYPE.TDES, mgm_key)
         ctrl.verify_pin(DEFAULT_PIN)
 


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

The error was caused by wrong indentation, which meant that the function that stores the key on a yubikey was only being called in some cases

Fix #369

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
