### PR TITLE
fix: normalize targets file contents prior hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+## [0.35.4] - 08/14/2025
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Normalize targets file contents prior to hashing ([#660])
+
+[660]: https://github.com/openlawlibrary/taf/pull/660
+
 ## [0.35.3] - 06/23/2025
 
 ## [Unreleased]
@@ -1575,7 +1587,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 [keepachangelog]: https://keepachangelog.com/en/1.0.0/
 [semver]: https://semver.org/spec/v2.0.0.html
-[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.35.3...HEAD
+[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.35.4...HEAD
+[0.35.4]: https://github.com/openlawlibrary/taf/compare/v0.35.3...v0.35.4
 [0.35.3]: https://github.com/openlawlibrary/taf/compare/v0.35.2...v0.35.3
 [0.35.2]: https://github.com/openlawlibrary/taf/compare/v0.35.1...v0.35.2
 [0.35.1]: https://github.com/openlawlibrary/taf/compare/v0.35.0...v0.35.1

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 PACKAGE_NAME = "taf"
-VERSION = "0.35.3"
+VERSION = "0.35.4"
 AUTHOR = "Open Law Library"
 AUTHOR_EMAIL = "info@openlawlib.org"
 DESCRIPTION = "Implementation of archival authentication"

--- a/taf/api/targets.py
+++ b/taf/api/targets.py
@@ -382,7 +382,7 @@ def register_target_files(
 
     added_targets_data, removed_targets_data = auth_repo.get_all_target_files_state()
     if not added_targets_data and not removed_targets_data:
-        taf_logger.log("NOTICE", "No updated targets")
+        taf_logger.log("NOTICE", "No added or removed targets")
         return False
 
     all_updated_targets = list(added_targets_data.keys()) if added_targets_data else []

--- a/taf/utils.py
+++ b/taf/utils.py
@@ -11,6 +11,7 @@ import tempfile
 import shutil
 import uuid
 import sys
+from io import BytesIO
 from getpass import getpass
 from functools import wraps
 from pathlib import Path
@@ -444,6 +445,9 @@ def get_file_details(
     # Getting the file hashes
     file_hashes = {}
     with storage_backend.get(filepath) as fileobj:
+        original_content = fileobj.read()
+        normalized_content = normalize_line_endings(original_content)
+        fileobj = BytesIO(normalized_content)
         for algorithm in hash_algorithms:
             digest_object = digest_fileobject(fileobj, algorithm)
             file_hashes.update({algorithm: digest_object.hexdigest()})


### PR DESCRIPTION
Targets files are already unix-style normalized. However, hash compare is flaky on Windows. This is because files that were previously touched by unix are now touched by windows and the hash compare becomes incorrect. To resolve, normalize content before compare

## Description (e.g. "Related to ...", etc.)

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
