### PR TITLE
feat: add yubikey debug logs; introduce `taf-debug.log` and log rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
+- Add log rotation and log size limit ([613])
+- Add yubikey debug logging statements ([613])
 - Implement get all auth repos logic ([599])
 - Add Commitish model ([596])
 - Aadd tests for part of the git module ([596])
@@ -33,6 +35,7 @@ and this project adheres to [Semantic Versioning][semver].
 - Ensure that every target role has a delegations attribute [(595)]
 - Fix wrong default branch assignment for target repos [(593)]
 
+[613]: https://github.com/openlawlibrary/taf/pull/613
 [612]: https://github.com/openlawlibrary/taf/pull/612
 [604]: https://github.com/openlawlibrary/taf/pull/604
 [603]: https://github.com/openlawlibrary/taf/pull/603

--- a/taf/log.py
+++ b/taf/log.py
@@ -76,7 +76,12 @@ def initialize_logger_handlers():
         log_location = _get_log_location()
         log_path = str(log_location / settings.LOG_FILENAME)
         file_loggers["log"] = taf_logger.add(
-            log_path, format=_FILE_FORMAT_STRING, level=settings.FILE_LOGGING_LEVEL
+            log_path,
+            format=_FILE_FORMAT_STRING,
+            level=settings.FILE_LOGGING_LEVEL,
+            rotation="30 MB",
+            retention=5,
+            compression="zip",
         )
 
         if settings.SEPARATE_ERRORS:
@@ -85,14 +90,20 @@ def initialize_logger_handlers():
                 error_log_path,
                 format=_FILE_FORMAT_STRING,
                 level=settings.ERROR_LOGGING_LEVEL,
+                rotation="30 MB",
+                retention=5,
+                compression="zip",
             )
-    #     try:
-    #         tuf.log.set_filehandler_log_level(settings.FILE_LOGGING_LEVEL)
-    #     except tuf.exceptions.Error:
-    #         pass
-    # else:
-    # # if file logging is disabled, also disable tuf file logging
-    # disable_tuf_file_logging()
+
+        debug_log_path = str(log_location / settings.DEBUG_LOG_FILENAME)
+        file_loggers["debug"] = taf_logger.add(
+            debug_log_path,
+            format=_FILE_FORMAT_STRING,
+            level=settings.DEBUG_LOGGING_LEVEL,
+            rotation="30 MB",
+            retention=5,
+            compression="zip",
+        )
 
 
 initialize_logger_handlers()

--- a/taf/log.py
+++ b/taf/log.py
@@ -4,8 +4,6 @@ import logging
 from typing import Dict
 from pathlib import Path
 
-# import tuf.log
-# import tuf.exceptions
 from loguru import logger as taf_logger
 import taf.settings as settings
 
@@ -44,7 +42,6 @@ def formatter(record):
 def disable_console_logging():
     try:
         taf_logger.remove(console_loggers["log"])
-        # disable_tuf_console_logging()
     except ValueError:
         # will be raised if this is called twice
         pass
@@ -53,26 +50,9 @@ def disable_console_logging():
 def disable_file_logging():
     try:
         taf_logger.remove(file_loggers["log"])
-        # disable_tuf_console_logging()
     except ValueError:
         # will be raised if this is called twice
         pass
-
-
-# def disable_tuf_console_logging():
-#     try:
-#         tuf.log.set_console_log_level(logging.CRITICAL)
-#     except securesystemslib.exceptions.Error:
-#         pass
-
-
-# def disable_tuf_file_logging():
-#     if tuf.log.file_handler is not None:
-#         tuf.log.disable_file_logging()
-#     else:
-#         logging.getLogger("tuf").setLevel(logging.CRITICAL)
-#     logging.getLogger("securesystemslib_keys").setLevel(logging.CRITICAL)
-#     logging.getLogger("securesystemslib_util").setLevel(logging.CRITICAL)
 
 
 def _get_log_location():
@@ -91,10 +71,6 @@ def initialize_logger_handlers():
         console_loggers["log"] = taf_logger.add(
             sys.stdout, format=formatter, level=VERBOSITY_LEVELS[settings.VERBOSITY]
         )
-        # tuf.log.set_console_log_level(logging.ERROR)
-    # else:
-    # if console logging is disable, remove tuf console logger
-    # disable_tuf_console_logging()
 
     if settings.ENABLE_FILE_LOGGING:
         log_location = _get_log_location()

--- a/taf/settings.py
+++ b/taf/settings.py
@@ -49,6 +49,8 @@ FILE_LOGGING_LEVEL = logging.INFO
 
 ERROR_LOGGING_LEVEL = logging.WARNING
 
+DEBUG_LOGGING_LEVEL = logging.DEBUG
+
 # Location of the log files. It can be specified by setting LOGS_LOCATION
 # and by setting an environment variable called TAF_LOG.
 # If this location is not specified logs will be placed ~/.taf
@@ -57,6 +59,8 @@ LOGS_LOCATION = None
 LOG_FILENAME = "taf.log"
 
 ERROR_LOG_FILENAME = "taf.err"
+
+DEBUG_LOG_FILENAME = "taf-debug.log"
 
 LOG_COMMAND_OUTPUT = False
 


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

- Add a bunch of yubikey logging statements
- Add `taf-debug.log` log that stores our debug log statements.
- Since taf-debug.log grows relatively quickly in size, add logrotation with a file size limit and a retention rate

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
