### PR TITLE
Fix setup role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Fix setup role when specifying public keys in keys-description ([511])
+
+[511]: https://github.com/openlawlibrary/taf/pull/511
 [508]: https://github.com/openlawlibrary/taf/pull/508
 [504]: https://github.com/openlawlibrary/taf/pull/504
 [494]: https://github.com/openlawlibrary/taf/pull/494

--- a/taf/api/targets.py
+++ b/taf/api/targets.py
@@ -368,7 +368,7 @@ def register_target_files(
         prompt_for_keys=prompt_for_keys,
     )
 
-    if write:
+    if updated and write:
         taf_repo.writeall()
         if commit:
             auth_repo = AuthenticationRepository(path=taf_repo.path)

--- a/taf/api/utils/_roles.py
+++ b/taf/api/utils/_roles.py
@@ -131,7 +131,9 @@ def setup_role(
         # as previous_keys
         # this means that TUF expects at least one of those signing keys to be present
         # we are setting up this role, so there should be no previous keys
-        tuf.roledb._roledb_dict[repository._repository_name][role.name]["previous_keyids"] = []
+        tuf.roledb._roledb_dict[repository._repository_name][role.name][
+            "previous_keyids"
+        ] = []
 
 
 def _role_obj(

--- a/taf/api/utils/_roles.py
+++ b/taf/api/utils/_roles.py
@@ -96,7 +96,7 @@ def get_roles_and_paths_of_key(
 @log_on_end(DEBUG, "Finished setting up role {role.name:s}", logger=taf_logger)
 def setup_role(
     role: Role,
-    repository: Repository,
+    repository: TUFRepository,
     verification_keys: Dict,
     signing_keys: Optional[Dict] = None,
     parent: Optional[Targets] = None,

--- a/taf/api/utils/_roles.py
+++ b/taf/api/utils/_roles.py
@@ -126,7 +126,7 @@ def setup_role(
                 role_obj.add_external_signature_provider(
                     key, partial(yubikey_signature_provider, key_name, key["keyid"])
                 )
-        # Even though we add all verification key (public keys directly specified in the keys-description)
+        # Even though we add all verification keys (public keys directly specified in the keys-description)
         # and those loaded from YubiKeys, only those directly specified in keys-description are registered
         # as previous_keys
         # this means that TUF expects at least one of those signing keys to be present

--- a/taf/api/utils/_roles.py
+++ b/taf/api/utils/_roles.py
@@ -1,3 +1,4 @@
+import tuf
 from logging import DEBUG, INFO
 from typing import Dict, List, Optional, Union
 from functools import partial
@@ -125,6 +126,12 @@ def setup_role(
                 role_obj.add_external_signature_provider(
                     key, partial(yubikey_signature_provider, key_name, key["keyid"])
                 )
+        # Even though we add all verification key (public keys directly specified in the keys-description)
+        # and those loaded from YubiKeys, only those directly specified in keys-description are registered
+        # as previous_keys
+        # this means that TUF expects at least one of those signing keys to be present
+        # we are setting up this role, so there should be no previous keys
+        tuf.roledb._roledb_dict[repository._repository_name][role.name]["previous_keyids"] = []
 
 
 def _role_obj(


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

If public keys are specified in the keys-description, these verification keys are added without corresponding signing keys. TUF registers these key IDs as previous key IDs. This means that signing will fail unless one of the signing keys matches one of the public keys (we must have tested this with a YubiKey containing such a key).

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
