### PR TITLE
feat: validate branch can be modified with check branch length function

### DIFF
--- a/taf/validation.py
+++ b/taf/validation.py
@@ -14,6 +14,7 @@ def validate_branch(
     updated_roles,
     check_capstone_roles=None,
     check_branch_roles=None,
+    check_branch_lengths_fun=None,
 ):
     """
     Validates corresponding branches of the authentication repository
@@ -45,7 +46,10 @@ def validate_branch(
         branch_name, merge_branches[auth_repo]
     )
 
-    _check_lengths_of_branches(targets_and_commits, branch_name)
+    if check_branch_lengths_fun:
+        check_branch_lengths_fun(targets_and_commits, branch_name)
+    else:
+        _check_lengths_of_branches(targets_and_commits, branch_name)
 
     unmodified_roles_and_versions = {
         role_name: None


### PR DESCRIPTION
We're lacking some flexibility when validating different kinds of branches that don't fit into our regular branch style. We have this issues with RDF, and we used different validation logic to side-step taf. To fix this, we just need different branch length validation. This commit makes `validate_branch` accept `check_branch_lengths_fun` as argument and thus makes the function more generic and parametrizable.

Closes: #331

## Description (e.g. "Related to ...", etc.)

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
