### PR TITLE
fix: run validation with --no-deps when pushing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][keepachangelog],
 and this project adheres to [Semantic Versioning][semver].
 
+
 ## [Unreleased]
 
 ### Added
@@ -13,9 +14,20 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+
+## [0.33.1]
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Run validation with --no-deps when pushing ([579])
 - Do not update last validated commit if pushing to a branch other than the default branch ([577])
 - Fix determining from which commit the update should start if the auth repo is in front of all target repos ([577])
 
+[579]: https://github.com/openlawlibrary/taf/pull/579
 [577]: https://github.com/openlawlibrary/taf/pull/577
 
 ## [0.33.0]
@@ -1390,7 +1402,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 [keepachangelog]: https://keepachangelog.com/en/1.0.0/
 [semver]: https://semver.org/spec/v2.0.0.html
-[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.33.0...HEAD
+[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.33.1...HEAD
+[0.33.1]: https://github.com/openlawlibrary/taf/compare/v0.33.0...v0.33.1
 [0.33.0]: https://github.com/openlawlibrary/taf/compare/v0.32.4...v0.33.0
 [0.32.4]: https://github.com/openlawlibrary/taf/compare/v0.32.3...v0.32.4
 [0.32.3]: https://github.com/openlawlibrary/taf/compare/v0.32.2...v0.32.3

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 PACKAGE_NAME = "taf"
-VERSION = "0.33.0"
+VERSION = "0.33.1"
 AUTHOR = "Open Law Library"
 AUTHOR_EMAIL = "info@openlawlib.org"
 DESCRIPTION = "Implementation of archival authentication"

--- a/taf/resources/pre-push
+++ b/taf/resources/pre-push
@@ -3,10 +3,8 @@
 # Path to the TAF CLI executable
 TAF_CLI="taf"
 
-# Get the last validated commit using the new CLI command
 output=$($TAF_CLI repo latest-commit-and-branch)
 
-# Get the last validated commit using the new CLI command
 if [ $? -ne 0 ]; then
     echo "Failed to retrieve the last validated commit."
     DEFAULT_BRANCH=""
@@ -34,7 +32,7 @@ fi
 
 
 # Run the TAF validation command with --from-latest
-$TAF_CLI repo validate --from-latest
+$TAF_CLI repo validate --from-latest --no-deps
 VALIDATION_STATUS=$?
 
 # Check the validation status

--- a/taf/utils.py
+++ b/taf/utils.py
@@ -1,5 +1,4 @@
 import platform
-import re
 import click
 import errno
 import datetime

--- a/taf/utils.py
+++ b/taf/utils.py
@@ -1,4 +1,5 @@
 import platform
+import re
 import click
 import errno
 import datetime
@@ -394,30 +395,25 @@ def ensure_pre_push_hook(auth_repo_path: Path) -> bool:
         Path(__file__).parent / "resources" / "pre-push"
     ).resolve()
 
-    if not pre_push_script.exists():
-        if not resources_pre_push_script.exists():
-            taf_logger.error(
-                f"Resources pre-push script not found at {resources_pre_push_script}"
-            )
-            return False
+    # always copy the newest version of the pre-push hook
 
-        shutil.copy(resources_pre_push_script, pre_push_script)
-        try:
-            if platform.system() != "Windows":
-                # Unix-like systems
-                pre_push_script.chmod(0o755)
-        except Exception as e:
-            taf_logger.error(f"Error setting executable permission: {e}")
-            return False
+    shutil.copy(resources_pre_push_script, pre_push_script)
+    try:
+        if platform.system() != "Windows":
+            # Unix-like systems
+            pre_push_script.chmod(0o755)
+    except Exception as e:
+        taf_logger.error(f"Error setting executable permission: {e}")
+        return False
 
-        # Check if permissions were set correctly on Unix-like systems
-        if platform.system() != "Windows" and not os.access(pre_push_script, os.X_OK):
-            taf_logger.error(
-                f"Failed to set pre-push git hook executable permission. Please set it manually for {pre_push_script}."
-            )
-            return False
-        taf_logger.info("Pre-push hook not present. Pre-push hook added successfully.")
-        return True
+    # Check if permissions were set correctly on Unix-like systems
+    if platform.system() != "Windows" and not os.access(pre_push_script, os.X_OK):
+        taf_logger.error(
+            f"Failed to set pre-push git hook executable permission. Please set it manually for {pre_push_script}."
+        )
+        return False
+    taf_logger.info("Pre-push hook not present. Pre-push hook added successfully.")
+    return True
 
     return True
 

--- a/taf/utils.py
+++ b/taf/utils.py
@@ -411,7 +411,7 @@ def ensure_pre_push_hook(auth_repo_path: Path) -> bool:
             f"Failed to set pre-push git hook executable permission. Please set it manually for {pre_push_script}."
         )
         return False
-    taf_logger.info("Pre-push hook not present. Pre-push hook added successfully.")
+    taf_logger.info("Pre-push hook updated successfully.")
     return True
 
     return True


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

- Run validation with --no-deps when pushing
- Always copy the  current pre-push hook
- Release 0.33.1

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
