### PR TITLE
Remove unused optional parameter from _yk_piv_ctrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+[564]: https://github.com/openlawlibrary/taf/pull/564
+
 ## [0.32.1] - 11/01/2024
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- Remove unused optional parameter from _yk_piv_ctrl ([572])
+
 ### Fixed
+
+[572]: https://github.com/openlawlibrary/taf/pull/572
 
 ## [0.32.2]
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ tests_require = [
     "jinja2==3.1.*",
 ]
 
-yubikey_require = ["yubikey-manager==5.1.*"]
+yubikey_require = ["yubikey-manager==5.5.*"]
 
 
 kwargs = {

--- a/taf/api/yubikey.py
+++ b/taf/api/yubikey.py
@@ -161,7 +161,7 @@ def setup_signing_yubikey(
     on_exceptions=TAFError,
     reraise=True,
 )
-def setup_test_yubikey(key_path: str) -> None:
+def setup_test_yubikey(key_path: str, key_size: Optional[int] = 2048) -> None:
     """
     Reset the inserted yubikey, set default pin and copy the specified key
     to it.
@@ -183,7 +183,7 @@ def setup_test_yubikey(key_path: str) -> None:
     print(f"Importing RSA private key from {key_path} to Yubikey...")
     pin = yk.DEFAULT_PIN
 
-    pub_key = yk.setup(pin, "Test Yubikey", private_key_pem=key_pem)
+    pub_key = yk.setup(pin, "Test Yubikey", private_key_pem=key_pem, key_size=key_size)
     print("\nPrivate key successfully imported.\n")
     print("\nPublic key (PEM): \n{}".format(pub_key.decode("utf-8")))
     print("Pin: {}\n".format(pin))

--- a/taf/repository_tool.py
+++ b/taf/repository_tool.py
@@ -155,7 +155,7 @@ def yubikey_signature_provider(name, key_id, key, data):  # pylint: disable=W061
             inserted_key = yk.get_piv_public_key_tuf()
             if expected_key_id != inserted_key["keyid"]:
                 return None
-            serial_num = yk.get_serial_num(inserted_key)
+            serial_num = yk.get_serial_num()
             pin = yk.get_key_pin(serial_num)
             if pin is None:
                 pin = yk.get_and_validate_pin(name)

--- a/taf/tools/yubikey/yubikey_utils.py
+++ b/taf/tools/yubikey/yubikey_utils.py
@@ -147,7 +147,7 @@ class Root3YubiKey(FakeYubiKey):
 
 
 @contextmanager
-def _yk_piv_ctrl_mock(serial=None, pub_key_pem=None):
+def _yk_piv_ctrl_mock(serial=None):
     global INSERTED_YUBIKEY
 
     if INSERTED_YUBIKEY is None:

--- a/taf/yubikey.py
+++ b/taf/yubikey.py
@@ -178,7 +178,7 @@ def is_valid_pin(pin):
 
 
 @raise_yubikey_err("Cannot get serial number.")
-def get_serial_num(pub_key_pem=None):
+def get_serial_num():
     """Get Yubikey serial number.
 
     Args:
@@ -191,12 +191,12 @@ def get_serial_num(pub_key_pem=None):
     Raises:
         - YubikeyError
     """
-    with _yk_piv_ctrl(pub_key_pem=pub_key_pem) as (_, serial):
+    with _yk_piv_ctrl() as (_, serial):
         return serial
 
 
 @raise_yubikey_err("Cannot export x509 certificate.")
-def export_piv_x509(cert_format=serialization.Encoding.PEM, pub_key_pem=None):
+def export_piv_x509(cert_format=serialization.Encoding.PEM):
     """Exports YubiKey's piv slot x509.
 
     Args:
@@ -210,13 +210,13 @@ def export_piv_x509(cert_format=serialization.Encoding.PEM, pub_key_pem=None):
     Raises:
         - YubikeyError
     """
-    with _yk_piv_ctrl(pub_key_pem=pub_key_pem) as (ctrl, _):
+    with _yk_piv_ctrl() as (ctrl, _):
         x509 = ctrl.get_certificate(SLOT.SIGNATURE)
         return x509.public_bytes(encoding=cert_format)
 
 
 @raise_yubikey_err("Cannot export public key.")
-def export_piv_pub_key(pub_key_format=serialization.Encoding.PEM, pub_key_pem=None):
+def export_piv_pub_key(pub_key_format=serialization.Encoding.PEM):
     """Exports YubiKey's piv slot public key.
 
     Args:
@@ -230,7 +230,7 @@ def export_piv_pub_key(pub_key_format=serialization.Encoding.PEM, pub_key_pem=No
     Raises:
         - YubikeyError
     """
-    with _yk_piv_ctrl(pub_key_pem=pub_key_pem) as (ctrl, _):
+    with _yk_piv_ctrl() as (ctrl, _):
         try:
             x509_cert = ctrl.get_certificate(SLOT.SIGNATURE)
             public_key = x509_cert.public_key()
@@ -256,7 +256,7 @@ def export_yk_certificate(certs_dir, key):
 
 
 @raise_yubikey_err("Cannot get public key in TUF format.")
-def get_piv_public_key_tuf(scheme=DEFAULT_RSA_SIGNATURE_SCHEME, pub_key_pem=None):
+def get_piv_public_key_tuf(scheme=DEFAULT_RSA_SIGNATURE_SCHEME):
     """Return public key from a Yubikey in TUF's RSAKEY_SCHEMA format.
 
     Args:
@@ -272,12 +272,12 @@ def get_piv_public_key_tuf(scheme=DEFAULT_RSA_SIGNATURE_SCHEME, pub_key_pem=None
     Raises:
         - YubikeyError
     """
-    pub_key_pem = export_piv_pub_key(pub_key_pem=pub_key_pem).decode("utf-8")
+    pub_key_pem = export_piv_pub_key().decode("utf-8")
     return import_rsakey_from_pem(pub_key_pem, scheme)
 
 
 @raise_yubikey_err("Cannot sign data.")
-def sign_piv_rsa_pkcs1v15(data, pin, pub_key_pem=None):
+def sign_piv_rsa_pkcs1v15(data, pin):
     """Sign data with key from YubiKey's piv slot.
 
     Args:
@@ -292,7 +292,7 @@ def sign_piv_rsa_pkcs1v15(data, pin, pub_key_pem=None):
     Raises:
         - YubikeyError
     """
-    with _yk_piv_ctrl(pub_key_pem=pub_key_pem) as (ctrl, _):
+    with _yk_piv_ctrl() as (ctrl, _):
         ctrl.verify_pin(pin)
         return ctrl.sign(
             SLOT.SIGNATURE, KEY_TYPE.RSA2048, data, hashes.SHA256(), padding.PKCS1v15()

--- a/taf/yubikey.py
+++ b/taf/yubikey.py
@@ -99,8 +99,7 @@ def _yk_piv_ctrl(serial=None):
     """Context manager to open connection and instantiate Piv Session.
 
     Args:
-        - pub_key_pem(str): Match Yubikey's public key (PEM) if multiple keys
-                            are inserted
+        - serial (str): Match Yubikey's serial multiple keys are inserted
 
     Returns:
         - ykman.piv.PivSession


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

We do not currently, and have never needed to pass a public key pem to the piv context manager.
The code that is invoked if this pem is passed does not work, but the general idea is also not robust enough (see comments in #515).
Since we are not using this, I think that we should just remove this code. We'll implement it if a need for it arises.
Also found and fixed a minor `setup_test_yubikey` issue

Closes #515 

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
