### PR TITLE
docs: Add licensing blurb to contribtuting docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,3 +33,9 @@ and a reviewer will take a look.
 
 Whenever submitting code, please make sure to adhere to generally accepted
 Python coding standards, such as [PEP-8](https://peps.python.org/pep-0008/).
+
+## Licensing
+
+Please ensure that you have read the license that TAF is licensed under, the
+GNU Affero General Public License, version 3. By submitting a contribution
+to TAF, you agree to the license.


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

This PR clarifies how contributions are handled license-wise. I don't think it's strictly necessary to have this added, but based on discussions we've had this may be handy to iterate on.

I'm therefore opening this PR to have an item for others to take a look at. We should be careful on the wording here and others more qualified than me should have a look of course.

On the gittuf project, we mandate the use of the [DCO](https://developercertificate.org/) [signoff](https://wiki.linuxfoundation.org/dco) to handle licensing, but TAF may likely have a different policy.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
