### PR TITLE
is_git_repository rework and fix failing test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning][semver].
 ### Added
 
 
-- - Added lazy loading to CLI [481]
+- Added lazy loading to CLI [481]
 - Testing repositories with dependencies ([479], [487])
 - Hid plaintext when users are prompted to insert YubiKey and press ENTER [473]
 - Added functionality for parallel execution of child repo during clone and update for performance enhancement [472]
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- Raise a more descriptive error if `pygit2` repository cannot be instantiated  ([485], [489])
 - Enhanced commit_and_push for better error logging and update the last validated commit ([469])
 - Generate public key from private key if .pub file is missing ([462])
 - Port release workflow from Azure Pipelines to GitHub Actions ([458])
@@ -35,8 +36,9 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
-
+[487]: https://github.com/openlawlibrary/taf/pull/489
 [487]: https://github.com/openlawlibrary/taf/pull/487
+[487]: https://github.com/openlawlibrary/taf/pull/485
 [481]: https://github.com/openlawlibrary/taf/pull/481
 [479]: https://github.com/openlawlibrary/taf/pull/479
 [473]: https://github.com/openlawlibrary/taf/pull/473

--- a/taf/api/targets.py
+++ b/taf/api/targets.py
@@ -299,11 +299,10 @@ def list_targets(
                             last_signed_commit
                         ):
                             branch_top_commit = repo.top_commit_of_branch(branch)
-                            repo_output["unsigned"] = (
-                                branch_top_commit
-                                in repo.all_commits_since_commit(
-                                    last_signed_commit, branch
-                                )
+                            repo_output[
+                                "unsigned"
+                            ] = branch_top_commit in repo.all_commits_since_commit(
+                                last_signed_commit, branch
                             )
             repo_output["something-to-commit"] = repo.something_to_commit()
 

--- a/taf/exceptions.py
+++ b/taf/exceptions.py
@@ -173,8 +173,8 @@ class TimestampMetadataUpdateError(MetadataUpdateError):
 
 class PygitError(TAFError):
     pass
-        
-         
+
+
 class NoSpeculativeBranchError(TAFError):
     pass
 

--- a/taf/git.py
+++ b/taf/git.py
@@ -114,10 +114,13 @@ class GitRepository:
         if self._pygit is None:
             try:
                 self._pygit = PyGitRepository(self)
+                if not self._pygit:
+                    raise PygitError("PyGitRepository instance is None")
+
             except Exception as e:
-                raise PygitError(
-                    f"Failed to instantiate PyGitRepository due to error: {e}"
-                )
+                error_message = f"Failed to instantiate PyGitRepository: {e}"
+                logging.error(error_message)
+                raise PygitError(error_message)
         return self._pygit
 
     @classmethod

--- a/taf/git.py
+++ b/taf/git.py
@@ -181,6 +181,7 @@ class GitRepository:
 
         except GitError:
             return False
+        return False
 
     @property
     def is_git_repository_root(self) -> bool:

--- a/taf/git.py
+++ b/taf/git.py
@@ -206,9 +206,9 @@ class GitRepository:
         return f"Repo {self.name}: "
 
     @property
-    def pygit_repo(self) -> Optional[pygit2.Repository]:
+    def pygit_repo(self) -> pygit2.Repository:
         if self.pygit.repo is None:
-            raise PygitError(f"Failed to instantiate PyGitRepository")
+            raise PygitError("Failed to instantiate PyGitRepository")
         return self.pygit.repo
 
     @property

--- a/taf/git.py
+++ b/taf/git.py
@@ -207,6 +207,8 @@ class GitRepository:
 
     @property
     def pygit_repo(self) -> Optional[pygit2.Repository]:
+        if self.pygit.repo is None:
+            raise PygitError(f"Failed to instantiate PyGitRepository")
         return self.pygit.repo
 
     @property

--- a/taf/git.py
+++ b/taf/git.py
@@ -109,7 +109,7 @@ class GitRepository:
         if not self.is_git_repository:
             raise GitError(
                 self,
-                message=f"The path '{self.path}' is not a Git repository.",
+                message=f"The path '{self.path.as_posix()}' is not a Git repository.",
             )
         if self._pygit is None:
             try:

--- a/taf/pygit.py
+++ b/taf/pygit.py
@@ -5,7 +5,7 @@ from taf.log import taf_logger as logger
 from taf.exceptions import GitError
 from taf.exceptions import PygitError
 import os.path
-import logging 
+import logging
 
 
 class PyGitRepository:
@@ -123,10 +123,3 @@ class PyGitRepository:
                 message=f"fatal: Path '{path}' does not exist in '{commit}'",
             )
         return self._list_files_at_revision(root)
-    
-    def __init__(self, path: str):
-        try:
-            self.repo = pygit2.Repository(path)
-        except Exception as e:
-            logging.error(f"Failed to instantiate PyGitRepository: {str(e)}")
-            raise PygitError(f"Failed to instantiate PyGitRepository: {str(e)}")

--- a/taf/pygit.py
+++ b/taf/pygit.py
@@ -3,9 +3,7 @@ import pygit2
 from collections import defaultdict
 from taf.log import taf_logger as logger
 from taf.exceptions import GitError
-from taf.exceptions import PygitError
 import os.path
-import logging
 
 
 class PyGitRepository:

--- a/taf/tests/test_git/test_git.py
+++ b/taf/tests/test_git/test_git.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import pytest
 import tempfile
 from taf.exceptions import GitError

--- a/taf/tests/test_git/test_git.py
+++ b/taf/tests/test_git/test_git.py
@@ -36,10 +36,9 @@ def test_is_git_repository_root_non_bare(repository):
 
 def test_head_commit_sha():
     with tempfile.TemporaryDirectory() as tmpdirname:
-        repo_path = Path(tmpdirname).as_posix()
         repo = GitRepository(path=tmpdirname)
         with pytest.raises(
             GitError,
-            match=f"Repo {repo.name}: The path '{repo_path}' is not a Git repository.",
+            match=f"Repo {repo.name}: The path '{repo.path.as_posix()}' is not a Git repository.",
         ):
             repo.head_commit_sha() is not None

--- a/taf/tests/test_git/test_git.py
+++ b/taf/tests/test_git/test_git.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import pytest
 import tempfile
 from taf.exceptions import GitError
@@ -35,6 +36,10 @@ def test_is_git_repository_root_non_bare(repository):
 
 def test_head_commit_sha():
     with tempfile.TemporaryDirectory() as tmpdirname:
+        repo_path = Path(tmpdirname).as_posix()
         repo = GitRepository(path=tmpdirname)
-        with pytest.raises(GitError, match=f"{tmpdirname} is not a git repository"):
+        with pytest.raises(
+            GitError,
+            match=f"Repo {repo.name}: The path '{repo_path}' is not a Git repository.",
+        ):
             repo.head_commit_sha() is not None

--- a/taf/tests/test_repository/test_repository.py
+++ b/taf/tests/test_repository/test_repository.py
@@ -133,11 +133,7 @@ def test_to_json_dict():
             else:
                 assert repo_value == attr_value
 
-    for (
-        repo_library_dir,
-        repo_name,
-        repo_path,
-    ) in (
+    for (repo_library_dir, repo_name, repo_path,) in (
         (library_dir, name, None),
         (None, None, Path(library_dir, name)),
     ):

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -81,9 +81,9 @@ class UpdateState:
     validated_commits_per_target_repos_branches: Dict[str, Dict[str, str]] = field(
         factory=dict
     )
-    additional_commits_per_target_repos_branches: Dict[str, Dict[str, List[str]]] = (
-        field(factory=dict)
-    )
+    additional_commits_per_target_repos_branches: Dict[
+        str, Dict[str, List[str]]
+    ] = field(factory=dict)
     validated_auth_commits: List[str] = field(factory=list)
     temp_root: TempPartition = field(default=None)
 
@@ -1352,10 +1352,12 @@ but commit not on branch {current_branch}"
                         ).get(branch)
                         branch_data[branch]["new"] = [commit_info]
                         branch_data[branch]["after_pull"] = [commit_info]
-                        branch_data[branch]["unauthenticated"] = (
-                            self.state.additional_commits_per_target_repos_branches.get(
-                                repo_name, {}
-                            ).get(branch, [])
+                        branch_data[branch][
+                            "unauthenticated"
+                        ] = self.state.additional_commits_per_target_repos_branches.get(
+                            repo_name, {}
+                        ).get(
+                            branch, []
                         )
                         if old_head is not None:
                             branch_data[branch]["before_pull"] = old_head


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Implement `is_git_repository` without using `pygit_repository` in order to avoid a circular invocation

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
