### PR TITLE
Add key names and decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
+- Add a command for setting names of keys ([594])
+- Add an option to specify names of keys using an external file ([594])
 - Implement adaptive timeout for Git clone operations ([592])
 - Check if repository is synced with remote before running API functions ([592])
 - Add key names from config files to metadata during repository setup, following updates to TUF and securesystemslib [(583)]
@@ -24,6 +26,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 - Fix wrong default branch assignment for target repos [(593)]
 
+[594]: https://github.com/openlawlibrary/taf/pull/594
 [593]: https://github.com/openlawlibrary/taf/pull/593
 [592]: https://github.com/openlawlibrary/taf/pull/592
 [583]: https://github.com/openlawlibrary/taf/pull/583

--- a/taf/api/api_workflow.py
+++ b/taf/api/api_workflow.py
@@ -101,7 +101,15 @@ def key_management(
     return decorator
 
 
-def _map_keynames_to_keyids(auth_repo, pin_args):
+def _map_keynames_to_keyids(
+    auth_repo: AuthenticationRepository,
+    pin_args: Dict
+) -> Dict:
+    """
+    Finds key ids based on key names and inserts
+    key id and key pin, if specified via pin_args,
+    into a dictionary.
+    """
     key_id_pins: Dict = {}
     if not pin_args:
         return key_id_pins
@@ -126,6 +134,7 @@ def _map_keynames_to_keyids(auth_repo, pin_args):
         ]
         taf_logger.error(f"Keys {', '.join(not_existing_names)} not defined")
         raise TAFError(f"Keys {', '.join(not_existing_names)} not defined")
+    return key_id_pins
 
 
 @contextmanager

--- a/taf/api/api_workflow.py
+++ b/taf/api/api_workflow.py
@@ -102,8 +102,7 @@ def key_management(
 
 
 def _map_keynames_to_keyids(
-    auth_repo: AuthenticationRepository,
-    pin_args: Dict
+    auth_repo: AuthenticationRepository, pin_args: Dict
 ) -> Dict:
     """
     Finds key ids based on key names and inserts

--- a/taf/api/api_workflow.py
+++ b/taf/api/api_workflow.py
@@ -1,8 +1,12 @@
+from collections import defaultdict
 from contextlib import contextmanager
+import functools
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Callable, Dict, List, Optional, Union
 
-from taf.api.utils._conf import find_keystore
+import click
+from taf.api.utils._conf import find_keystore, read_keys_name_mapping
+from taf.api.yubikey import get_yk_roles
 from taf.auth_repo import AuthenticationRepository
 from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
 from taf.exceptions import PushFailedError, TAFError
@@ -10,6 +14,134 @@ from taf.keys import load_signers
 from taf.log import taf_logger
 from taf.messages import git_commit_message
 from taf.constants import METADATA_DIRECTORY_NAME
+from taf.log import taf_logger
+from taf.yubikey.yubikey_manager import manage_pins
+
+
+def key_management(
+    roles: Optional[List[str]] = None,
+    roles_fn: Optional[Callable[[Dict[str, str]], List[str]]] = None,
+) -> Callable:
+    """
+    Decorator that:
+    - Captures dynamic PIN arguments
+    - Ensures necessary signers are loaded.
+    - Cleans up PIN manager
+    - Reads key name mappings if `keys_description` is provided.
+
+    Parameters:
+    - path (str): Path to the authentication repository.
+    - roles (Optional[List[str]]): List of predefined roles to be loaded.
+    - roles_fn (Optional[Callable[[Dict[str, str]], List[str]]]): Function that determines roles to be loaded.
+    - keystore_path (Optional[str]): Path to the keystore.
+    - keys_description (Optional[str]): Path to a key description file.
+
+    Returns:
+    - Callable: Decorated function with authentication management.
+    """
+    roles = roles or []
+
+    def decorator(func: Callable) -> Callable:
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            path: Path = kwargs.pop("path")
+            auth_repo = AuthenticationRepository(path=path)
+
+            keystore_path = kwargs.get("keystore")
+            keys_description = kwargs.get("keys_description")
+
+            if keys_description:
+                keys_name_mappings = read_keys_name_mapping(keys_description)
+                auth_repo.add_key_names(keys_name_mappings)
+
+            all_roles = list(roles)
+            if callable(roles_fn):
+                roles_to_update = roles_fn()
+                if isinstance(roles_to_update, list):
+                    all_roles.extend(roles_to_update)
+                else:
+                    taf_logger.error("roles_fn must return a list")
+                    raise TAFError("roles_fn must return a list")
+
+            all_roles = list(set(all_roles))
+            if not all_roles:
+                # determine roles based on the inserted yubikeys
+                roles_per_yks = get_yk_roles(path)
+                for yk_roles in roles_per_yks.values():
+                    for role in yk_roles:
+                        if role not in all_roles:
+                            all_roles.append(role)
+
+            if not all_roles:
+                taf_logger.error(f"No roles specified")
+                raise TAFError("No roles specified")
+
+            taf_logger.info(f"Loading keys of roles {', '.join(all_roles)}")
+
+            with manage_pins() as pin_manager:
+
+                auth_repo.pin_manager = pin_manager
+                pin_args: Dict[str, str] = {}
+                i = 0
+
+                pins = kwargs.get("pins")
+                while i < len(pins):
+                    if pins[i].startswith("--"):
+                        key = pins[i][2:]  # Strip "--"
+                        if i + 1 < len(pins) and not pins[i + 1].startswith("--"):
+                            pin_args[key] = pins[i + 1]
+                            i += 1  # Skip the value in the next iteration
+                    i += 1
+
+                key_id_pins: Dict = {}
+                if pin_args:
+
+                    key_name_key_ids = auth_repo.get_key_ids_of_key_names(
+                        pin_args.keys()
+                    )
+                    for key_name, key_id in key_name_key_ids.items():
+                        if key_name in pin_args:
+                            key_id_pins[key_id] = pin_args[key_name]
+
+                    if len(key_id_pins) != len(pin_args):
+                        all_roles = auth_repo.get_all_roles()
+                        for key_name, key_pin in pin_args.items():
+                            for role_name in all_roles:
+                                if role_name == key_name:
+                                    key_ids = auth_repo.get_key_ids_of_role(role_name)
+                                    if len(key_ids) == 1:
+                                        key_id_pins[key_ids[0]] = key_pin
+
+                    if len(key_id_pins) != len(pin_args):
+                        not_existing_names = [
+                            key_name
+                            for key_name in pin_args
+                            if key_name not in key_id_pins
+                        ]
+                        taf_logger.error(
+                            f"Keys {', '.join(not_existing_names)} not defined"
+                        )
+                        raise TAFError(
+                            f"Keys {', '.join(not_existing_names)} not defined"
+                        )
+
+                # Load signers for required roles
+                for role in all_roles:
+                    if not auth_repo.check_if_keys_loaded(role):
+                        keystore_signers, yubikey_signers = load_signers(
+                            auth_repo,
+                            role,
+                            keystore=keystore_path,
+                            key_id_pins=key_id_pins,
+                        )
+                        auth_repo.add_signers_to_cache({role: keystore_signers})
+                        auth_repo.add_signers_to_cache({role: yubikey_signers})
+
+            return func(auth_repo, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
 
 
 @contextmanager

--- a/taf/api/dependencies.py
+++ b/taf/api/dependencies.py
@@ -3,6 +3,7 @@ from logging import DEBUG, ERROR
 from typing import Dict, Optional
 import click
 from taf.api.targets import register_target_files
+from taf.api.utils._conf import read_keys_name_mapping
 import taf.repositoriesdb as repositoriesdb
 from logdecorator import log_on_end, log_on_error, log_on_start
 from taf.api.utils._git import check_if_clean_and_synced
@@ -74,6 +75,7 @@ def add_dependency(
     commit: Optional[bool] = True,
     push: Optional[bool] = True,
     no_prompt: Optional[bool] = False,
+    keys_description: Optional[str] = None,
 ) -> None:
     """
     Add a dependency (an authentication repository) to dependencies.json or update it if it was already added to this file.
@@ -110,6 +112,8 @@ def add_dependency(
         raise TAFError("Authentication repository's path not provided")
 
     auth_repo = AuthenticationRepository(path=path, pin_manager=pin_manager)
+    keys_name_mappings = read_keys_name_mapping(keys_description)
+    auth_repo.add_key_names(keys_name_mappings)
     if not auth_repo.is_git_repository_root:
         taf_logger.error(f"{path} is not a git repository!")
         return
@@ -200,6 +204,7 @@ def remove_dependency(
     prompt_for_keys: Optional[bool] = False,
     commit: Optional[bool] = True,
     push: Optional[bool] = True,
+    keys_description: Optional[str] = None,
 ) -> None:
     """
     Remove a dependency (an authentication repository) from dependencies.json
@@ -223,6 +228,8 @@ def remove_dependency(
         raise TAFError("Authentication repository's path not provided")
 
     auth_repo = AuthenticationRepository(path=path, pin_manager=pin_manager)
+    keys_name_mappings = read_keys_name_mapping(keys_description)
+    auth_repo.add_key_names(keys_name_mappings)
     if not auth_repo.is_git_repository_root:
         print(f"{path} is not a git repository!")
         return

--- a/taf/api/dependencies.py
+++ b/taf/api/dependencies.py
@@ -47,6 +47,7 @@ def _add_to_dependencies(
     Path(dependencies_path).write_text(json.dumps(dependencies_json, indent=4))
 
 
+@check_if_clean_and_synced
 @log_on_start(
     DEBUG, "Adding or updating dependency {dependency_name:s}", logger=taf_logger
 )
@@ -58,7 +59,6 @@ def _add_to_dependencies(
     on_exceptions=TAFError,
     reraise=True,
 )
-@check_if_clean_and_synced
 def add_dependency(
     path: str,
     pin_manager: PinManager,
@@ -185,6 +185,7 @@ def add_dependency(
     )
 
 
+@check_if_clean_and_synced
 @log_on_start(DEBUG, "Remove dependency {dependency_name:s}", logger=taf_logger)
 @log_on_end(DEBUG, "Finished removing dependency", logger=taf_logger)
 @log_on_error(
@@ -194,7 +195,6 @@ def add_dependency(
     on_exceptions=TAFError,
     reraise=True,
 )
-@check_if_clean_and_synced
 def remove_dependency(
     path: str,
     pin_manager: PinManager,

--- a/taf/api/metadata.py
+++ b/taf/api/metadata.py
@@ -23,6 +23,7 @@ from taf.auth_repo import AuthenticationRepository
     on_exceptions=TAFError,
     reraise=False,
 )
+@check_if_clean_and_synced
 def add_key_names(
     path: str,
     keys_description: Path,

--- a/taf/api/metadata.py
+++ b/taf/api/metadata.py
@@ -39,11 +39,21 @@ def add_key_names(
         raise TAFError(f"{keys_description} does not exist")
 
     commit_msg = commit_msg or git_commit_message("add-key-names")
+
     keys_name_mappings = read_keys_name_mapping(keys_description)
     if not keys_name_mappings:
         raise TAFError(f"{keys_description} is not a valid keys description json file")
 
     auth_repo = AuthenticationRepository(path=path, pin_manager=pin_manager)
+    existing_mapping = auth_repo.keys_name_mappings
+    for key_id, key_name in dict(keys_name_mappings).items():
+        if key_id in existing_mapping and key_name == keys_name_mappings[key_id]:
+            keys_name_mappings.pop(key_id)
+
+    if not len(keys_name_mappings):
+        taf_logger.log("NOTICE", "All names already added to the repository")
+        return
+
     auth_repo.add_key_names(keys_name_mappings)
     parent_roles = set()
     for key_id in keys_name_mappings:

--- a/taf/api/metadata.py
+++ b/taf/api/metadata.py
@@ -18,7 +18,7 @@ from taf.auth_repo import AuthenticationRepository
 
 @log_on_error(
     ERROR,
-    "An error occurred while adding key names: {e!r}",
+    "An error occurred while adding key names: {e}",
     logger=taf_logger,
     on_exceptions=TAFError,
     reraise=False,

--- a/taf/api/metadata.py
+++ b/taf/api/metadata.py
@@ -41,8 +41,8 @@ def add_key_names(
 
     commit_msg = commit_msg or git_commit_message("add-key-names")
 
-    keys_description = json.loads(keys_description.read_text())
-    key_names_mapping = keys_description.get("yubikeys")
+    keys_description_data = json.loads(keys_description.read_text())
+    key_names_mapping = keys_description_data.get("yubikeys")
 
     auth_repo = AuthenticationRepository(path=path, pin_manager=pin_manager)
     parent_roles = set()
@@ -72,7 +72,7 @@ def add_key_names(
 
     with manage_repo_and_signers(
         auth_repo,
-        parent_roles,
+        list(parent_roles),
         keystore,
         scheme,
         prompt_for_keys,

--- a/taf/api/roles.py
+++ b/taf/api/roles.py
@@ -34,6 +34,7 @@ from securesystemslib.signer._key import SSlibKey
 from taf.yubikey.yubikey_manager import PinManager
 
 
+@check_if_clean_and_synced
 @log_on_start(DEBUG, "Adding a new role {role:s}", logger=taf_logger)
 @log_on_end(DEBUG, "Finished adding a new role", logger=taf_logger)
 @log_on_error(
@@ -43,7 +44,6 @@ from taf.yubikey.yubikey_manager import PinManager
     on_exceptions=TAFError,
     reraise=True,
 )
-@check_if_clean_and_synced
 def add_role(
     path: str,
     pin_manager: PinManager,
@@ -150,6 +150,7 @@ def add_role(
         auth_repo.do_timestamp()
 
 
+@check_if_clean_and_synced
 @log_on_start(DEBUG, "Adding new paths to role {delegated_role:s}", logger=taf_logger)
 @log_on_end(DEBUG, "Finished adding new paths to role", logger=taf_logger)
 @log_on_error(
@@ -160,13 +161,13 @@ def add_role(
     reraise=True,
 )
 def add_role_paths(
+    path: str,
     paths: List[str],
     pin_manager: PinManager,
     delegated_role: str,
     keystore: str,
     commit: Optional[bool] = True,
     auth_repo: Optional[AuthenticationRepository] = None,
-    auth_path: Optional[str] = None,
     prompt_for_keys: Optional[bool] = False,
     push: Optional[bool] = True,
     keys_description: Optional[str] = None,
@@ -193,7 +194,7 @@ def add_role_paths(
     """
 
     if auth_repo is None:
-        auth_repo = AuthenticationRepository(path=auth_path, pin_manger=pin_manager)
+        auth_repo = AuthenticationRepository(path=path, pin_manger=pin_manager)
     elif auth_repo.pin_manager is None:
         auth_repo.pin_manager = pin_manager
 
@@ -228,6 +229,7 @@ def add_role_paths(
         auth_repo.update_snapshot_and_timestamp()
 
 
+@check_if_clean_and_synced
 @log_on_start(DEBUG, "Adding new roles", logger=taf_logger)
 @log_on_end(DEBUG, "Finished adding new roles", logger=taf_logger)
 @log_on_error(
@@ -237,7 +239,6 @@ def add_role_paths(
     on_exceptions=TAFError,
     reraise=True,
 )
-@check_if_clean_and_synced
 def add_roles(
     path: str,
     pin_manager: PinManager,
@@ -335,6 +336,7 @@ def add_roles(
         auth_repo.do_timestamp()
 
 
+@check_if_clean_and_synced
 @log_on_start(NOTICE, "Adding a new signing key", logger=taf_logger)
 @log_on_end(DEBUG, "Finished adding a new signing key", logger=taf_logger)
 @log_on_error(
@@ -344,7 +346,6 @@ def add_roles(
     on_exceptions=TAFError,
     reraise=True,
 )
-@check_if_clean_and_synced
 def add_signing_key(
     path: str,
     pin_manager: PinManager,
@@ -419,6 +420,7 @@ def add_signing_key(
             auth_repo.update_snapshot_and_timestamp()
 
 
+@check_if_clean_and_synced
 @log_on_start(NOTICE, "Revoking signing key", logger=taf_logger)
 @log_on_end(DEBUG, "Finished revoking signing key", logger=taf_logger)
 @log_on_error(
@@ -428,7 +430,6 @@ def add_signing_key(
     on_exceptions=TAFError,
     reraise=True,
 )
-@check_if_clean_and_synced
 def revoke_signing_key(
     path: str,
     pin_manager: PinManager,
@@ -504,6 +505,15 @@ def revoke_signing_key(
 
 
 @check_if_clean_and_synced
+@log_on_start(DEBUG, "Rotating signing key {key_id:s}", logger=taf_logger)
+@log_on_end(DEBUG, "Finished rotating signing key", logger=taf_logger)
+@log_on_error(
+    ERROR,
+    "An error occurred while rotating a signing key {e}",
+    logger=taf_logger,
+    on_exceptions=TAFError,
+    reraise=True,
+)
 def rotate_signing_key(
     path: str,
     pin_manager: PinManager,

--- a/taf/api/targets.py
+++ b/taf/api/targets.py
@@ -12,6 +12,7 @@ from taf.api.roles import (
     add_role_paths,
     remove_paths,
 )
+from taf.api.utils._conf import read_keys_name_mapping
 from taf.api.utils._git import check_if_clean_and_synced
 from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME, TARGETS_DIRECTORY_NAME
 from taf.exceptions import TAFError
@@ -53,6 +54,7 @@ def add_target_repo(
     commit: Optional[bool] = True,
     prompt_for_keys: Optional[bool] = False,
     push: Optional[bool] = True,
+    keys_description: Optional[str] = None,
 ) -> None:
     """
     Add a new target repository by adding it to repositories.json, creating a delegation (if targets is not
@@ -83,6 +85,8 @@ def add_target_repo(
         None
     """
     auth_repo = AuthenticationRepository(path=path, pin_manager=pin_manager)
+    keys_name_mappings = read_keys_name_mapping(keys_description)
+    auth_repo.add_key_names(keys_name_mappings)
 
     if library_dir is None:
         library_dir = str(auth_repo.path.parent.parent)
@@ -371,6 +375,9 @@ def register_target_files(
     elif auth_repo.pin_manager is None:
         auth_repo.pin_manager = pin_manager
 
+    keys_name_mappings = read_keys_name_mapping(roles_key_infos)
+    auth_repo.add_key_names(keys_name_mappings)
+
     added_targets_data, removed_targets_data = auth_repo.get_all_target_files_state()
     if not added_targets_data and not removed_targets_data:
         taf_logger.log("NOTICE", "No updated targets")
@@ -441,6 +448,7 @@ def remove_target_repo(
     prompt_for_keys: Optional[bool] = False,
     push: Optional[bool] = True,
     scheme: Optional[str] = DEFAULT_RSA_SIGNATURE_SCHEME,
+    keys_description: Optional[str] = None,
 ) -> None:
     """
     Remove target repository from repositories.json, remove delegation, and target files and
@@ -459,6 +467,8 @@ def remove_target_repo(
         None
     """
     auth_repo = AuthenticationRepository(path=path, pin_manager=pin_manager)
+    keys_name_mappings = read_keys_name_mapping(keys_description)
+    auth_repo.add_key_names(keys_name_mappings)
 
     tarets_updated = _remove_from_repositories_json(auth_repo, target_name)
 
@@ -660,6 +670,9 @@ def update_and_sign_targets(
     """
     repo_path = Path(path).resolve()
     auth_repo = AuthenticationRepository(path=repo_path, pin_manager=pin_manager)
+    keys_name_mappings = read_keys_name_mapping(roles_key_infos)
+    auth_repo.add_key_names(keys_name_mappings)
+
     if library_dir is None:
         library_dir = str(repo_path.parent.parent)  # Ensure this uses the Path object
     repositoriesdb.load_repositories(auth_repo)

--- a/taf/api/targets.py
+++ b/taf/api/targets.py
@@ -25,6 +25,7 @@ from taf.auth_repo import AuthenticationRepository
 from taf.yubikey.yubikey_manager import PinManager
 
 
+@check_if_clean_and_synced
 @log_on_start(DEBUG, "Adding target repository {target_name:s}", logger=taf_logger)
 @log_on_end(DEBUG, "Finished adding target repository", logger=taf_logger)
 @log_on_error(
@@ -34,7 +35,6 @@ from taf.yubikey.yubikey_manager import PinManager
     on_exceptions=TAFError,
     reraise=True,
 )
-@check_if_clean_and_synced
 def add_target_repo(
     path: str,
     pin_manager: PinManager,
@@ -129,6 +129,7 @@ def add_target_repo(
         # delegated to another target role
         taf_logger.info("Role already exists")
         add_role_paths(
+            path=auth_repo.path,
             paths=[target_name],
             pin_manager=pin_manager,
             delegated_role=role,
@@ -430,6 +431,7 @@ def register_target_files(
             auth_repo.update_snapshot_and_timestamp()
 
 
+@check_if_clean_and_synced
 @log_on_start(DEBUG, "Removing target repository {target_name:s}", logger=taf_logger)
 @log_on_end(DEBUG, "Finished removing target repository", logger=taf_logger)
 @log_on_error(
@@ -439,7 +441,6 @@ def register_target_files(
     on_exceptions=TAFError,
     reraise=True,
 )
-@check_if_clean_and_synced
 def remove_target_repo(
     path: str,
     pin_manager: PinManager,
@@ -561,6 +562,7 @@ def _save_top_commit_of_repo_to_target(
     _update_target_repos(auth_repo_path, targets_dir, target_repo_path, add_branch)
 
 
+@check_if_clean_and_synced
 @log_on_start(DEBUG, "Updating target files", logger=taf_logger)
 @log_on_end(DEBUG, "Finished updating target files", logger=taf_logger)
 @log_on_error(
@@ -570,7 +572,6 @@ def _save_top_commit_of_repo_to_target(
     on_exceptions=TAFError,
     reraise=True,
 )
-@check_if_clean_and_synced
 def update_target_repos_from_repositories_json(
     path: str,
     pin_manager: PinManager,
@@ -627,6 +628,7 @@ def update_target_repos_from_repositories_json(
     )
 
 
+@check_if_clean_and_synced
 @log_on_start(DEBUG, "Updating target files", logger=taf_logger)
 @log_on_end(DEBUG, "Finished updating target files", logger=taf_logger)
 @log_on_error(
@@ -636,7 +638,6 @@ def update_target_repos_from_repositories_json(
     on_exceptions=TAFError,
     reraise=True,
 )
-@check_if_clean_and_synced
 def update_and_sign_targets(
     path: str,
     pin_manager: PinManager,

--- a/taf/api/utils/_conf.py
+++ b/taf/api/utils/_conf.py
@@ -70,9 +70,12 @@ def read_keys_name_mapping(keys_description: Optional[Union[str, Path]]) -> Dict
         scheme = key_data.get("scheme", DEFAULT_RSA_SIGNATURE_SCHEME)
         if "public" in key_data:
             pub_key = key_data["public"]
-            ssl_pub_key = get_sslib_key_from_value(pub_key, scheme=scheme)
-            key_id = _get_legacy_keyid(ssl_pub_key)
-            keys_name_mappings[key_id] = key_name
+            try:
+                ssl_pub_key = get_sslib_key_from_value(pub_key, scheme=scheme)
+                key_id = _get_legacy_keyid(ssl_pub_key)
+                keys_name_mappings[key_id] = key_name
+            except ValueError:
+                taf_logger.log("NOTICE", f"Invalid public key {key_name}")
         elif "keyid" in key_data:
             key_id = key_data["keyid"]
             keys_name_mappings[key_id] = key_name

--- a/taf/api/utils/_conf.py
+++ b/taf/api/utils/_conf.py
@@ -1,6 +1,9 @@
+import json
+from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
+from taf.tuf.keys import get_sslib_key_from_value, _get_legacy_keyid
 from taf.log import taf_logger
 from pathlib import Path
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 
 def find_taf_directory(auth_repo_path: Union[Path, str]) -> Optional[Path]:
@@ -45,3 +48,33 @@ def find_keystore(path: Union[str, Path]) -> Optional[Path]:
             return keystore_path
     taf_logger.debug(f"No keystore found starting from {path}")
     return None
+
+
+def read_keys_name_mapping(keys_description: Optional[Union[str, Path]]) -> Dict:
+    keys_name_mappings: Dict = {}
+    if keys_description is None:
+        return keys_name_mappings
+
+    keys_description_path = Path(keys_description)
+    if not keys_description_path.is_file():
+        return keys_name_mappings
+
+    try:
+        keys_description_data = json.loads(keys_description_path.read_text())
+    except json.decoder.JSONDecodeError:
+        return keys_name_mappings
+
+    key_names_mapping = keys_description_data.get("yubikeys")
+
+    for key_name, key_data in key_names_mapping.items():
+        scheme = key_data.get("scheme", DEFAULT_RSA_SIGNATURE_SCHEME)
+        if "public" in key_data:
+            pub_key = key_data["public"]
+            ssl_pub_key = get_sslib_key_from_value(pub_key, scheme=scheme)
+            key_id = _get_legacy_keyid(ssl_pub_key)
+            keys_name_mappings[key_id] = key_name
+        elif "keyid" in key_data:
+            key_id = key_data["keyid"]
+            keys_name_mappings[key_id] = key_name
+
+    return keys_name_mappings

--- a/taf/api/utils/_git.py
+++ b/taf/api/utils/_git.py
@@ -6,14 +6,20 @@ from taf.git import GitRepository
 def check_if_clean_and_synced(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        skip_check = kwargs.pop("skip_clean_check", False)
-        if not skip_check:
+        skip_clean_check = kwargs.pop("skip_clean_check", False)
+        skip_remote_check = kwargs.pop("skip_remote_check", False)
+
+        if not skip_clean_check or not skip_remote_check:
             path = kwargs.get("path", None)
             if path is None:
                 path = args[0]
             repo = GitRepository(path=path)
+
+        if not skip_clean_check:
             if repo.something_to_commit():
                 raise RepositoryNotCleanError(repo.name)
+
+        if not skip_remote_check:
             if repo.has_remote():
                 if not repo.synced_with_remote(repo.default_branch):
                     raise RepositoryNotSynced(repo.name)

--- a/taf/api/yubikey.py
+++ b/taf/api/yubikey.py
@@ -107,10 +107,10 @@ def export_yk_certificate(
         return
 
 
-@log_on_start(DEBUG, "Listing roles of the inserted YubiKey", logger=taf_logger)
+@log_on_start(DEBUG, "Listing roles of inserted YubiKesy", logger=taf_logger)
 @log_on_error(
     ERROR,
-    "An error occurred while listing roles of the inserted YubiKey: {e}",
+    "An error occurred while listing roles of inserted YubiKeys: {e}",
     logger=taf_logger,
     on_exceptions=TAFError,
     reraise=True,

--- a/taf/keys.py
+++ b/taf/keys.py
@@ -208,6 +208,7 @@ def _load_yubikeys(
     key_names: List[str],
     retry_on_failure: bool,
     hide_threshold_message: bool,
+    key_id_pins: Optional[Dict] = None
 ):
     """
     Loads YubiKeys for a specified role using given key names and manages the interaction process.
@@ -226,6 +227,7 @@ def _load_yubikeys(
         retry_on_failure=retry_on_failure,
         hide_already_loaded_message=True,
         hide_threshold_message=hide_threshold_message,
+        key_id_pins=key_id_pins,
     )
 
     loaded_keyids = [signer.public_key.keyid for signer in signers_yubikeys]
@@ -257,6 +259,7 @@ def load_signers(
     keystore: Optional[str] = None,
     scheme: Optional[str] = DEFAULT_RSA_SIGNATURE_SCHEME,
     prompt_for_keys: Optional[bool] = False,
+    key_id_pins: Optional[Dict] = None,
 ) -> Tuple[List[Dict], List[Dict]]:
     """
     Load role's signing keys. Make sure that at least the threshold of keys was
@@ -334,6 +337,7 @@ def load_signers(
                 key_names=key_names,
                 retry_on_failure=use_yubikey_for_signing_confirmed,
                 hide_threshold_message=hide_threshold_message,
+                key_id_pins=key_id_pins,
             )
             signers_yubikeys.extend(loaded_signers)
             if loaded_keys:

--- a/taf/keys.py
+++ b/taf/keys.py
@@ -208,7 +208,7 @@ def _load_yubikeys(
     key_names: List[str],
     retry_on_failure: bool,
     hide_threshold_message: bool,
-    key_id_pins: Optional[Dict] = None
+    key_id_pins: Optional[Dict] = None,
 ):
     """
     Loads YubiKeys for a specified role using given key names and manages the interaction process.

--- a/taf/messages.py
+++ b/taf/messages.py
@@ -14,6 +14,7 @@ MESSAGES = {
         "add-roles": "Add new roles {roles}",
         "add-signing-key": "Add new signing key to role {role}",
         "remove-role-paths": "Remove delegations {paths} from role {role}",
+        "add-key-names": "Add key names",
     }
 }
 

--- a/taf/tests/test_api/roles/api/test_roles.py
+++ b/taf/tests/test_api/roles/api/test_roles.py
@@ -111,6 +111,7 @@ def test_add_role_paths(
     NEW_PATHS = ["some-path3"]
     ROLE_NAME = "delegated_role"
     add_role_paths(
+        path=auth_repo_with_delegations.path,
         auth_repo=auth_repo_with_delegations,
         pin_manager=pin_manager,
         paths=NEW_PATHS,

--- a/taf/tests/tuf/test_query_repo/test_query_repo.py
+++ b/taf/tests/tuf/test_query_repo/test_query_repo.py
@@ -264,7 +264,7 @@ def test_generate_roles_description(tuf_repo_with_delegations):
 
 def test_sort_roles_targets_for_filenames(tuf_repo_with_delegations):
     actual = tuf_repo_with_delegations.sort_roles_targets_for_filenames()
-    assert actual["targets"] == ["test1", "test2"]
+    assert set(actual["targets"]) == {"test1", "test2"}
     assert set(actual["delegated_role"]) == set(["dir1/path1", "dir2/path1"])
     assert actual["inner_role"] == ["dir2/path2"]
 

--- a/taf/tools/cli/__init__.py
+++ b/taf/tools/cli/__init__.py
@@ -120,3 +120,34 @@ def process_custom_command_line_args(ctx):
         else {}
     )
     return custom
+
+
+def common_repo_edit_options(func):
+    """
+    Decorator to add common options to Click command functions.
+    """
+    func = click.option(
+        "--keystore", default=None, help="Location of the keystore files"
+    )(func)
+    func = click.option(
+        "--no-commit",
+        is_flag=True,
+        default=False,
+        help="Indicates that the changes should not be committed automatically",
+    )(func)
+    func = click.option(
+        "--prompt-for-keys",
+        is_flag=True,
+        default=False,
+        help="Whether to ask the user to enter their key if not located inside the keystore directory",
+    )(func)
+    func = click.option(
+        "--keys-description",
+        help="A dictionary containing information about the keys or a path to a json file which stores this information",
+    )(func)
+    func = click.option(
+        "--no-remote-check",
+        is_flag=True,
+        help="Whether to skip the check if there are any remote changes. Can be used when the SSH key requires a passphrase",
+    )(func)
+    return func

--- a/taf/tools/dependencies/__init__.py
+++ b/taf/tools/dependencies/__init__.py
@@ -49,9 +49,11 @@ def add_dependency_command():
     @click.option("--keystore", default=None, help="Location of the keystore files")
     @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
     @click.option("--no-commit", is_flag=True, default=False, help="Indicates that the changes should not be committed automatically")
+    @click.option("--keys-description", help="A dictionary containing information about the "
+                  "keys or a path to a json file which stores this information")
     @click.pass_context
     @pin_managed
-    def add(ctx, dependency_name, path, branch_name, dependency_url, out_of_band_commit, dependency_path, keystore, prompt_for_keys, no_commit, pin_manager):
+    def add(ctx, dependency_name, path, branch_name, dependency_url, out_of_band_commit, dependency_path, keystore, prompt_for_keys, no_commit, pin_manager, keys_description):
         custom = process_custom_command_line_args(ctx)
         add_dependency(
             path=path,
@@ -65,6 +67,7 @@ def add_dependency_command():
             custom=custom,
             prompt_for_keys=prompt_for_keys,
             commit=not no_commit,
+            keys_description=keys_description,
         )
     return add
 
@@ -87,8 +90,10 @@ def remove_dependency_command():
     @click.option("--keystore", default=None, help="Location of the keystore files")
     @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
     @click.option("--no-commit", is_flag=True, default=False, help="Indicates that the changes should not be committed automatically")
+    @click.option("--keys-description", help="A dictionary containing information about the "
+                  "keys or a path to a json file which stores this information")
     @pin_managed
-    def remove(dependency_name, path, keystore, prompt_for_keys, no_commit, pin_manager):
+    def remove(dependency_name, path, keystore, prompt_for_keys, no_commit, pin_manager, keys_description):
         remove_dependency(
             path=path,
             pin_manager=pin_manager,
@@ -96,6 +101,7 @@ def remove_dependency_command():
             keystore=keystore,
             prompt_for_keys=prompt_for_keys,
             commit=not no_commit,
+            keys_description=keys_description,
         )
     return remove
 

--- a/taf/tools/dependencies/__init__.py
+++ b/taf/tools/dependencies/__init__.py
@@ -1,7 +1,7 @@
 import click
 from taf.api.dependencies import add_dependency, remove_dependency
 from taf.exceptions import TAFError
-from taf.tools.cli import catch_cli_exception, find_repository, process_custom_command_line_args
+from taf.tools.cli import catch_cli_exception, common_repo_edit_options, find_repository, process_custom_command_line_args
 from taf.tools.repo import pin_managed
 
 
@@ -41,19 +41,15 @@ def add_dependency_command():
     @find_repository
     @catch_cli_exception(handle=TAFError)
     @click.argument("dependency_name")
+    @common_repo_edit_options
     @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.option("--branch-name", default=None, help="Name of the branch which contains the out-of-band commit")
     @click.option("--dependency-url", default=None, help="URL from which the dependency should be cloned if not already on disk")
     @click.option("--out-of-band-commit", default=None, help="Out-of-band commit SHA")
     @click.option("--dependency-path", default=None, help="Dependency's filesystem path")
-    @click.option("--keystore", default=None, help="Location of the keystore files")
-    @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
-    @click.option("--no-commit", is_flag=True, default=False, help="Indicates that the changes should not be committed automatically")
-    @click.option("--keys-description", help="A dictionary containing information about the "
-                  "keys or a path to a json file which stores this information")
     @click.pass_context
     @pin_managed
-    def add(ctx, dependency_name, path, branch_name, dependency_url, out_of_band_commit, dependency_path, keystore, prompt_for_keys, no_commit, pin_manager, keys_description):
+    def add(ctx, dependency_name, path, branch_name, dependency_url, out_of_band_commit, dependency_path, keystore, prompt_for_keys, no_commit, pin_manager, keys_description, no_remote_check):
         custom = process_custom_command_line_args(ctx)
         add_dependency(
             path=path,
@@ -68,6 +64,7 @@ def add_dependency_command():
             prompt_for_keys=prompt_for_keys,
             commit=not no_commit,
             keys_description=keys_description,
+            skip_remote_check=no_remote_check
         )
     return add
 
@@ -86,14 +83,10 @@ def remove_dependency_command():
     @find_repository
     @catch_cli_exception(handle=TAFError)
     @click.argument("dependency-name")
+    @common_repo_edit_options
     @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--keystore", default=None, help="Location of the keystore files")
-    @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
-    @click.option("--no-commit", is_flag=True, default=False, help="Indicates that the changes should not be committed automatically")
-    @click.option("--keys-description", help="A dictionary containing information about the "
-                  "keys or a path to a json file which stores this information")
     @pin_managed
-    def remove(dependency_name, path, keystore, prompt_for_keys, no_commit, pin_manager, keys_description):
+    def remove(dependency_name, path, keystore, prompt_for_keys, no_commit, pin_manager, keys_description, no_remote_check):
         remove_dependency(
             path=path,
             pin_manager=pin_manager,
@@ -102,6 +95,7 @@ def remove_dependency_command():
             prompt_for_keys=prompt_for_keys,
             commit=not no_commit,
             keys_description=keys_description,
+            skip_remote_check=no_remote_check
         )
     return remove
 

--- a/taf/tools/metadata/__init__.py
+++ b/taf/tools/metadata/__init__.py
@@ -74,8 +74,10 @@ def update_expiration_dates_command():
     @click.option("--start-date", default=datetime.datetime.now(), type=ISO_DATE, help="Date to which the interval is added")
     @click.option("--no-commit", is_flag=True, default=False, help="Indicates that the changes should not be committed automatically")
     @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
+    @click.option("--keys-description", help="A dictionary containing information about the "
+                  "keys or a path to a json file which stores this information")
     @pin_managed
-    def update_expiration_dates(path, role, interval, keystore, scheme, start_date, no_commit, prompt_for_keys, pin_manager):
+    def update_expiration_dates(path, role, interval, keystore, scheme, start_date, no_commit, prompt_for_keys, pin_manager, keys_description):
         if not len(role):
             print("Specify at least one role")
             return
@@ -88,7 +90,8 @@ def update_expiration_dates_command():
             scheme=scheme,
             start_date=start_date,
             commit=not no_commit,
-            prompt_for_keys=prompt_for_keys
+            prompt_for_keys=prompt_for_keys,
+            keys_description=keys_description,
         )
     return update_expiration_dates
 

--- a/taf/tools/metadata/__init__.py
+++ b/taf/tools/metadata/__init__.py
@@ -9,14 +9,9 @@ from taf.utils import ISO_DATE_PARAM_TYPE as ISO_DATE
 import datetime
 
 
-
 def add_key_names_command():
-    @click.command(
-    help=(
-        "If key names are not specified when creating repositories or adding a new role, "
-        "this command can be used to specify names of keys given a name-public key mapping."
-        )
-    )
+    @click.command(help="""If key names are not specified when creating repositories or adding a new role, "
+        "this command can be used to specify names of keys given a name-public key mapping.""")
     @find_repository
     @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.option("--keys-description", required=True, type=click.Path(exists=True), help="A dictionary containing information about the "

--- a/taf/tools/metadata/__init__.py
+++ b/taf/tools/metadata/__init__.py
@@ -1,11 +1,31 @@
 import click
-from taf.api.metadata import update_metadata_expiration_date, check_expiration_dates
+from pathlib import Path
+from taf.api.metadata import update_metadata_expiration_date, check_expiration_dates, add_key_names
 from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
 from taf.exceptions import TAFError
 from taf.tools.cli import catch_cli_exception, find_repository
 from taf.tools.repo import pin_managed
 from taf.utils import ISO_DATE_PARAM_TYPE as ISO_DATE
 import datetime
+
+
+
+def add_key_names_command():
+    @click.command(
+    help=(
+        "If key names are not specified when creating repositories or adding a new role, "
+        "this command can be used to specify names of keys given a name-public key mapping."
+        )
+    )
+    @find_repository
+    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
+    @click.option("--keys-description", required=True, type=click.Path(exists=True), help="A dictionary containing information about the "
+                  "keys or a path to a json file which stores the needed information")
+    @click.option("--keystore", default=None, help="Location of the keystore files")
+    @pin_managed
+    def addding_key_names(path, keys_description, keystore, pin_manager):
+        add_key_names(path=path, keys_description=Path(keys_description), keystore=keystore, pin_manager=pin_manager)
+    return addding_key_names
 
 
 def check_expiration_dates_command():
@@ -79,5 +99,6 @@ def update_expiration_dates_command():
 
 
 def attach_to_group(group):
+    group.add_command(add_key_names_command(), name="add-key-names")
     group.add_command(check_expiration_dates_command(), name='check-expiration-dates')
     group.add_command(update_expiration_dates_command(), name='update-expiration-dates')

--- a/taf/tools/roles/__init__.py
+++ b/taf/tools/roles/__init__.py
@@ -14,7 +14,7 @@ from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
 from taf.exceptions import TAFError
 from taf.auth_repo import AuthenticationRepository
 from taf.log import taf_logger
-from taf.tools.cli import catch_cli_exception, find_repository
+from taf.tools.cli import catch_cli_exception, common_repo_edit_options, find_repository
 
 from taf.api.roles import add_role_paths
 from taf.tools.repo import pin_managed
@@ -65,16 +65,12 @@ def add_roles_command():
     """)
     @find_repository
     @catch_cli_exception(handle=TAFError)
+    @common_repo_edit_options
     @click.option("--config-file", type=click.Path(exists=True), help="Path to the JSON configuration file.")
     @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme used for signing")
-    @click.option("--keystore", default=None, help="Location of the keystore files")
-    @click.option("--no-commit", is_flag=True, default=False, help="Indicates that the changes should not be committed automatically")
-    @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
-    @click.option("--keys-description", help="A dictionary containing information about the "
-                  "keys or a path to a json file which stores this information")
     @pin_managed
-    def add_roles(config_file, path, scheme, keystore, no_commit, prompt_for_keys, pin_manager, keys_description):
+    def add_roles(config_file, path, scheme, keystore, no_commit, prompt_for_keys, pin_manager, keys_description, no_remote_check):
         add_multiple_roles(
             path=path,
             pin_manager=pin_manager,
@@ -84,6 +80,7 @@ def add_roles_command():
             prompt_for_keys=prompt_for_keys,
             commit=not no_commit,
             keys_description=keys_description,
+            skip_remote_check=no_remote_check,
         )
     return add_roles
 
@@ -118,29 +115,26 @@ def add_role_paths_command():
     @find_repository
     @catch_cli_exception(handle=TAFError)
     @click.argument("role")
+    @common_repo_edit_options
     @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.option("--delegated-path", multiple=True, help="Paths associated with the delegated role")
-    @click.option("--keystore", default=None, help="Location of the keystore files")
-    @click.option("--no-commit", is_flag=True, default=False, help="Indicates that the changes should not be committed automatically")
-    @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
-    @click.option("--keys-description", help="A dictionary containing information about the "
-                  "keys or a path to a json file which stores this information")
     @pin_managed
-    def adding_role_paths(role, path, delegated_path, keystore, no_commit, prompt_for_keys, pin_manager, keys_description):
+    def adding_role_paths(role, path, delegated_path, keystore, no_commit, prompt_for_keys, pin_manager, keys_description, no_remote_check):
         if not delegated_path:
             print("Specify at least one path")
             return
 
         add_role_paths(
+            path=path,
             paths=delegated_path,
             pin_manager=pin_manager,
             delegated_role=role,
             keystore=keystore,
             commit=not no_commit,
-            auth_path=path,
             prompt_for_keys=prompt_for_keys,
             push=not no_commit,
             keys_description=keys_description,
+            skip_remote_check=no_remote_check,
         )
     return adding_role_paths
 
@@ -157,16 +151,12 @@ def remove_role_command():
     @find_repository
     @catch_cli_exception(handle=TAFError)
     @click.argument("role")
+    @common_repo_edit_options
     @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--keystore", default=None, help="Location of the keystore files")
     @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme used for signing")
     @click.option("--remove-targets/--no-remove-targets", default=True, help="Should targets delegated to this role also be removed. If not removed, they are signed by the parent role")
-    @click.option("--no-commit", is_flag=True, default=False, help="Indicates that the changes should not be committed automatically")
-    @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
-    @click.option("--keys-description", help="A dictionary containing information about the "
-                  "keys or a path to a json file which stores this information")
     @pin_managed
-    def remove(role, path, keystore, scheme, remove_targets, no_commit, prompt_for_keys, pin_manager, keys_description):
+    def remove(role, path, keystore, scheme, remove_targets, no_commit, prompt_for_keys, pin_manager, keys_description, no_remote_check):
         remove_role(
             path=path,
             pin_manager=pin_manager,
@@ -177,6 +167,7 @@ def remove_role_command():
             commit=not no_commit,
             prompt_for_keys=prompt_for_keys,
             keys_description=keys_description,
+            skip_remote_check=no_remote_check,
         )
     return remove
 
@@ -185,16 +176,12 @@ def remove_paths_command():
     @click.command(help="""Remove paths from delegated role""")
     @find_repository
     @catch_cli_exception(handle=TAFError)
+    @common_repo_edit_options
     @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.option("--delegated-path", multiple=True, help="A list of paths to be removed")
-    @click.option("--keystore", default=None, help="Location of the keystore files")
     @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme used for signing")
-    @click.option("--no-commit", is_flag=True, default=False, help="Indicates that the changes should not be committed automatically")
-    @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
-    @click.option("--keys-description", help="A dictionary containing information about the "
-                  "keys or a path to a json file which stores this information")
     @pin_managed
-    def remove_delegated_paths(path, delegated_path, keystore, scheme, no_commit, prompt_for_keys, pin_manager, keys_description):
+    def remove_delegated_paths(path, delegated_path, keystore, scheme, no_commit, prompt_for_keys, pin_manager, keys_description, no_remote_check):
         if not delegated_path:
             print("Specify at least one role")
             return
@@ -208,6 +195,7 @@ def remove_paths_command():
             commit=not no_commit,
             prompt_for_keys=prompt_for_keys,
             keys_description=keys_description,
+            skip_remote_check=no_remote_check,
         )
     return remove_delegated_paths
 
@@ -224,17 +212,13 @@ def add_signing_key_command():
         """)
     @find_repository
     @catch_cli_exception(handle=TAFError)
+    @common_repo_edit_options
     @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.option("--role", multiple=True, help="A list of roles to whose list of signing keys the new key should be added")
     @click.option("--pub-key-path", default=None, help="Path to the public key corresponding to the private key which should be registered as the role's signing key")
-    @click.option("--keystore", default=None, help="Location of the keystore files")
     @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme used for signing")
-    @click.option("--no-commit", is_flag=True, default=False, help="Indicates that the changes should not be committed automatically")
-    @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
-    @click.option("--keys-description", help="A dictionary containing information about the "
-                  "keys or a path to a json file which stores this information")
     @pin_managed
-    def adding_signing_key(path, role, pub_key_path, keystore, scheme, no_commit, prompt_for_keys, pin_manager, keys_description):
+    def adding_signing_key(path, role, pub_key_path, keystore, scheme, no_commit, prompt_for_keys, pin_manager, keys_description, no_remote_check):
         if not role:
             print("Specify at least one role")
             return
@@ -249,6 +233,7 @@ def add_signing_key_command():
             commit=not no_commit,
             prompt_for_keys=prompt_for_keys,
             keys_description=keys_description,
+            skip_remote_check=no_remote_check,
         )
     return adding_signing_key
 
@@ -259,17 +244,13 @@ def revoke_signing_key_command():
         """)
     @find_repository
     @catch_cli_exception(handle=TAFError)
+    @common_repo_edit_options
     @click.argument("keyid")
     @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.option("--role", multiple=True, help="A list of roles from which to remove the key. If unspecified, the key is removed from all roles by default.")
-    @click.option("--keystore", default=None, help="Location of the keystore files")
     @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme used for signing")
-    @click.option("--no-commit", is_flag=True, default=False, help="Indicates that the changes should not be committed automatically")
-    @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
-    @click.option("--keys-description", help="A dictionary containing information about the "
-                  "keys or a path to a json file which stores this information")
     @pin_managed
-    def revoke_key(path, role, keyid, keystore, scheme, no_commit, prompt_for_keys, pin_manager, keys_description):
+    def revoke_key(path, role, keyid, keystore, scheme, no_commit, prompt_for_keys, pin_manager, keys_description, no_remote_check):
 
         revoke_signing_key(
             path=path,
@@ -280,7 +261,8 @@ def revoke_signing_key_command():
             scheme=scheme,
             commit=not no_commit,
             prompt_for_keys=prompt_for_keys,
-            keys_description=keys_description
+            keys_description=keys_description,
+            skip_remote_check=no_remote_check,
         )
     return revoke_key
 
@@ -295,15 +277,15 @@ def rotate_signing_key_command():
     @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
     @click.option("--role", multiple=True, help="A list of roles from which to remove the key. Remove from all by default")
     @click.option("--pub-key-path", default=None, help="Path to the public key corresponding to the private key which should be registered as the role's signing key")
-    @click.option("--keystore", default=None, help="Location of the keystore files")
     @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme used for signing")
-    @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
     @click.option("--revoke-commit-msg", default=None, help="Revoke key commit message")
     @click.option("--add-commit-msg", default=None, help="Add new signing key commit message")
-    @click.option("--keys-description", help="A dictionary containing information about the "
-                  "keys or a path to a json file which stores this information")
+    @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
+    @click.option("--keys-description", help="A dictionary containing information about the keys or a path to a json file which stores this information")
+    @click.option("--no-remote-check", is_flag=True, help="Whether to skip the check if there are any remote changes. Can be used when the SSH key requires a passphrase")
+    @click.option("--keystore", default=None, help="Location of the keystore files")
     @pin_managed
-    def rotate_key(path, role, keyid, pub_key_path, keystore, scheme, prompt_for_keys, revoke_commit_msg, add_commit_msg, pin_manager, keys_description):
+    def rotate_key(path, role, keyid, pub_key_path, keystore, scheme, prompt_for_keys, revoke_commit_msg, add_commit_msg, pin_manager, keys_description, no_remote_check):
         rotate_signing_key(
             path=path,
             pin_manager=pin_manager,
@@ -316,6 +298,7 @@ def rotate_signing_key_command():
             revoke_commit_msg=revoke_commit_msg,
             add_commit_msg=add_commit_msg,
             keys_description=keys_description,
+            skip_remote_check=no_remote_check,
         )
     return rotate_key
 

--- a/taf/tools/roles/__init__.py
+++ b/taf/tools/roles/__init__.py
@@ -71,8 +71,10 @@ def add_roles_command():
     @click.option("--keystore", default=None, help="Location of the keystore files")
     @click.option("--no-commit", is_flag=True, default=False, help="Indicates that the changes should not be committed automatically")
     @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
+    @click.option("--keys-description", help="A dictionary containing information about the "
+                  "keys or a path to a json file which stores this information")
     @pin_managed
-    def add_roles(config_file, path, scheme, keystore, no_commit, prompt_for_keys, pin_manager):
+    def add_roles(config_file, path, scheme, keystore, no_commit, prompt_for_keys, pin_manager, keys_description):
         add_multiple_roles(
             path=path,
             pin_manager=pin_manager,
@@ -81,6 +83,7 @@ def add_roles_command():
             scheme=scheme,
             prompt_for_keys=prompt_for_keys,
             commit=not no_commit,
+            keys_description=keys_description,
         )
     return add_roles
 
@@ -120,8 +123,10 @@ def add_role_paths_command():
     @click.option("--keystore", default=None, help="Location of the keystore files")
     @click.option("--no-commit", is_flag=True, default=False, help="Indicates that the changes should not be committed automatically")
     @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
+    @click.option("--keys-description", help="A dictionary containing information about the "
+                  "keys or a path to a json file which stores this information")
     @pin_managed
-    def adding_role_paths(role, path, delegated_path, keystore, no_commit, prompt_for_keys, pin_manager):
+    def adding_role_paths(role, path, delegated_path, keystore, no_commit, prompt_for_keys, pin_manager, keys_description):
         if not delegated_path:
             print("Specify at least one path")
             return
@@ -135,6 +140,7 @@ def add_role_paths_command():
             auth_path=path,
             prompt_for_keys=prompt_for_keys,
             push=not no_commit,
+            keys_description=keys_description,
         )
     return adding_role_paths
 
@@ -157,8 +163,10 @@ def remove_role_command():
     @click.option("--remove-targets/--no-remove-targets", default=True, help="Should targets delegated to this role also be removed. If not removed, they are signed by the parent role")
     @click.option("--no-commit", is_flag=True, default=False, help="Indicates that the changes should not be committed automatically")
     @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
+    @click.option("--keys-description", help="A dictionary containing information about the "
+                  "keys or a path to a json file which stores this information")
     @pin_managed
-    def remove(role, path, keystore, scheme, remove_targets, no_commit, prompt_for_keys, pin_manager):
+    def remove(role, path, keystore, scheme, remove_targets, no_commit, prompt_for_keys, pin_manager, keys_description):
         remove_role(
             path=path,
             pin_manager=pin_manager,
@@ -168,6 +176,7 @@ def remove_role_command():
             remove_targets=remove_targets,
             commit=not no_commit,
             prompt_for_keys=prompt_for_keys,
+            keys_description=keys_description,
         )
     return remove
 
@@ -182,8 +191,10 @@ def remove_paths_command():
     @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme used for signing")
     @click.option("--no-commit", is_flag=True, default=False, help="Indicates that the changes should not be committed automatically")
     @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
+    @click.option("--keys-description", help="A dictionary containing information about the "
+                  "keys or a path to a json file which stores this information")
     @pin_managed
-    def remove_delegated_paths(path, delegated_path, keystore, scheme, no_commit, prompt_for_keys, pin_manager):
+    def remove_delegated_paths(path, delegated_path, keystore, scheme, no_commit, prompt_for_keys, pin_manager, keys_description):
         if not delegated_path:
             print("Specify at least one role")
             return
@@ -196,6 +207,7 @@ def remove_paths_command():
             scheme=scheme,
             commit=not no_commit,
             prompt_for_keys=prompt_for_keys,
+            keys_description=keys_description,
         )
     return remove_delegated_paths
 
@@ -219,8 +231,10 @@ def add_signing_key_command():
     @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme used for signing")
     @click.option("--no-commit", is_flag=True, default=False, help="Indicates that the changes should not be committed automatically")
     @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
+    @click.option("--keys-description", help="A dictionary containing information about the "
+                  "keys or a path to a json file which stores this information")
     @pin_managed
-    def adding_signing_key(path, role, pub_key_path, keystore, scheme, no_commit, prompt_for_keys, pin_manager):
+    def adding_signing_key(path, role, pub_key_path, keystore, scheme, no_commit, prompt_for_keys, pin_manager, keys_description):
         if not role:
             print("Specify at least one role")
             return
@@ -233,7 +247,8 @@ def add_signing_key_command():
             keystore=keystore,
             scheme=scheme,
             commit=not no_commit,
-            prompt_for_keys=prompt_for_keys
+            prompt_for_keys=prompt_for_keys,
+            keys_description=keys_description,
         )
     return adding_signing_key
 
@@ -251,8 +266,10 @@ def revoke_signing_key_command():
     @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme used for signing")
     @click.option("--no-commit", is_flag=True, default=False, help="Indicates that the changes should not be committed automatically")
     @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
+    @click.option("--keys-description", help="A dictionary containing information about the "
+                  "keys or a path to a json file which stores this information")
     @pin_managed
-    def revoke_key(path, role, keyid, keystore, scheme, no_commit, prompt_for_keys, pin_manager):
+    def revoke_key(path, role, keyid, keystore, scheme, no_commit, prompt_for_keys, pin_manager, keys_description):
 
         revoke_signing_key(
             path=path,
@@ -262,7 +279,8 @@ def revoke_signing_key_command():
             keystore=keystore,
             scheme=scheme,
             commit=not no_commit,
-            prompt_for_keys=prompt_for_keys
+            prompt_for_keys=prompt_for_keys,
+            keys_description=keys_description
         )
     return revoke_key
 
@@ -282,8 +300,10 @@ def rotate_signing_key_command():
     @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
     @click.option("--revoke-commit-msg", default=None, help="Revoke key commit message")
     @click.option("--add-commit-msg", default=None, help="Add new signing key commit message")
+    @click.option("--keys-description", help="A dictionary containing information about the "
+                  "keys or a path to a json file which stores this information")
     @pin_managed
-    def rotate_key(path, role, keyid, pub_key_path, keystore, scheme, prompt_for_keys, revoke_commit_msg, add_commit_msg, pin_manager):
+    def rotate_key(path, role, keyid, pub_key_path, keystore, scheme, prompt_for_keys, revoke_commit_msg, add_commit_msg, pin_manager, keys_description):
         rotate_signing_key(
             path=path,
             pin_manager=pin_manager,
@@ -295,6 +315,7 @@ def rotate_signing_key_command():
             pub_key_path=pub_key_path,
             revoke_commit_msg=revoke_commit_msg,
             add_commit_msg=add_commit_msg,
+            keys_description=keys_description,
         )
     return rotate_key
 

--- a/taf/tools/targets/__init__.py
+++ b/taf/tools/targets/__init__.py
@@ -70,8 +70,10 @@ def add_repo_command():
     @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
     @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme used for signing")
     @click.option("--no-commit", is_flag=True, default=False, help="Indicates that the changes should not be committed automatically")
+    @click.option("--keys-description", help="A dictionary containing information about the "
+                  "keys or a path to a json file which stores this information")
     @pin_managed
-    def add_repo(path, target_path, target_name, role, config_file, keystore, prompt_for_keys, scheme, no_commit, pin_manager):
+    def add_repo(path, target_path, target_name, role, config_file, keystore, prompt_for_keys, scheme, no_commit, pin_manager, keys_description):
 
         config_data = {}
         if config_file:
@@ -107,6 +109,7 @@ def add_repo_command():
                 prompt_for_keys=prompt_for_keys,
                 commit=not no_commit,
                 should_create_new_role=True,
+                keys_description=keys_description,
             )
         else:
             add_target_repo(
@@ -122,6 +125,7 @@ def add_repo_command():
                 prompt_for_keys=prompt_for_keys,
                 commit=not no_commit,
                 should_create_new_role=False,
+                keys_description=keys_description,
             )
     return add_repo
 
@@ -176,14 +180,17 @@ def remove_repo_command():
     @click.argument("target-name")
     @click.option("--keystore", default=None, help="Location of the keystore files")
     @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
+    @click.option("--keys-description", help="A dictionary containing information about the "
+                  "keys or a path to a json file which stores this information")
     @pin_managed
-    def remove_repo(path, target_name, keystore, prompt_for_keys, pin_manager):
+    def remove_repo(path, target_name, keystore, prompt_for_keys, pin_manager, keys_description):
         remove_target_repo(
             path=path,
             pin_manager=pin_manager,
             target_name=target_name,
             keystore=keystore,
             prompt_for_keys=prompt_for_keys,
+            keys_description=keys_description,
         )
     return remove_repo
 
@@ -214,7 +221,7 @@ def sign_targets_command():
                 scheme=scheme,
                 update_snapshot_and_timestamp=True,
                 prompt_for_keys=prompt_for_keys,
-                commit=not no_commit
+                commit=not no_commit,
             )
         except TAFError as e:
             click.echo()
@@ -276,7 +283,8 @@ def update_and_sign_command():
                     keystore=keystore,
                     scheme=scheme,
                     prompt_for_keys=prompt_for_keys,
-                    commit=not no_commit
+                    commit=not no_commit,
+                    keys_description=keys_description,
                 )
         except TAFError as e:
             click.echo()

--- a/taf/tuf/repository.py
+++ b/taf/tuf/repository.py
@@ -866,7 +866,7 @@ class MetadataRepository(Repository):
             num_of_keys_without_name = threshold
 
         for num in range(threshold - num_of_keys_without_name, threshold):
-            key_names.append(num + 1)
+            key_names.append(f"{role_name}{num + 1}")
         return key_names
 
     def get_key_ids_of_key_names(self, key_names: List[str]):

--- a/taf/tuf/repository.py
+++ b/taf/tuf/repository.py
@@ -185,6 +185,10 @@ class MetadataRepository(Repository):
         """
         return self._snapshot_info
 
+    def add_key_names(self, keys_keys_name_mappings: Dict) -> None:
+        for key_id, key_name in keys_keys_name_mappings.items():
+            self.add_key_name(key_name, key_id, overwrite=True)
+
     def add_key_name(self, key_name, key_id, overwrite=False):
         # make sure _keys_name_mappings is initialized
         self.keys_name_mappings

--- a/taf/tuf/repository.py
+++ b/taf/tuf/repository.py
@@ -149,6 +149,9 @@ class MetadataRepository(Repository):
 
     @property
     def keys_name_mappings(self):
+        """
+        Key id to key name
+        """
         try:
             if self._keys_name_mappings is None:
                 self._keys_name_mappings = self.load_key_names()
@@ -156,6 +159,15 @@ class MetadataRepository(Repository):
             # repository does not exist yet, so no metadata files
             self._keys_name_mappings = {}
         return self._keys_name_mappings
+
+    @property
+    def keys_name_mappings_reverse(self):
+        """
+        Key name to key id
+        """
+        if not self.keys_name_mappings:
+            return None
+        return {value: key for key, value in self.keys_name_mappings.items()}
 
     @property
     def metadata_path(self) -> Path:
@@ -856,6 +868,15 @@ class MetadataRepository(Repository):
         for num in range(threshold - num_of_keys_without_name, threshold):
             key_names.append(num + 1)
         return key_names
+
+    def get_key_ids_of_key_names(self, key_names: List[str]):
+        key_name_keys = {}
+        reverse_mapping = self.keys_name_mappings_reverse
+        for key_name in key_names:
+            if key_name in reverse_mapping:
+                keyid = reverse_mapping[key_name]
+                key_name_keys[key_name] = keyid
+        return key_name_keys
 
     def get_keyids_of_role(self, role_name: str) -> List:
         """

--- a/taf/utils.py
+++ b/taf/utils.py
@@ -143,6 +143,21 @@ def is_run_from_python_executable() -> bool:
     return getattr(sys, "frozen", False)
 
 
+def read_extra_args(kwargs, extra_args_name) -> Dict:
+    i = 0
+
+    ret: Dict = {}
+    args = kwargs.get(extra_args_name)
+    while i < len(args):
+        if args[i].startswith("--"):
+            name = args[i][2:]  # Strip "--"
+            if i + 1 < len(args) and not args[i + 1].startswith("--"):
+                ret[name] = args[i + 1]
+                i += 1  # Skip the value in the next iteration
+        i += 1
+    return ret
+
+
 def read_input_dict(value):
     if value is None:
         return {}

--- a/taf/yubikey/yubikey.py
+++ b/taf/yubikey/yubikey.py
@@ -259,7 +259,6 @@ def get_and_validate_pin(
                 f"Incorrect PIN. Do you want to try again? {retries} retires left."
             ):
                 raise InvalidPINError("PIN input cancelled")
-        pin = None
     return pin
 
 


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Implemented a command for adding/updating key names. The input can be the whole keys-description json, or just the "yubikeys" part of it. Added this input to all other commits that sign metadata files. Names of keys are read from these files if present. This can be used in case a repository was created before specifying key names was possible. Such repositories can also be updated using the new add key names command.


The key_management decorator is designed to handle loading signing keys within Click commands. The roles parameter defines a static list of TUF roles that require loaded signers. The roles_fn parameter allows dynamically determining roles based on user-provided PINs or other conditions. If none of them is provided, roles are determined based on the inserted YubiKeys. Captures PINs from unstructured CLI arguments 

E.g. `command name--name2 123456 --name1 123456`

Example usage:
```
@click.command(context_settings={"ignore_unknown_options": True})
@click.option("--path",  required=True, help="Path to the authentication repository.")
@key_management(
    roles=["root", "targets"],
    roles_fn=manually_written_function,
)
def my_command(auth_repo):
 # auth_repo is initialized, contains the pin manager and all loaded signing keys
```

Fix #521 

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
