### PR TITLE
fix: move yubikey_utils from tests folder

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ except ModuleNotFoundError:
     tests_exist = False  # type: ignore
 if tests_exist:
     kwargs["entry_points"]["pytest11"] = (
-        ["taf_yubikey_utils = taf.tests.yubikey_utils"],
+        ["taf_yubikey_utils = taf.tools.yubikey.yubikey_utils"],
     )
 
 setup(**kwargs)

--- a/taf/tests/test_repository_tool/conftest.py
+++ b/taf/tests/test_repository_tool/conftest.py
@@ -5,7 +5,7 @@ from securesystemslib.interface import (
     import_rsa_publickey_from_file,
 )
 from taf.repository_tool import Repository
-from taf.tests.yubikey_utils import (
+from taf.tools.yubikey.yubikey_utils import (
     Root1YubiKey,
     Root2YubiKey,
     Root3YubiKey,

--- a/taf/tests/test_repository_tool/test_repository_tool.py
+++ b/taf/tests/test_repository_tool/test_repository_tool.py
@@ -9,7 +9,7 @@ import taf.exceptions
 import taf.yubikey as yk
 from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
 from taf.tests import TEST_WITH_REAL_YK
-from taf.tests.yubikey_utils import VALID_PIN
+from taf.tools.yubikey.yubikey_utils import VALID_PIN
 from taf.utils import to_tuf_datetime_format
 
 

--- a/taf/tests/test_yubikey/conftest.py
+++ b/taf/tests/test_yubikey/conftest.py
@@ -3,7 +3,7 @@ from taf.tests import TEST_WITH_REAL_YK
 from taf.tests.conftest import KEYSTORE_PATH
 
 from pytest import fixture
-from taf.tests.yubikey_utils import TargetYubiKey, _yk_piv_ctrl_mock
+from taf.tools.yubikey.yubikey_utils import TargetYubiKey, _yk_piv_ctrl_mock
 
 
 def pytest_configure(config):

--- a/taf/tools/yubikey/yubikey_utils.py
+++ b/taf/tools/yubikey/yubikey_utils.py
@@ -1,5 +1,5 @@
 import datetime
-import random
+import secrets
 from contextlib import contextmanager
 
 from cryptography import x509
@@ -19,7 +19,7 @@ class FakeYubiKey:
         self.priv_key_pem = priv_key_path.read_bytes()
         self.pub_key_pem = pub_key_path.read_bytes()
 
-        self._serial = serial if serial else random.randint(100000, 999999)
+        self._serial = serial if serial else secrets.randbelow(900000) + 100000
         self._pin = pin
 
         self.scheme = scheme


### PR DESCRIPTION

## Description (e.g. "Related to ...", etc.)

`yubikey_utils` module should be moved from tests folder since this folder is excluded during wheel creation.
Use random generator suitable for security/cryptographic purposes (bandit).

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
