### PR TITLE
Release 0.32.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import find_packages, setup
-import sys
 
 PACKAGE_NAME = "taf"
 VERSION = "0.31.2"
@@ -59,8 +58,8 @@ kwargs = {
         "cryptography==38.0.*",
         "securesystemslib==0.25.*",
         "loguru==0.7.*",
-        "pygit2==1.9.*; python_version < \"3.11\"",
-        "pygit2==1.14.*; python_version >= \"3.11\"",
+        'pygit2==1.9.*; python_version < "3.11"',
+        'pygit2==1.14.*; python_version >= "3.11"',
         "pyOpenSSL==22.1.*",
         "logdecorator==2.*",
     ],

--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,6 @@ tests_require = [
 
 yubikey_require = ["yubikey-manager==5.1.*"]
 
-# Determine the appropriate version of pygit2 based on the Python version
-if sys.version_info >= (3, 11):
-    pygit2_version = "pygit2==1.14.1"
-elif sys.version_info >= (3, 7) and sys.version_info < (3, 11):
-    pygit2_version = "pygit2==1.9.*"
 
 kwargs = {
     "name": PACKAGE_NAME,
@@ -64,7 +59,8 @@ kwargs = {
         "cryptography==38.0.*",
         "securesystemslib==0.25.*",
         "loguru==0.7.*",
-        pygit2_version,
+        "pygit2==1.9.*; python_version < \"3.11\"",
+        "pygit2==1.14.*; python_version >= \"3.11\"",
         "pyOpenSSL==22.1.*",
         "logdecorator==2.*",
     ],

--- a/taf/api/dependencies.py
+++ b/taf/api/dependencies.py
@@ -8,7 +8,7 @@ from taf.api.utils._metadata import (
     update_snapshot_and_timestamp,
     update_target_metadata,
 )
-from taf.api.utils._git import check_if_clean, commit_and_push
+from taf.api.utils._git import check_if_clean
 from taf.messages import git_commit_message
 from pathlib import Path
 
@@ -176,7 +176,7 @@ def add_dependency(
         commit_msg = git_commit_message(
             "add-dependency", dependency_name=dependency_name
         )
-        commit_and_push(auth_repo, commit_msg=commit_msg, push=push)
+        auth_repo.commit_and_push(commit_msg=commit_msg, push=push)
     else:
         print("\nPlease commit manually.\n")
 
@@ -266,7 +266,7 @@ def remove_dependency(
         commit_msg = git_commit_message(
             "remove-dependency", dependency_name=dependency_name
         )
-        commit_and_push(auth_repo, commit_msg=commit_msg, push=push)
+        auth_repo.commit_and_push(commit_msg=commit_msg, push=push)
     else:
         print("\nPlease commit manually.\n")
 

--- a/taf/api/metadata.py
+++ b/taf/api/metadata.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from logging import INFO, ERROR
 from typing import Dict, List, Optional, Tuple
 from logdecorator import log_on_end, log_on_error
-from taf.api.utils._git import check_if_clean, commit_and_push
+from taf.api.utils._git import check_if_clean
 from taf.exceptions import TAFError
 from taf.keys import load_signing_keys
 from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
@@ -156,7 +156,7 @@ def update_metadata_expiration_date(
         commit_msg = git_commit_message(
             "update-expiration-dates", roles=",".join(roles)
         )
-        commit_and_push(auth_repo, commit_msg=commit_msg, push=push)
+        auth_repo.commit_and_push(commit_msg=commit_msg, push=push)
 
 
 @log_on_end(INFO, "Updated expiration date of {role:s}", logger=taf_logger)

--- a/taf/api/repository.py
+++ b/taf/api/repository.py
@@ -6,7 +6,6 @@ from taf.api.utils._roles import setup_role
 from taf.messages import git_commit_message
 from taf.models.types import RolesIterator
 from taf.models.types import RolesKeysData
-from taf.api.utils._git import commit_and_push
 from taf.models.converter import from_dict
 
 from pathlib import Path
@@ -125,7 +124,7 @@ def create_repository(
     if commit:
         auth_repo.init_repo()
         commit_msg = git_commit_message("create-repo")
-        commit_and_push(auth_repo, push=False, commit_msg=commit_msg)
+        auth_repo.commit_and_push(push=False, commit_msg=commit_msg)
     else:
         print("\nPlease commit manually.\n")
 

--- a/taf/api/repository.py
+++ b/taf/api/repository.py
@@ -194,7 +194,7 @@ def taf_status(path: str, library_dir: Optional[str] = None, indent: int = 0) ->
     print(f"{indent_str}Something to commit: {auth_repo.something_to_commit()}")
     print(f"{indent_str}Target Repositories Status:")
     # Call the list_targets function
-    list_targets(path=path, library_dir=library_dir)
+    list_targets(path=path)
 
     # Load dependencies using repositoriesdb.get_auth_repositories
     repositoriesdb.load_dependencies(auth_repo, library_dir=library_dir)

--- a/taf/api/roles.py
+++ b/taf/api/roles.py
@@ -10,7 +10,7 @@ from logdecorator import log_on_end, log_on_error, log_on_start
 from taf.api.utils._roles import _role_obj, create_delegations
 from taf.messages import git_commit_message
 from tuf.repository_tool import Targets
-from taf.api.utils._git import check_if_clean, commit_and_push
+from taf.api.utils._git import check_if_clean
 from taf.exceptions import KeystoreError, TAFError
 from taf.models.converter import from_dict
 from taf.models.types import RolesIterator, TargetsRole, compare_roles_data
@@ -140,7 +140,7 @@ def add_role(
             auth_repo, keystore, scheme=scheme, prompt_for_keys=prompt_for_keys
         )
         commit_msg = git_commit_message("add-role", role=role)
-        commit_and_push(auth_repo, commit_msg=commit_msg, push=push)
+        auth_repo.commit_and_push(commit_msg=commit_msg, push=push)
     else:
         taf_logger.log("NOTICE", "\nPlease commit manually\n")
 
@@ -206,7 +206,7 @@ def add_role_paths(
             commit_msg = git_commit_message(
                 "add-role-paths", paths=", ".join(paths), role=delegated_role
             )
-            commit_and_push(auth_repo, commit_msg=commit_msg, push=push)
+            auth_repo.commit_and_push(commit_msg=commit_msg, push=push)
         else:
             taf_logger.log("NOTICE", "\nPlease commit manually\n")
     else:
@@ -303,7 +303,7 @@ def add_multiple_roles(
     if commit:
         roles_names = [role.name for role in new_roles]
         commit_msg = git_commit_message("add-roles", roles=", ".join(roles_names))
-        commit_and_push(auth_repo, commit_msg=commit_msg, push=push)
+        auth_repo.commit_and_push(commit_msg=commit_msg, push=push)
     else:
         taf_logger.log("NOTICE", "\nPlease commit manually\n")
 
@@ -414,7 +414,7 @@ def add_signing_key(
         # commit_msg = git_commit_message(
         #     "add-signing-key", role={role}
         # )
-        commit_and_push(auth_repo, commit_msg=commit_msg, push=push)
+        auth_repo.commit_and_push(commit_msg=commit_msg, push=push)
     else:
         taf_logger.log("NOTICE", "\nPlease commit manually\n")
 
@@ -842,7 +842,7 @@ def remove_role(
     )
     if commit:
         commit_msg = git_commit_message("remove-role", role=role)
-        commit_and_push(auth_repo, commit_msg=commit_msg, push=push)
+        auth_repo.commit_and_push(commit_msg=commit_msg, push=push)
     else:
         taf_logger.log("NOTICE", "Please commit manually")
 
@@ -903,7 +903,7 @@ def remove_paths(
         commit_msg = git_commit_message(
             "remove-role-paths", paths=", ".join(paths), role=delegated_role
         )
-        commit_and_push(auth_repo, commit_msg=commit_msg, push=push)
+        auth_repo.commit_and_push(commit_msg=commit_msg, push=push)
     elif delegation_existed:
         taf_logger.log("NOTICE", "\nPlease commit manually\n")
     return delegation_existed

--- a/taf/api/targets.py
+++ b/taf/api/targets.py
@@ -443,7 +443,7 @@ def remove_target_repo(
         os.unlink(str(target_file_path))
         removed_targets_data[target_name] = {}
     else:
-        taf_logger.log("NOTICE", f"{target_file_path} target file does not exist")
+        taf_logger.info(f"{target_file_path} target file does not exist")
 
     changes_committed = False
     if len(added_targets_data) or len(removed_targets_data):
@@ -480,7 +480,7 @@ def remove_target_repo(
         )
         changes_committed = True
     else:
-        taf_logger.log("NOTICE", f"{target_name} not among delegated paths")
+        taf_logger.info(f"{target_name} not among delegated paths")
     # update snapshot and timestamp calls write_all, so targets updates will be saved too
     if changes_committed and push:
         auth_repo.push()

--- a/taf/api/targets.py
+++ b/taf/api/targets.py
@@ -16,7 +16,7 @@ from taf.api.roles import (
     add_role_paths,
     remove_paths,
 )
-from taf.api.utils._git import check_if_clean, commit_and_push
+from taf.api.utils._git import check_if_clean
 from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
 from taf.exceptions import TAFError
 from taf.git import GitRepository
@@ -185,7 +185,7 @@ def add_target_repo(
     )
     if commit:
         commit_msg = git_commit_message("add-target", target_name=target_name)
-        commit_and_push(auth_repo, commit_msg=commit_msg, push=push)
+        auth_repo.commit_and_push(commit_msg=commit_msg, push=push)
     else:
         taf_logger.log("NOTICE", "\nPlease commit manually\n")
 
@@ -265,7 +265,7 @@ def list_targets(
     head_commit = auth_repo.head_commit_sha()
     if head_commit is None:
         taf_logger.log("NOTICE", "Repository is empty")
-        return
+        return {}
     top_commit = [head_commit]
     repositoriesdb.load_repositories(auth_repo)
     target_repositories = repositoriesdb.get_deduplicated_repositories(auth_repo)
@@ -377,7 +377,7 @@ def register_target_files(
         if commit:
             auth_repo = AuthenticationRepository(path=taf_repo.path)
             commit_msg = git_commit_message("update-targets")
-            commit_and_push(auth_repo, commit_msg=commit_msg, push=push)
+            auth_repo.commit_and_push(commit_msg=commit_msg, push=push)
         elif not no_commit_warning:
             taf_logger.log("NOTICE", "\nPlease commit manually\n")
 

--- a/taf/api/targets.py
+++ b/taf/api/targets.py
@@ -18,7 +18,7 @@ from taf.api.roles import (
 )
 from taf.api.utils._git import check_if_clean, commit_and_push
 from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
-from taf.exceptions import NoRemoteError, TAFError
+from taf.exceptions import TAFError
 from taf.git import GitRepository
 from taf.messages import git_commit_message
 
@@ -246,7 +246,7 @@ def export_targets_history(
 
 def list_targets(
     path: str,
-) -> None:
+) -> Dict:
     """
     Returns a dictionary containing target repositories of an authentication repository and their states (are the work directories clean, are there
     remove changes that have not yed been pulled, are there commits that have not yet been signed).

--- a/taf/api/utils/_git.py
+++ b/taf/api/utils/_git.py
@@ -1,9 +1,6 @@
 import functools
-from typing import Optional
-from taf.auth_repo import AuthenticationRepository
-from taf.exceptions import GitError, RepositoryNotCleanError, TAFError
+from taf.exceptions import RepositoryNotCleanError
 from taf.git import GitRepository
-from taf.log import taf_logger
 
 
 def check_if_clean(func):

--- a/taf/api/utils/_git.py
+++ b/taf/api/utils/_git.py
@@ -20,34 +20,3 @@ def check_if_clean(func):
         return func(*args, **kwargs)
 
     return wrapper
-
-
-def commit_and_push(
-    auth_repo: AuthenticationRepository,
-    commit_msg: Optional[str] = None,
-    push: Optional[bool] = True,
-) -> None:
-    if commit_msg is None:
-        commit_msg = input("\nEnter commit message and press ENTER\n\n")
-    auth_repo.commit(commit_msg)
-
-    if push and auth_repo.has_remote():
-        try:
-            auth_repo.push()
-            taf_logger.log("NOTICE", "Successfully pushed to remote")
-
-            new_commit_branch = auth_repo.default_branch
-            if new_commit_branch:
-                new_commit = auth_repo.top_commit_of_branch(new_commit_branch)
-                if new_commit:
-                    auth_repo.set_last_validated_commit(new_commit)
-                    taf_logger.info(f"Updated last_validated_commit to {new_commit}")
-            else:
-                taf_logger.warning(
-                    "Default branch is None, skipping last_validated_commit update."
-                )
-        except GitError as e:
-            taf_logger.error(
-                f"Push failed: {str(e)}. Please check if there are upstream changes."
-            )
-            raise TAFError("Push operation failed") from e

--- a/taf/auth_repo.py
+++ b/taf/auth_repo.py
@@ -150,6 +150,34 @@ class AuthenticationRepository(GitRepository, TAFRepository):
             return f"{self.alias}: "
         return f"Auth repo {self.name}: "
 
+    def commit_and_push(
+        self,
+        commit_msg: Optional[str] = None,
+        push: Optional[bool] = True,
+        commit: Optional[bool] = True,
+    ) -> None:
+
+        if commit:
+            if commit_msg is None:
+                commit_msg = input("\nEnter commit message and press ENTER\n\n")
+            self.commit(commit_msg)
+
+        if push:
+            push_successful = self.push()
+            if push_successful:
+                new_commit_branch = self.default_branch
+                if new_commit_branch:
+                    new_commit = self.top_commit_of_branch(new_commit_branch)
+                    if new_commit:
+                        self.set_last_validated_commit(new_commit)
+                        self._log_notice(
+                            "NOTICE", f"Updated last_validated_commit to {new_commit}"
+                        )
+                else:
+                    self._log_warning(
+                        "Default branch is None, skipping last_validated_commit update."
+                    )
+
     def get_target(self, target_name, commit=None, safely=True) -> Optional[Dict]:
         if commit is None:
             commit = self.head_commit_sha()

--- a/taf/auth_repo.py
+++ b/taf/auth_repo.py
@@ -171,7 +171,7 @@ class AuthenticationRepository(GitRepository, TAFRepository):
                     if new_commit:
                         self.set_last_validated_commit(new_commit)
                         self._log_notice(
-                            "NOTICE", f"Updated last_validated_commit to {new_commit}"
+                            f"Updated last_validated_commit to {new_commit}"
                         )
                 else:
                     self._log_warning(

--- a/taf/exceptions.py
+++ b/taf/exceptions.py
@@ -117,6 +117,12 @@ class MultipleRepositoriesNotCleanError(TAFError):
         self.message = message
 
 
+class NoRemoteError(GitError):
+    def __init__(self, repo):
+        message = f"No remotes configured for repository {repo.name}"
+        super().__init__(message)
+
+
 class ScriptExecutionError(TAFError):
     def __init__(self, script: str, error_msg: str):
         message = (

--- a/taf/git.py
+++ b/taf/git.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import taf.settings as settings
 from taf.exceptions import (
+    NoRemoteError,
     NothingToCommitError,
     TAFError,
     CloneRepoException,
@@ -1516,6 +1517,8 @@ class GitRepository:
         # check if the latest local commit matches
         # the latest remote commit on the specified branch
 
+        if not self.has_remote():
+            raise NoRemoteError(self)
         if url:
             urls = [url]
         elif self.urls:

--- a/taf/git.py
+++ b/taf/git.py
@@ -9,7 +9,7 @@ import pygit2
 import subprocess
 import logging
 from collections import OrderedDict
-from functools import reduce
+from functools import partial, reduce
 from pathlib import Path
 
 import taf.settings as settings
@@ -24,7 +24,7 @@ from taf.exceptions import (
     UpdateFailedError,
     PygitError,
 )
-from taf.log import taf_logger
+from taf.log import NOTICE, taf_logger
 from taf.utils import run
 from typing import Callable, Dict, List, Optional, Tuple, Union
 from .pygit import PyGitRepository
@@ -144,6 +144,7 @@ class GitRepository:
     logging_functions = {
         logging.DEBUG: taf_logger.debug,
         logging.INFO: taf_logger.info,
+        NOTICE: partial(taf_logger.log, "NOTICE"),
         logging.WARNING: taf_logger.warning,
         logging.ERROR: taf_logger.error,
         logging.CRITICAL: taf_logger.critical,
@@ -348,6 +349,9 @@ class GitRepository:
 
     def _log_info(self, message: str) -> None:
         self._log(self.logging_functions[logging.INFO], message)
+
+    def _log_notice(self, message: str) -> None:
+        self._log(self.logging_functions[NOTICE], message)
 
     def _log_warning(self, message: str) -> None:
         self._log(self.logging_functions[logging.WARNING], message)
@@ -1393,26 +1397,37 @@ class GitRepository:
         branch: Optional[str] = None,
         set_upstream: Optional[bool] = False,
         force: Optional[bool] = False,
-    ) -> None:
-        """Push all changes"""
-        if branch is None:
-            branch = self.get_current_branch()
+    ) -> bool:
 
-        hook_path = Path(self.path) / ".git" / "hooks" / "pre-push"
-        if hook_path.exists():
-            self._log_info("Validating and pushing...")
+        if not self.has_remote():
+            self._log_warning("Could not push changes. No remotes configured")
+            return False
 
-        upstream_flag = "-u" if set_upstream else ""
-        force_flag = "-f" if force else ""
-        self._git(
-            "push {} {} origin {}",
-            upstream_flag,
-            force_flag,
-            branch,
-            log_error=True,
-            reraise_error=True,
-            log_success_msg="Successfully pushed commit(s)",
-        )
+        try:
+            """Push all changes"""
+            if branch is None:
+                branch = self.get_current_branch()
+
+            hook_path = Path(self.path) / ".git" / "hooks" / "pre-push"
+            if hook_path.exists():
+                self._log_notice("Validating and pushing...")
+
+            upstream_flag = "-u" if set_upstream else ""
+            force_flag = "-f" if force else ""
+            self._git(
+                "push {} {} origin {}",
+                upstream_flag,
+                force_flag,
+                branch,
+                reraise_error=True,
+            )
+            self._log_notice("Successfully pushed to remote")
+            return True
+        except GitError as e:
+            self._log_error(
+                f"Push failed: {str(e)}. Please check if there are upstream changes."
+            )
+            raise TAFError("Push operation failed") from e
 
     def remove_remote(self, remote_name: str) -> None:
         try:

--- a/taf/tests/test_updater/conftest.py
+++ b/taf/tests/test_updater/conftest.py
@@ -41,7 +41,6 @@ from taf.tests.conftest import (
     KEYSTORE_PATH,
     TEST_INIT_DATA_PATH,
 )
-from taf.api.utils._git import commit_and_push
 
 
 KEYS_DESCRIPTION = str(TEST_INIT_DATA_PATH / "keys.json")
@@ -678,7 +677,7 @@ def update_and_sign_metadata_without_clean_check(
         )
 
     commit_msg = git_commit_message("update-expiration-dates", roles=",".join(roles))
-    commit_and_push(auth_repo, commit_msg=commit_msg, push=False)
+    auth_repo.commit_and_push(commit_msg=commit_msg, push=False)
 
 
 def update_target_repository(

--- a/taf/tools/targets/__init__.py
+++ b/taf/tools/targets/__init__.py
@@ -61,8 +61,7 @@ def add_repo_command():
                 custom = json.loads(Path(custom_file).read_text())
             except json.JSONDecodeError:
                 taf_logger.error("Invalid custom JSON provided")
-                sys.exit(1)
-
+                sys.exit
         add_target_repo(
             path=path,
             target_path=target_path,
@@ -111,11 +110,11 @@ def list_targets_command():
         - if they are up-to-date with remote
         - if there are uncommitted changes""")
     @find_repository
-    @catch_cli_exception(handle=TAFError)
+    @catch_cli_exception(handle=TAFError, print_error=True)
     @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--library-dir", default=None, help="Directory where target repositories and, optionally, authentication repository are located. If omitted it is calculated based on authentication repository's path. Authentication repo is presumed to be at library-dir/namespace/auth-repo-name")
-    def list(path, library_dir):
-        list_targets(path, library_dir)
+    def list(path):
+        targets_status = list_targets(path)
+        taf_logger.log("NOTICE", json.dumps(targets_status, indent=4))
     return list
 
 

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -434,10 +434,12 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                     library_dir=self.library_dir,
                     only_load_targets=True,
                     excluded_target_globs=self.excluded_target_globs,
+                    raise_error_if_no_urls=True,
                 )
                 target_repositories = repositoriesdb.get_deduplicated_repositories(
                     self.state.users_auth_repo,
                     excluded_target_globs=self.excluded_target_globs,
+                    raise_error_if_no_urls=True,
                 )
                 self.state.repos_on_disk = {
                     target_repo.name: target_repo
@@ -956,6 +958,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                     self.state.auth_commits_since_last_validated[-1::],
                     excluded_target_globs=self.excluded_target_globs,
                     library_dir=self.library_dir,
+                    raise_error_if_no_urls=not self.only_validate,
                 )
             )
             if self.only_validate:


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

The most important issue addressed in this PR and this release is the specification of pygit2 version. The previous implementation only worked when installing in editable mode. Tested by building a wheel using python 3.10 and installing in a python 3.12 environment.

This also contains a fix for validating or listing targets of an authentication repository that does not contain `mirrors.json`. Without `mirrors.json`, urls of target repositories cannot be set. However, this should not make it impossible to validate a repository that might not have been pushed upstream yet.

Also made some changes to the logging levels - the default is now NOTICE and not INFO.
Moved some code to the auth repo class. In the future, more features will be moved to this class.

In combination with previous PRs, these changes make CLI commands more robust and improve error handling. We can close #497 and create new, more specific issues, should any additional problems be encountered

Closes #497 


## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
