### PR TITLE
Add tests for get last remote commit and reset to commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,15 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
+- Add tests for `get_last_remote_commit` and `reset_to_commit` ([573])
 - Implement full partial update. Store last validated commit per repo ([559)])
 
 ### Changed
 
 ### Fixed
 
-
-[559]: https://github.com/openlawlibrary/taf/pull/558
+[573]: https://github.com/openlawlibrary/taf/pull/573
+[559]: https://github.com/openlawlibrary/taf/pull/559
 
 
 ## [0.32.4]

--- a/taf/git.py
+++ b/taf/git.py
@@ -1460,13 +1460,19 @@ class GitRepository:
         self._git(f"reset {flag} HEAD~{num_of_commits}")
 
     def reset_to_commit(
-        self, commit: str, branch: Optional[str] = None, hard: Optional[bool] = False
+        self,
+        commit: str,
+        branch: Optional[str] = None,
+        hard: Optional[bool] = False,
+        reset_remote_tracking=True,
     ) -> None:
         flag = "--hard" if hard else "--soft"
 
-        if branch is None:
-            branch = self.get_current_branch()
-        self.update_branch_refs(branch, commit)
+        if reset_remote_tracking:
+            if branch is None:
+                branch = self.get_current_branch()
+            self.update_branch_refs(branch, commit)
+
         if hard:
             self._git(f"reset {flag} HEAD")
 
@@ -1626,7 +1632,8 @@ class GitRepository:
 
     def top_commit_of_remote_branch(self, branch, remote="origin"):
         """
-        Fetches the top commit of the specified remote branch.
+        Fetches the top commit of the specified remote tracking branch.
+
         """
         remote_branch = f"{remote}/{branch}"
         if not self.branch_exists(remote_branch, include_remotes=True):

--- a/taf/tests/test_git/conftest.py
+++ b/taf/tests/test_git/conftest.py
@@ -10,6 +10,7 @@ from taf.tests.conftest import TEST_DATA_REPOS_PATH
 TEST_DIR = Path(TEST_DATA_REPOS_PATH, "test-git")
 REPO_NAME = "repository"
 CLONE_REPO_NAME = "repository2"
+ORIGIN_REPO_NAME = "origin_repo"
 
 
 @fixture
@@ -28,6 +29,16 @@ def repository():
     except NothingToCommitError:
         pass  # this can happen if cleanup was not successful
 
+    yield repo
+    repo.cleanup()
+    shutil.rmtree(path, onerror=on_rm_error)
+
+
+@fixture
+def origin_repo(repository):
+    path = TEST_DIR / ORIGIN_REPO_NAME
+    repo = GitRepository(path=path)
+    repo.clone_from_disk(repository.path, is_bare=True)
     yield repo
     repo.cleanup()
     shutil.rmtree(path, onerror=on_rm_error)

--- a/taf/tests/test_git/test_git.py
+++ b/taf/tests/test_git/test_git.py
@@ -68,9 +68,6 @@ def test_get_last_remote_commit(origin_repo, clone_repository):
     last_remote_on_origin = clone_repository.get_last_remote_commit(
         clone_repository.get_remote_url()
     )
-    assert last_remote_on_origin == origin_repo.top_commit_of_branch(
-        origin_repo.default_branch
-    )
     assert last_remote_on_origin == top_commit
 
 

--- a/taf/tests/test_git/test_git.py
+++ b/taf/tests/test_git/test_git.py
@@ -51,3 +51,49 @@ def test_all_commits_since_commit_when_repo_empty(empty_repository):
     all_commits_empty = empty_repository.all_commits_since_commit()
     assert isinstance(all_commits_empty, list)
     assert len(all_commits_empty) == 0
+
+
+def test_get_last_remote_commit(origin_repo, clone_repository):
+    clone_repository.urls = [origin_repo.path]
+    clone_repository.clone()
+    clone_repository.commit_empty("test commit1")
+    top_commit = clone_repository.commit_empty("test commit2")
+    clone_repository.push()
+    initial_commit = clone_repository.initial_commit
+    clone_repository.reset_to_commit(initial_commit)
+    assert (
+        clone_repository.top_commit_of_branch(clone_repository.default_branch)
+        == initial_commit
+    )
+    last_remote_on_origin = clone_repository.get_last_remote_commit(
+        clone_repository.get_remote_url()
+    )
+    assert last_remote_on_origin == origin_repo.top_commit_of_branch(
+        origin_repo.default_branch
+    )
+    assert last_remote_on_origin == top_commit
+
+
+def test_reset_to_commit_when_reset_remote_tracking(origin_repo, clone_repository):
+    # reset to commit is also expected to update the remote tracking branch by default
+    clone_repository.urls = [origin_repo.path]
+    clone_repository.clone()
+    initial_commit = clone_repository.initial_commit
+    clone_repository.reset_to_commit(initial_commit)
+    assert (
+        clone_repository.top_commit_of_remote_branch(clone_repository.default_branch)
+        == initial_commit
+    )
+
+
+def test_reset_to_commit_when_not_reset_remote_tracking(origin_repo, clone_repository):
+    # reset to commit is also expected to update the remote tracking branch by default
+    clone_repository.urls = [origin_repo.path]
+    clone_repository.clone()
+    top_commit = clone_repository.head_commit_sha()
+    initial_commit = clone_repository.initial_commit
+    clone_repository.reset_to_commit(initial_commit, reset_remote_tracking=False)
+    assert (
+        clone_repository.top_commit_of_remote_branch(clone_repository.default_branch)
+        == top_commit
+    )

--- a/taf/tests/test_git/test_git.py
+++ b/taf/tests/test_git/test_git.py
@@ -84,7 +84,6 @@ def test_reset_to_commit_when_reset_remote_tracking(origin_repo, clone_repositor
 
 
 def test_reset_to_commit_when_not_reset_remote_tracking(origin_repo, clone_repository):
-    # reset to commit is also expected to update the remote tracking branch by default
     clone_repository.urls = [origin_repo.path]
     clone_repository.clone()
     top_commit = clone_repository.head_commit_sha()


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Added tests for the functionalities mentioned in issue #563

The behavior described in the issue description is not a bug, but was modified recently.
When resetting commits, remote tracking branches are updated too by default. This was
implemented as not doing so cause some nasty updater bugs.
Added a flag that can prevent that update, if it is not needed and expected in other use cases.
Also, `get_last_remote_commit` returns the commit of the remote repository, while `top_commit_of_remote_branch`
returns the top commit of the specified remote tracking branch. I updated the `top_commit_of_remote_branch` method's
docstring.  

Closes #563

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
