### PR TITLE
fix: hide plaintext yuibkey input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning][semver].
 - Added workflow to build standalone executable of TAF ([447])
 - Added git hook check for updater ([460])
 
+- Hid plaintext when users are prompted to insert YubiKey and press ENTER [473]
+
 ### Changed
 
 - Generate public key from private key if .pub file is missing ([462])
@@ -32,6 +34,7 @@ and this project adheres to [Semantic Versioning][semver].
 [458]: https://github.com/openlawlibrary/taf/pull/458
 [455]: https://github.com/openlawlibrary/taf/pull/455
 [447]: https://github.com/openlawlibrary/taf/pull/447
+[473]: https://github.com/openlawlibrary/taf/pull/473
 
 
 ## [0.29.2] - 07/04/2024

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -186,18 +186,22 @@ class RepositoryConfig:
         default=False,
         metadata={"docs": "Whether update fails if a warning is raised. Optional."},
     )
+    bare: bool = field(
+        default=False,
+        metadata={
+            "docs": "Whether to clone repositories as bare repositories. If set to true, all repositories will be cloned as bare repositories. Optional."
+        },
+    )
     no_deps: bool = field(
         default=False,
         metadata={"docs": "Specifies whether or not to update dependencies. Optional."},
     )
-    # JMC: Addition of --no-targets option to allow user to skip target repos when validating the authentication repository.
     no_targets: bool = field(
         default=False,
         metadata={
             "docs": "Flag to skip target repositiory validation and validate only authentication repos. Optional."
         },
     )
-    # JMC: Addition of --no-upstream option to allow user to opt out of comparing with the remote repository and be added to clone and update
     no_upstream: bool = field(
         default=True,
         metadata={
@@ -297,6 +301,9 @@ def update_repository(config: RepositoryConfig):
         if config.url is None:
             raise UpdateFailedError("URL cannot be determined. Please specify it")
 
+    if auth_repo.is_bare_repository:
+        # Handle updates for bare repositories
+        config.bare = True
     return _update_or_clone_repository(config)
 
 
@@ -325,6 +332,7 @@ def _update_or_clone_repository(config: RepositoryConfig):
             scripts_root_dir=config.scripts_root_dir,
             checkout=config.checkout,
             excluded_target_globs=config.excluded_target_globs,
+            bare=config.bare,
             # JMC: pass the no_deps, no_targets, and no_upstream flags
             no_deps=config.no_deps,
             no_targets=config.no_targets,
@@ -388,6 +396,7 @@ def _update_named_repository(
     scripts_root_dir=None,
     checkout=True,
     excluded_target_globs=None,
+    bare=False,
     no_deps=False,
     no_targets=False,
     no_upstream=True,
@@ -473,6 +482,7 @@ def _update_named_repository(
         out_of_band_authentication,
         checkout,
         excluded_target_globs,
+        bare,
         no_targets,
         no_upstream,
     )
@@ -615,6 +625,7 @@ def _update_current_repository(
     out_of_band_authentication,
     checkout,
     excluded_target_globs,
+    bare,
     # JMC: Addition of new flags
     no_targets,
     no_upstream,
@@ -634,6 +645,7 @@ def _update_current_repository(
         out_of_band_authentication,
         checkout,
         excluded_target_globs,
+        bare,
         no_upstream=no_upstream,
         no_targets=no_targets,
     )
@@ -666,6 +678,7 @@ def validate_repository(
     validate_from_commit=None,
     excluded_target_globs=None,
     strict=False,
+    bare=False,
     no_targets=False,
     no_deps=False,
 ):
@@ -697,6 +710,7 @@ def validate_repository(
             only_validate=True,
             validate_from_commit=validate_from_commit,
             excluded_target_globs=excluded_target_globs,
+            bare=bare,
             no_targets=no_targets,
             no_deps=no_deps,
         )

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -333,7 +333,6 @@ def _update_or_clone_repository(config: RepositoryConfig):
             checkout=config.checkout,
             excluded_target_globs=config.excluded_target_globs,
             bare=config.bare,
-            # JMC: pass the no_deps, no_targets, and no_upstream flags
             no_deps=config.no_deps,
             no_targets=config.no_targets,
             no_upstream=config.no_upstream,
@@ -584,7 +583,6 @@ def _update_named_repository(
             # do not call the handlers if only validating the repositories
             # if a handler fails and we are in the development mode, revert the update
             # so that it's easy to try again after fixing the handler
-            # JMC: Added "and not no_targets:" to this first line of code
             if not only_validate and not excluded_target_globs and not no_targets:
                 _execute_repo_handlers(
                     update_status,
@@ -626,7 +624,6 @@ def _update_current_repository(
     checkout,
     excluded_target_globs,
     bare,
-    # JMC: Addition of new flags
     no_targets,
     no_upstream,
 ):

--- a/taf/yubikey.py
+++ b/taf/yubikey.py
@@ -32,6 +32,7 @@ from yubikit.piv import (
 from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
 from taf.exceptions import InvalidPINError, YubikeyError
 from taf.utils import get_pin_for
+from getpass import getpass
 
 DEFAULT_PIN = "123456"
 DEFAULT_PUK = "12345678"
@@ -436,7 +437,8 @@ def yubikey_prompt(
         if retrying:
             if prompt_message is None:
                 prompt_message = f"Please insert {key_name} YubiKey and press ENTER"
-            input(prompt_message)
+            # JMC: hide input with getpass()
+            getpass(prompt_message)
         # make sure that YubiKey is inserted
         try:
             serial_num = get_serial_num()

--- a/taf/yubikey.py
+++ b/taf/yubikey.py
@@ -437,7 +437,6 @@ def yubikey_prompt(
         if retrying:
             if prompt_message is None:
                 prompt_message = f"Please insert {key_name} YubiKey and press ENTER"
-            # JMC: hide input with getpass()
             getpass(prompt_message)
         # make sure that YubiKey is inserted
         try:


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Utilized getpass() to hide the plaintext when prompted to "insert {key_name} YubiKey and press ENTER." Fix #399.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
