### PR TITLE
fix: use mirrors.json urls when cloning dependencies

### DIFF
--- a/taf/tests/test_updater/update_utils.py
+++ b/taf/tests/test_updater/update_utils.py
@@ -126,7 +126,7 @@ def clone_repositories(
         shutil.rmtree(client_test_root)
     config = UpdateConfig(
         operation=OperationType.CLONE,
-        url=str(origin_auth_repo.path),
+        remote_url=str(origin_auth_repo.path),
         update_from_filesystem=True,
         path=None,
         library_dir=str(clients_dir),
@@ -235,7 +235,7 @@ def update_and_check_commit_shas(
 
     config = UpdateConfig(
         operation=operation,
-        url=str(origin_auth_repo.path),
+        remote_url=str(origin_auth_repo.path),
         update_from_filesystem=True,
         path=str(clients_auth_repo_path) if auth_repo_name_exists else None,
         library_dir=str(clients_dir),
@@ -299,7 +299,7 @@ def update_invalid_repos_and_check_if_repos_exist(
 
     config = UpdateConfig(
         operation=operation,
-        url=str(origin_auth_repo.path),
+        remote_url=str(origin_auth_repo.path),
         update_from_filesystem=True,
         path=str(clients_auth_repo_path) if auth_repo_name_exists else None,
         library_dir=str(clients_dir),

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -151,7 +151,7 @@ def clone_repo_command():
 
         config = UpdateConfig(
             operation=OperationType.CLONE,
-            url=url,
+            remote_url=url,
             path=path,
             library_dir=library_dir,
             update_from_filesystem=from_fs,

--- a/taf/updater/handlers.py
+++ b/taf/updater/handlers.py
@@ -76,7 +76,7 @@ class GitUpdater(FetcherInterface):
     def targets_dir(self):
         return str(self.validation_auth_repo.path / "targets")
 
-    def __init__(self, auth_url, repository_directory, repository_name):
+    def __init__(self, auth_urls, repository_directory, repository_name):
         """
         Args:
         auth_url: repository url of the git repository which we want to clone.
@@ -91,7 +91,7 @@ class GitUpdater(FetcherInterface):
 
         validation_path = settings.validation_repo_path.get(repository_name)
 
-        self.set_validation_repo(validation_path, auth_url)
+        self.set_validation_repo(validation_path, auth_urls)
 
         self._init_commits()
 
@@ -187,11 +187,11 @@ class GitUpdater(FetcherInterface):
 
         return wrapper
 
-    def set_validation_repo(self, path, url):
+    def set_validation_repo(self, path, urls):
         """
         Used outside of GitUpdater to access validation auth repo.
         """
-        self.validation_auth_repo = AuthenticationRepository(path=path, urls=[url])
+        self.validation_auth_repo = AuthenticationRepository(path=path, urls=urls)
 
     def cleanup(self):
         """

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -347,7 +347,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
             ),
         )
         self.operation = update_config.operation
-        self.url = update_config.url
+        self.urls = update_config.clone_urls or [update_config.remote_url]
         self.library_dir = update_config.library_dir
         self.auth_path = update_config.path
         self.update_from_filesystem = update_config.update_from_filesystem
@@ -410,7 +410,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
         self.state.existing_repo = False
         if self.auth_path:
             self.state.users_auth_repo = AuthenticationRepository(
-                path=self.auth_path, urls=[self.url]
+                path=self.auth_path, urls=self.urls
             )
             self.state.auth_repo_name = self.state.users_auth_repo.name
             if self.state.users_auth_repo.is_git_repository_root:
@@ -468,7 +468,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
             if not self.state.existing_repo:
                 return UpdateStatus.SUCCESS
 
-            auth_repo = AuthenticationRepository(path=self.auth_path, urls=[self.url])
+            auth_repo = AuthenticationRepository(path=self.auth_path, urls=self.urls)
             taf_logger.info(
                 f"{auth_repo.name}: Checking if local repositories are clean..."
             )
@@ -594,7 +594,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
 
             path = Path(self.state.temp_root.temp_dir, "auth_repo").absolute()
             self.state.validation_auth_repo = AuthenticationRepository(
-                path=path, urls=[self.url], alias="Validation repository"
+                path=path, urls=self.urls, alias="Validation repository"
             )
             self.state.validation_auth_repo.clone(bare=True)
             self.state.validation_auth_repo.fetch(fetch_all=True)
@@ -760,7 +760,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
         try:
 
             self.state.update_handler = GitUpdater(
-                self.url, self.library_dir, self.state.validation_auth_repo.name
+                self.urls, self.library_dir, self.state.validation_auth_repo.name
             )
             last_validated_remote_commit, error = _run_tuf_updater(
                 self.state.update_handler, self.state.auth_repo_name
@@ -791,7 +791,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                 self.state.users_auth_repo = AuthenticationRepository(
                     library_dir=self.library_dir,
                     name=self.state.auth_repo_name,
-                    urls=[self.url],
+                    urls=self.urls,
                 )
 
             self._validate_operation_type()
@@ -854,7 +854,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                 self.state.users_auth_repo = AuthenticationRepository(
                     self.library_dir,
                     self.state.auth_repo_name,
-                    urls=[self.url],
+                    urls=self.urls,
                 )
 
     def _validate_operation_type(self):


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Fixes NILL when running `taf repo clone https://github.com/oll-test-repos/narf-nill-law.git` and some of the target repos have ssh instead of https urls.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
