### PR TITLE
fix: pin pyscard back in yubikey extras; release v0.35.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+## [0.35.3] - 06/23/2025
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Fix pyscard in setup.py ([#656])
+
+[655]: https://github.com/openlawlibrary/taf/pull/655
+
 ## [0.35.2] - 06/16/2025
 
 ### Added
@@ -1561,7 +1575,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 [keepachangelog]: https://keepachangelog.com/en/1.0.0/
 [semver]: https://semver.org/spec/v2.0.0.html
-[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.35.2...HEAD
+[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.35.3...HEAD
+[0.35.3]: https://github.com/openlawlibrary/taf/compare/v0.35.2...v0.35.3
 [0.35.2]: https://github.com/openlawlibrary/taf/compare/v0.35.1...v0.35.2
 [0.35.1]: https://github.com/openlawlibrary/taf/compare/v0.35.0...v0.35.1
 [0.35.0]: https://github.com/openlawlibrary/taf/compare/v0.35.0a2...v0.35.0

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ tests_require = [
     "pytest-benchmark==4.0.0",
 ]
 
-yubikey_require = ["yubikey-manager==5.5.*"]
+yubikey_require = ["yubikey-manager==5.5.*", "pyscard==2.2.1; python_version >= '3.9'",]
 
 
 kwargs = {
@@ -65,7 +65,6 @@ kwargs = {
         "pyOpenSSL==24.2.*",
         "logdecorator==2.*",
         "tomli==2.0.*",
-        "pyscard==2.2.1; python_version >= '3.9'",
     ],
     "extras_require": {
         "ci": ci_require,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 PACKAGE_NAME = "taf"
-VERSION = "0.35.2"
+VERSION = "0.35.3"
 AUTHOR = "Open Law Library"
 AUTHOR_EMAIL = "info@openlawlib.org"
 DESCRIPTION = "Implementation of archival authentication"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,10 @@ tests_require = [
     "pytest-benchmark==4.0.0",
 ]
 
-yubikey_require = ["yubikey-manager==5.5.*", "pyscard==2.2.1; python_version >= '3.9'",]
+yubikey_require = [
+    "yubikey-manager==5.5.*",
+    "pyscard==2.2.1; python_version >= '3.9'",
+]
 
 
 kwargs = {


### PR DESCRIPTION
Issues come up when installing taf without smart card packages installed on ubuntu machine. To sort out, we pin back pyscard in yubikey manager

## Description (e.g. "Related to ...", etc.)

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
