### PR TITLE
fix: pass on `KeyError` when disabling logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,10 @@ on:
     types: [created]
 
 env:
-  VERSIONS: "['3.8', '3.9', '3.10', '3.11', '3.12']"
-  LAST_VERSION: '3.12'
+  VERSIONS: "['3.9', '3.10', '3.11', '3.12']"
+  LAST_VERSION: "3.12"
 
 jobs:
-
   set_python_versions:
     runs-on: ubuntu-latest
     outputs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,13 +10,13 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/PyCQA/bandit
-    rev: "1.6.2"
+    rev: "1.8.6"
     hooks:
       - id: bandit
         args: [--recursive, -x, tests, -c, .bandit]
         files: .py$
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.4.1'
+    rev: "v1.4.1"
     hooks:
       - id: mypy
         args: [--ignore-missing-imports]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+## [0.35.5]  - 09/02/2025
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Fix(logging): pass on `KeyError` when disabling logging ([#663])
+
+[663]: https://github.com/openlawlibrary/taf/pull/663
+
 ## [0.35.4] - 08/14/2025
 
 ### Added
@@ -1587,7 +1599,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 [keepachangelog]: https://keepachangelog.com/en/1.0.0/
 [semver]: https://semver.org/spec/v2.0.0.html
-[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.35.4...HEAD
+[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.35.5...HEAD
+[0.35.5]: https://github.com/openlawlibrary/taf/compare/v0.35.4...v0.35.5
 [0.35.4]: https://github.com/openlawlibrary/taf/compare/v0.35.3...v0.35.4
 [0.35.3]: https://github.com/openlawlibrary/taf/compare/v0.35.2...v0.35.3
 [0.35.2]: https://github.com/openlawlibrary/taf/compare/v0.35.1...v0.35.2

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 PACKAGE_NAME = "taf"
-VERSION = "0.35.4"
+VERSION = "0.35.5"
 AUTHOR = "Open Law Library"
 AUTHOR_EMAIL = "info@openlawlib.org"
 DESCRIPTION = "Implementation of archival authentication"

--- a/taf/git.py
+++ b/taf/git.py
@@ -1954,7 +1954,7 @@ def repository_exists(url):
         http_url = url
 
     try:
-        response = requests.head(http_url)
+        response = requests.head(http_url)  # nosec B113
         return response.status_code == 200
     except requests.RequestException as e:
         print(f"Error checking repository URL: {e}")

--- a/taf/log.py
+++ b/taf/log.py
@@ -17,7 +17,7 @@ NOTICE = 25
 
 try:
     taf_logger.level("NOTICE", no=NOTICE, color="<yellow>", icon="!")
-except ValueError:
+except (KeyError, ValueError):
     # If the level already exists, we can ignore this error.
     pass
 
@@ -47,7 +47,7 @@ def formatter(record):
 def disable_console_logging():
     try:
         taf_logger.remove(console_loggers["log"])
-    except ValueError:
+    except (KeyError, ValueError):
         # will be raised if this is called twice
         pass
 
@@ -55,7 +55,7 @@ def disable_console_logging():
 def disable_file_logging():
     try:
         taf_logger.remove(file_loggers["log"])
-    except ValueError:
+    except (KeyError, ValueError):
         # will be raised if this is called twice
         pass
 

--- a/taf/tuf/keys.py
+++ b/taf/tuf/keys.py
@@ -187,7 +187,7 @@ class YkSigner(Signer):
                 return the Yubikey pin.
     """
 
-    _SECRET_PROMPT = "pin"
+    _SECRET_PROMPT = "pin"  # nosec B105
 
     def __init__(
         self,


### PR DESCRIPTION
Sometimes these functions get called twice and raise a `KeyError`. We now expect it and pass

## Description (e.g. "Related to ...", etc.)

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
