### PR TITLE
Fix: Fix setting last updated commit when pushing and update when only auth repo updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Do not update last validated commit if pushing to a branch other than the default branch ([577])
+- Fix determining from which commit the update should start if the auth repo is in front of all target repos ([577])
+
+[577]: https://github.com/openlawlibrary/taf/pull/577
+
 ## [0.33.0]
 
 ### Added

--- a/taf/auth_repo.py
+++ b/taf/auth_repo.py
@@ -184,25 +184,23 @@ class AuthenticationRepository(GitRepository, TAFRepository):
         if commit:
             if commit_msg is None:
                 commit_msg = input("\nEnter commit message and press ENTER\n\n")
-            self.commit(commit_msg)
+            new_commit = self.commit(commit_msg)
 
-        if push:
-            push_successful = self.push()
-            if push_successful:
-                new_commit_branch = self.default_branch
-                if new_commit_branch:
-                    new_commit = self.top_commit_of_branch(new_commit_branch)
-                    if new_commit:
+            if new_commit and push:
+                push_successful = self.push()
+                if push_successful:
+                    current_branch = self.get_current_branch()
+                    if current_branch == self.default_branch:
                         self.set_last_validated_of_repo(
                             self.name, new_commit, set_last_validated_commit=True
                         )
                         self._log_notice(
                             f"Updated last_validated_commit to {new_commit}"
                         )
-                else:
-                    self._log_warning(
-                        "Default branch is None, skipping last_validated_commit update."
-                    )
+                    else:
+                        self._log_warning(
+                            "Default branch is None, skipping last_validated_commit update."
+                        )
 
     def get_target(self, target_name, commit=None, safely=True) -> Optional[Dict]:
         if commit is None:
@@ -335,7 +333,10 @@ class AuthenticationRepository(GitRepository, TAFRepository):
 
         repo = self.pygit_repo
 
-        walker = repo.walk(repo.head.target, pygit2.GIT_SORT_TOPOLOGICAL)
+        default_branch = repo.lookup_branch(self.default_branch)
+        top_commit = default_branch.peel()
+
+        walker = repo.walk(top_commit.id, pygit2.GIT_SORT_TOPOLOGICAL)
 
         traversed_commits = []
         for commit in walker:

--- a/taf/auth_repo.py
+++ b/taf/auth_repo.py
@@ -198,8 +198,8 @@ class AuthenticationRepository(GitRepository, TAFRepository):
                             f"Updated last_validated_commit to {new_commit}"
                         )
                     else:
-                        self._log_warning(
-                            "Default branch is None, skipping last_validated_commit update."
+                        self._log_debug(
+                            "Not pushing to the default branch, skipping last_validated_commit update."
                         )
 
     def get_target(self, target_name, commit=None, safely=True) -> Optional[Dict]:

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -31,6 +31,7 @@ from logging import ERROR
 from typing import Dict, Tuple, Any
 from attr import define, field
 from logdecorator import log_on_error
+from taf.auth_repo import AuthenticationRepository
 from taf.git import GitRepository
 from taf.updater.types.update import OperationType, UpdateType
 from taf.updater.updater_pipeline import (
@@ -636,11 +637,11 @@ def validate_repository(
     else:
         library_dir = Path(library_dir).resolve()
 
+    auth_repo = AuthenticationRepository(path=auth_path)
     expected_repo_type = (
-        UpdateType.TEST
-        if (auth_path / "targets" / "test-auth-repo").exists()
-        else UpdateType.OFFICIAL
+        UpdateType.TEST if auth_repo.is_test_repo else UpdateType.OFFICIAL
     )
+
     auth_repo_name = None
 
     try:

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -1065,10 +1065,13 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
             repo_name: self._get_last_validated_commit(repo_name)
             for repo_name in self.state.users_target_repositories
         }
+        last_commits_per_repos[
+            self.state.users_auth_repo.name
+        ] = self._get_last_validated_commit(self.state.users_auth_repo.name)
 
-        last_validated_target_commits = list(set(last_commits_per_repos.values()))
+        last_validated_commits = list(set(last_commits_per_repos.values()))
 
-        if len(last_validated_target_commits) > 1:
+        if len(last_validated_commits) > 1:
             # not all target repositories were updated at the same time
             # updater was run with --exclude-targets
             # check if the repositories are in sync according to that data
@@ -2118,6 +2121,7 @@ def _update_tuf_current_revision(git_fetcher, updater, auth_repo_name):
         # using refresh, we have updated all main roles
         # we still need to update the delegated roles (if there are any)
         # and validate any target files
+
         current_targets = git_fetcher.get_current_targets()
         for target_path in current_targets:
             target_filepath = target_path.replace("\\", "/")


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

This PR contains 4 simple fixes:
- After running a command which pushes to the auth repo, we update the last validated commit. However, since we only validated commits that are on the default branch, last validated commit should only be updated when pushing to this branch
- Similarly, when traversing a repo's commit history, only traverse the default branch's history, even if a different branch is currently checked out.
- Replaced an outdated check if a repo is a test repo
- Determining from which commit the update of target repos should start was incorrect in cases when all target repositories were updated up to the same auth commit, but the auth repo was updated in the meantime. When some target repositories are excluded from the update, their last validated commits will be different and that case is not affected by this bug.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
