### PR TITLE
docs: Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing Guide
+
+Hello! If you're interested in contributing to TAF, then you're in the right
+place. This document details how contributions should be made to TAF.
+
+TAF is maintained by the Open Law Library, available
+[on the web](https://openlawlib.org) and on
+[GitHub](https://github.com/openlawlibrary).
+
+## Understanding TAF
+
+TAF can be complex to understand if you're new to the project. The
+[Architecture Overview](docs/architecture.md) is a good place to start to
+learn how TAF is designed. Prerequisite knowledge of [The Update Framework
+(TUF)](https://theupdateframework.io/) is highly suggested as well.
+For more detailed information, the [docs directory](docs) as well as the
+[specification directory](specification) have documents on TAF's internals.
+
+## The Issue Tracker
+
+The [issue tracker](https://github.com/openlawlibrary/taf/issues) contains
+various issues that need attention in the project. If you see an issue that
+you'd like to work on, feel free to comment on the issue! If you see an
+improvement for TAF, but are unsure about it, you can open an issue and a
+maintainer will take a look.
+
+## Submitting Contributions
+
+To submit a contribution to TAF, you'll need to fork the repository and
+submit a pull request to the GitHub repository. When you open a pull request,
+a template will appear; please add a description of what your change does
+and a reviewer will take a look.
+
+Whenever submitting code, please make sure to adhere to generally accepted
+Python coding standards, such as [PEP-8](https://peps.python.org/pep-0008/).


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

This PR adds a `CONTRIBUTING.md` file to TAF to help new contributors with ways to contribute. I'm modelling this around how other contribution docs look like for open source projects.

This is still a work-in-progress, partly due to the licensing section and other things that should be fleshed out.

Closes #608.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
