### PR TITLE
Pin `black` formatter version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ packages = find_packages()
 
 ci_require = [
     "bandit>=1.6.0",
-    "black>=19.3b0",
+    "black==22.12.0",
     "coverage==4.5.3",
     "pre-commit>=1.18.3",
     "pytest-cov==2.7.1",

--- a/taf/tools/conf/__init__.py
+++ b/taf/tools/conf/__init__.py
@@ -4,14 +4,31 @@ from taf.api.conf import init
 
 def init_command():
     @click.command(help="Create a .taf directory")
-    @click.option("--path", default=".", help=".taf directory's location. If not specified, set to the current directory")
-    @click.option("--keystore", default=None, help="Location of the keystore directory to copy from. Can be specified in keys-description dictionary")
-    @click.option("--keys-description", help="A dictionary containing information about the keys or a path to a json file which stores the needed information")
-    @click.option("--skip-keygen", is_flag=True, default=False, help="Skip generation of keys even if they do not exist")
+    @click.option(
+        "--path",
+        default=".",
+        help=".taf directory's location. If not specified, set to the current directory",
+    )
+    @click.option(
+        "--keystore",
+        default=None,
+        help="Location of the keystore directory to copy from. Can be specified in keys-description dictionary",
+    )
+    @click.option(
+        "--keys-description",
+        help="A dictionary containing information about the keys or a path to a json file which stores the needed information",
+    )
+    @click.option(
+        "--skip-keygen",
+        is_flag=True,
+        default=False,
+        help="Skip generation of keys even if they do not exist",
+    )
     def _init_command(path, keystore, keys_description, skip_keygen):
         init(path, keystore, keys_description, skip_keygen)
+
     return _init_command
 
 
 def attach_to_group(group):
-    group.add_command(init_command(), name='init')
+    group.add_command(init_command(), name="init")

--- a/taf/tools/dependencies/__init__.py
+++ b/taf/tools/dependencies/__init__.py
@@ -1,15 +1,22 @@
 import click
 from taf.api.dependencies import add_dependency, remove_dependency
 from taf.exceptions import TAFError
-from taf.tools.cli import catch_cli_exception, common_repo_edit_options, find_repository, process_custom_command_line_args
+from taf.tools.cli import (
+    catch_cli_exception,
+    common_repo_edit_options,
+    find_repository,
+    process_custom_command_line_args,
+)
 from taf.tools.repo import pin_managed
 
 
 def add_dependency_command():
-    @click.command(context_settings=dict(
-        ignore_unknown_options=True,
-        allow_extra_args=True,
-    ), help="""Add a dependency (an authentication repository) to dependencies.json or update it if it was already added to this file.
+    @click.command(
+        context_settings=dict(
+            ignore_unknown_options=True,
+            allow_extra_args=True,
+        ),
+        help="""Add a dependency (an authentication repository) to dependencies.json or update it if it was already added to this file.
         Update and sign targets metadata, snapshot and timestamp using yubikeys or keys loaded from the specified keystore location.
         Information that is added to dependencies.json includes out-of-band authentication commit and name
         of the branch which contains that commit. This out-of-band authentication commit represents a commit including and following
@@ -37,19 +44,48 @@ def add_dependency_command():
         If the dependency's full path is not provided, it is expected to be located in the same
         library root directory as the authentication repository, in a directory whose name corresponds to its name.
         If dependency's parent authentication repository's path is `E:\\examples\\root\\namespace\\auth`, and the dependency's namespace prefixed name is
-        `namespace1\\auth`, the target's path will be set to `E:\\examples\\root\\namespace1\\auth`.""")
+        `namespace1\\auth`, the target's path will be set to `E:\\examples\\root\\namespace1\\auth`.""",
+    )
     @find_repository
     @catch_cli_exception(handle=TAFError)
     @click.argument("dependency_name")
     @common_repo_edit_options
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--branch-name", default=None, help="Name of the branch which contains the out-of-band commit")
-    @click.option("--dependency-url", default=None, help="URL from which the dependency should be cloned if not already on disk")
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
+    @click.option(
+        "--branch-name",
+        default=None,
+        help="Name of the branch which contains the out-of-band commit",
+    )
+    @click.option(
+        "--dependency-url",
+        default=None,
+        help="URL from which the dependency should be cloned if not already on disk",
+    )
     @click.option("--out-of-band-commit", default=None, help="Out-of-band commit SHA")
-    @click.option("--dependency-path", default=None, help="Dependency's filesystem path")
+    @click.option(
+        "--dependency-path", default=None, help="Dependency's filesystem path"
+    )
     @click.pass_context
     @pin_managed
-    def add(ctx, dependency_name, path, branch_name, dependency_url, out_of_band_commit, dependency_path, keystore, prompt_for_keys, no_commit, pin_manager, keys_description, no_remote_check):
+    def add(
+        ctx,
+        dependency_name,
+        path,
+        branch_name,
+        dependency_url,
+        out_of_band_commit,
+        dependency_path,
+        keystore,
+        prompt_for_keys,
+        no_commit,
+        pin_manager,
+        keys_description,
+        no_remote_check,
+    ):
         custom = process_custom_command_line_args(ctx)
         add_dependency(
             path=path,
@@ -64,13 +100,15 @@ def add_dependency_command():
             prompt_for_keys=prompt_for_keys,
             commit=not no_commit,
             keys_description=keys_description,
-            skip_remote_check=no_remote_check
+            skip_remote_check=no_remote_check,
         )
+
     return add
 
 
 def remove_dependency_command():
-    @click.command(help="""Remove a dependency from dependencies.json.
+    @click.command(
+        help="""Remove a dependency from dependencies.json.
         Update and sign targets metadata, snapshot and timestamp using yubikeys or keys loaded from the specified keystore location.
 
         `taf dependencies remove --path auth-path dependency-name --keystore keystore-path`
@@ -79,14 +117,28 @@ def remove_dependency_command():
 
         `taf dependencies remove dependency-name --keystore keystore-path`
 
-        if inside an authentication repository""")
+        if inside an authentication repository"""
+    )
     @find_repository
     @catch_cli_exception(handle=TAFError)
     @click.argument("dependency-name")
     @common_repo_edit_options
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
     @pin_managed
-    def remove(dependency_name, path, keystore, prompt_for_keys, no_commit, pin_manager, keys_description, no_remote_check):
+    def remove(
+        dependency_name,
+        path,
+        keystore,
+        prompt_for_keys,
+        no_commit,
+        pin_manager,
+        keys_description,
+        no_remote_check,
+    ):
         remove_dependency(
             path=path,
             pin_manager=pin_manager,
@@ -95,11 +147,12 @@ def remove_dependency_command():
             prompt_for_keys=prompt_for_keys,
             commit=not no_commit,
             keys_description=keys_description,
-            skip_remote_check=no_remote_check
+            skip_remote_check=no_remote_check,
         )
+
     return remove
 
 
 def attach_to_group(group):
-    group.add_command(add_dependency_command(), name='add')
-    group.add_command(remove_dependency_command(), name='remove')
+    group.add_command(add_dependency_command(), name="add")
+    group.add_command(remove_dependency_command(), name="remove")

--- a/taf/tools/keystore/__init__.py
+++ b/taf/tools/keystore/__init__.py
@@ -5,7 +5,8 @@ from taf.tools.cli import catch_cli_exception
 
 
 def generate_keys_command():
-    @click.command(help="""Generate keystore files and save them to the specified location given a dictionary containing
+    @click.command(
+        help="""Generate keystore files and save them to the specified location given a dictionary containing
         information about each role - total number of keys, their lengths and keystore files' passwords.
         It is necessary to either directly specify this dictionary when calling this command or
         to provide a path to a `.json` file which contains the needed information.
@@ -31,17 +32,26 @@ def generate_keys_command():
 
         Default number of keys and threshold are 1, length 3072 and password is an empty string.
         If keystore location is specified through the keystore input parameter and not listed
-        in keys-description dictionary, keys will be saved to ./keystore""")
+        in keys-description dictionary, keys will be saved to ./keystore"""
+    )
     @catch_cli_exception(handle=KeystoreError)
-    @click.option("--keystore", default=None, help="Location of the keystore directory. Can be specified in keys-description dictionary")
-    @click.option("--keys-description", help="A dictionary containing information about the keys or a path to a json file which stores the needed information")
+    @click.option(
+        "--keystore",
+        default=None,
+        help="Location of the keystore directory. Can be specified in keys-description dictionary",
+    )
+    @click.option(
+        "--keys-description",
+        help="A dictionary containing information about the keys or a path to a json file which stores the needed information",
+    )
     def generate(keystore, keys_description):
         generate_keys(keystore, keys_description)
+
     return generate
 
 
 def attach_to_group(group):
-    group.add_command(generate_keys_command(), name='generate')
+    group.add_command(generate_keys_command(), name="generate")
 
 
 @click.group()
@@ -51,5 +61,5 @@ def cli():
 
 attach_to_group(cli)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     cli()

--- a/taf/tools/metadata/__init__.py
+++ b/taf/tools/metadata/__init__.py
@@ -1,6 +1,10 @@
 import click
 from pathlib import Path
-from taf.api.metadata import update_metadata_expiration_date, check_expiration_dates, add_key_names
+from taf.api.metadata import (
+    update_metadata_expiration_date,
+    check_expiration_dates,
+    add_key_names,
+)
 from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
 from taf.exceptions import TAFError
 from taf.tools.cli import catch_cli_exception, common_repo_edit_options, find_repository
@@ -11,31 +15,49 @@ import datetime
 
 
 def add_key_names_command():
-    @click.command(help="""If key names are not specified when creating repositories or adding a new role, "
-        "this command can be used to specify names of keys given a name-public key mapping.""")
+    @click.command(
+        help="""If key names are not specified when creating repositories or adding a new role, "
+        "this command can be used to specify names of keys given a name-public key mapping."""
+    )
     @find_repository
     @common_repo_edit_options
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
     @click.option("--commit-msg", default=None, help="Commit message")
     @pin_managed
-    def adding_key_names(path, keys_description, keystore, pin_manager, no_commit, no_remote_check, prompt_for_keys, commit_msg):
+    def adding_key_names(
+        path,
+        keys_description,
+        keystore,
+        pin_manager,
+        no_commit,
+        no_remote_check,
+        prompt_for_keys,
+        commit_msg,
+    ):
         if not keys_description or Path(keys_description).is_file():
             taf_logger.error("Provide a path to an existing keys-description file")
 
         add_key_names(
             path=path,
             keys_description=Path(keys_description),
-            keystore=keystore, pin_manager=pin_manager,
+            keystore=keystore,
+            pin_manager=pin_manager,
             commit=not no_commit,
             skip_remote_check=no_remote_check,
             prompt_for_keys=prompt_for_keys,
             commit_msg=commit_msg,
         )
+
     return adding_key_names
 
 
 def check_expiration_dates_command():
-    @click.command(help="""Check if the expiration dates of the metadata roles is still within an interval threshold.
+    @click.command(
+        help="""Check if the expiration dates of the metadata roles is still within an interval threshold.
         Expiration date is calculated by adding interval to start date. Interval is specified in days.
         The default value for interval in method is set to 30 days.
         Result contains metadata roles which have already expired and also roles which will expire (within the interval).
@@ -50,18 +72,35 @@ def check_expiration_dates_command():
         Given a 30 day interval from today (2022-07-22):
             timestamp will expire on 2022-07-22
             snapshot will expire on 2022-07-28
-            root will expire on 2022-08-19""")
+            root will expire on 2022-08-19"""
+    )
     @find_repository
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--interval", default=30, type=int, help="Number of days added to the start date")
-    @click.option("--start-date", default=datetime.datetime.now(), help="Date to which expiration interval is added", type=ISO_DATE)
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
+    @click.option(
+        "--interval",
+        default=30,
+        type=int,
+        help="Number of days added to the start date",
+    )
+    @click.option(
+        "--start-date",
+        default=datetime.datetime.now(),
+        help="Date to which expiration interval is added",
+        type=ISO_DATE,
+    )
     def checking_expiration_dates(path, interval, start_date):
         check_expiration_dates(path=path, interval=interval, start_date=start_date)
+
     return checking_expiration_dates
 
 
 def update_expiration_dates_command():
-    @click.command(help="""Update expiration date of the metadata file corresponding to the specified role.
+    @click.command(
+        help="""Update expiration date of the metadata file corresponding to the specified role.
         The new expiration date is calculated by adding interval to start date. The default
         value of the start date parameter is the current date, while default interval depends
         on the role and is:
@@ -74,18 +113,54 @@ def update_expiration_dates_command():
         that is not the case, it will be needed to either enter the signing key directly or
         sign the file using a yubikey.
 
-        If targets or other delegated role is updated, automatically sign snapshot and timestamp.""")
+        If targets or other delegated role is updated, automatically sign snapshot and timestamp."""
+    )
     @find_repository
     @catch_cli_exception(handle=TAFError)
     @common_repo_edit_options
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--role", multiple=True, help="A list of roles which expiration date should get updated")
-    @click.option("--interval", default=None, type=int, help="Number of days added to the start date")
-    @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme used for signing")
-    @click.option("--start-date", default=datetime.datetime.now(), type=ISO_DATE, help="Date to which the interval is added")
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
+    @click.option(
+        "--role",
+        multiple=True,
+        help="A list of roles which expiration date should get updated",
+    )
+    @click.option(
+        "--interval",
+        default=None,
+        type=int,
+        help="Number of days added to the start date",
+    )
+    @click.option(
+        "--scheme",
+        default=DEFAULT_RSA_SIGNATURE_SCHEME,
+        help="A signature scheme used for signing",
+    )
+    @click.option(
+        "--start-date",
+        default=datetime.datetime.now(),
+        type=ISO_DATE,
+        help="Date to which the interval is added",
+    )
     @click.option("--commit-msg", default=None, help="Commit message")
     @pin_managed
-    def update_expiration_dates(path, role, interval, keystore, scheme, start_date, no_commit, prompt_for_keys, pin_manager, keys_description, no_remote_check, commit_msg):
+    def update_expiration_dates(
+        path,
+        role,
+        interval,
+        keystore,
+        scheme,
+        start_date,
+        no_commit,
+        prompt_for_keys,
+        pin_manager,
+        keys_description,
+        no_remote_check,
+        commit_msg,
+    ):
         if not len(role):
             print("Specify at least one role")
             return
@@ -103,10 +178,11 @@ def update_expiration_dates_command():
             skip_remote_check=no_remote_check,
             commit_msg=commit_msg,
         )
+
     return update_expiration_dates
 
 
 def attach_to_group(group):
     group.add_command(add_key_names_command(), name="add-key-names")
-    group.add_command(check_expiration_dates_command(), name='check-expiration-dates')
-    group.add_command(update_expiration_dates_command(), name='update-expiration-dates')
+    group.add_command(check_expiration_dates_command(), name="check-expiration-dates")
+    group.add_command(update_expiration_dates_command(), name="update-expiration-dates")

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -9,17 +9,49 @@ from taf.exceptions import TAFError, UpdateFailedError
 from taf.log import initialize_logger_handlers, taf_logger
 from taf.tools.cli import catch_cli_exception, find_repository
 from taf.updater.types.update import UpdateType
-from taf.updater.updater import OperationType, UpdateConfig, clone_repository, update_repository, validate_repository
+from taf.updater.updater import (
+    OperationType,
+    UpdateConfig,
+    clone_repository,
+    update_repository,
+    validate_repository,
+)
 from taf.yubikey.yubikey_manager import pin_managed
 
 
 def common_update_options(f):
-    f = click.option("--expected-repo-type", default="either", type=click.Choice(["test", "official", "either"]), help="Indicates expected authentication repository type - test or official.")(f)
-    f = click.option("--scripts-root-dir", default=None, help="Scripts root directory, which can be used to move scripts out of the authentication repository for testing purposes.")(f)
-    f = click.option("--profile", is_flag=True, help="Flag used to run profiler and generate .prof file")(f)
-    f = click.option("--format-output", is_flag=True, help="Return formatted output which includes information on if build was successful and error message if it was raised")(f)
-    f = click.option("--exclude-target", multiple=True, help="Globs defining which target repositories should be ignored during update.")(f)
-    f = click.option("--strict", is_flag=True, default=False, help="Enable/disable strict mode - return an error if warnings are raised.")(f)
+    f = click.option(
+        "--expected-repo-type",
+        default="either",
+        type=click.Choice(["test", "official", "either"]),
+        help="Indicates expected authentication repository type - test or official.",
+    )(f)
+    f = click.option(
+        "--scripts-root-dir",
+        default=None,
+        help="Scripts root directory, which can be used to move scripts out of the authentication repository for testing purposes.",
+    )(f)
+    f = click.option(
+        "--profile",
+        is_flag=True,
+        help="Flag used to run profiler and generate .prof file",
+    )(f)
+    f = click.option(
+        "--format-output",
+        is_flag=True,
+        help="Return formatted output which includes information on if build was successful and error message if it was raised",
+    )(f)
+    f = click.option(
+        "--exclude-target",
+        multiple=True,
+        help="Globs defining which target repositories should be ignored during update.",
+    )(f)
+    f = click.option(
+        "--strict",
+        is_flag=True,
+        default=False,
+        help="Enable/disable strict mode - return an error if warnings are raised.",
+    )(f)
     return f
 
 
@@ -36,10 +68,14 @@ def _call_updater(config, format_output):
         successful = updater_output["event"] == "event/succeeded"
         if format_output:
             if successful:
-                print(json.dumps({'updateSuccessful': successful}, ))
+                print(
+                    json.dumps(
+                        {"updateSuccessful": successful},
+                    )
+                )
             else:
                 error = updater_output.get("error_msg", "")
-                print(json.dumps({'updateSuccessful': successful, "error": error}))
+                print(json.dumps({"updateSuccessful": successful, "error": error}))
 
         if not successful:
             sys.exit(1)
@@ -63,14 +99,15 @@ def start_profiling():
     def exit_profiler():
         pr.disable()
         print("Profiling completed")
-        filename = 'updater.prof'  # You can change the filename if needed
+        filename = "updater.prof"  # You can change the filename if needed
         pr.dump_stats(filename)
 
     atexit.register(exit_profiler)
 
 
 def create_repo_command():
-    @click.command(help="""
+    @click.command(
+        help="""
         \b
         Create a new authentication repository at the specified location by registering
         signing keys and generating initial metadata files. Information about the roles
@@ -111,16 +148,32 @@ def create_repo_command():
 
         If the test flag is set, a special target file will be created. This means that when
         calling the updater, it'll be necessary to use the --authenticate-test-repo flag.
-        """)
+        """
+    )
     @catch_cli_exception(handle=TAFError, remove_dir_on_error=True)
-    @click.argument("path", type=click.Path(exists=False, file_okay=False, dir_okay=True, writable=True))
-    @click.option("--keys-description", help="A dictionary containing information about the "
-                  "keys or a path to a json file which stores the needed information")
+    @click.argument(
+        "path",
+        type=click.Path(exists=False, file_okay=False, dir_okay=True, writable=True),
+    )
+    @click.option(
+        "--keys-description",
+        help="A dictionary containing information about the "
+        "keys or a path to a json file which stores the needed information",
+    )
     @click.option("--keystore", default=None, help="Location of the keystore files")
-    @click.option("--no-commit", is_flag=True, default=False, help="Indicates if the changes should be "
-                  "committed automatically")
-    @click.option("--test", is_flag=True, default=False, help="Indicates if the created repository "
-                  "is a test authentication repository")
+    @click.option(
+        "--no-commit",
+        is_flag=True,
+        default=False,
+        help="Indicates if the changes should be " "committed automatically",
+    )
+    @click.option(
+        "--test",
+        is_flag=True,
+        default=False,
+        help="Indicates if the created repository "
+        "is a test authentication repository",
+    )
     @pin_managed
     def create(path, keys_description, keystore, no_commit, test, pin_manager):
         create_repository(
@@ -131,11 +184,13 @@ def create_repo_command():
             commit=not no_commit,
             test=test,
         )
+
     return create
 
 
 def clone_repo_command():
-    @click.command(help="""
+    @click.command(
+        help="""
         Validate and clone authentication repositories and target repositories. URL of the
         remote authentication repository must be specified when calling this command. If the remote repository's URL is a file system path, the --from-fs flag must be used.
 
@@ -167,19 +222,71 @@ def clone_repo_command():
         The update can be performed in strict or non-strict mode. Strict mode is enabled by specifying
         --strict, which will raise errors during the update if any warnings are found. By default, --strict
         is disabled.
-        """)
+        """
+    )
     @catch_cli_exception(handle=UpdateFailedError, skip_cleanup=True)
     @click.argument("url")
     @common_update_options
-    @click.option("--path", help="Authentication repository's location. If not specified, calculated by combining repository's name specified in info.json and library dir")
-    @click.option("--library-dir", default=None, help="Directory where target repositories and, optionally, authentication repository are located. If not specified, set to the current directory")
-    @click.option("--from-fs", is_flag=True, default=False, help="Indicates if we want to clone a repository from the filesystem")
-    @click.option("--bare", is_flag=True, default=False, help="Clone repositories as bare repositories")
-    @click.option("--no-deps", is_flag=True, default=False, help="Optionally disables updating of dependencies")
-    @click.option("--upstream/--no-upstream", default=False, help="Skips comparison with remote repositories upstream")
-    @click.option("-v", "--verbosity", count=True, help="Displays varied levels of logging information based on verbosity level")
-    @click.option("--run-scripts/--no-run-scripts", default=False, help="Run the auxiliary lifecycle handler scripts.")
-    def clone(path, url, library_dir, from_fs, expected_repo_type, scripts_root_dir, profile, format_output, exclude_target, strict, bare, upstream, no_deps, verbosity, run_scripts):
+    @click.option(
+        "--path",
+        help="Authentication repository's location. If not specified, calculated by combining repository's name specified in info.json and library dir",
+    )
+    @click.option(
+        "--library-dir",
+        default=None,
+        help="Directory where target repositories and, optionally, authentication repository are located. If not specified, set to the current directory",
+    )
+    @click.option(
+        "--from-fs",
+        is_flag=True,
+        default=False,
+        help="Indicates if we want to clone a repository from the filesystem",
+    )
+    @click.option(
+        "--bare",
+        is_flag=True,
+        default=False,
+        help="Clone repositories as bare repositories",
+    )
+    @click.option(
+        "--no-deps",
+        is_flag=True,
+        default=False,
+        help="Optionally disables updating of dependencies",
+    )
+    @click.option(
+        "--upstream/--no-upstream",
+        default=False,
+        help="Skips comparison with remote repositories upstream",
+    )
+    @click.option(
+        "-v",
+        "--verbosity",
+        count=True,
+        help="Displays varied levels of logging information based on verbosity level",
+    )
+    @click.option(
+        "--run-scripts/--no-run-scripts",
+        default=False,
+        help="Run the auxiliary lifecycle handler scripts.",
+    )
+    def clone(
+        path,
+        url,
+        library_dir,
+        from_fs,
+        expected_repo_type,
+        scripts_root_dir,
+        profile,
+        format_output,
+        exclude_target,
+        strict,
+        bare,
+        upstream,
+        no_deps,
+        verbosity,
+        run_scripts,
+    ):
         settings.VERBOSITY = verbosity
         initialize_logger_handlers()
         if profile:
@@ -207,7 +314,8 @@ def clone_repo_command():
 
 
 def update_repo_command():
-    @click.command(help="""
+    @click.command(
+        help="""
         Update and validate local authentication repositories and target repositories.
 
         If the authentication repository and the target repositories are in the same root directory,
@@ -237,18 +345,61 @@ def update_repo_command():
         The update can be performed in strict or non-strict mode. Strict mode is enabled by specifying
         --strict, which will raise errors during the update if any warnings are found. By default, --strict
         is disabled.
-        """)
+        """
+    )
     @find_repository
     @catch_cli_exception(handle=UpdateFailedError, skip_cleanup=True)
     @common_update_options
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--library-dir", default=None, help="Directory where target repositories and, optionally, authentication repository are located. If not specified, calculated based on the authentication repository's path")
-    @click.option("--force", is_flag=True, default=False, help="Force Update repositories")
-    @click.option("--no-deps", is_flag=True, default=False, help="Optionally disables updating of dependencies.")
-    @click.option("--upstream/--no-upstream", default=False, help="Skips comparison with remote repositories upstream")
-    @click.option("-v", "--verbosity", count=True, help="Displays varied levels of logging information based on verbosity level")
-    @click.option("--run-scripts/--no-run-scripts", default=False, help="Run the auxiliary lifecycle handler scripts.")
-    def update(path, library_dir, expected_repo_type, scripts_root_dir, profile, format_output, exclude_target, strict, no_deps, force, upstream, verbosity, run_scripts):
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
+    @click.option(
+        "--library-dir",
+        default=None,
+        help="Directory where target repositories and, optionally, authentication repository are located. If not specified, calculated based on the authentication repository's path",
+    )
+    @click.option(
+        "--force", is_flag=True, default=False, help="Force Update repositories"
+    )
+    @click.option(
+        "--no-deps",
+        is_flag=True,
+        default=False,
+        help="Optionally disables updating of dependencies.",
+    )
+    @click.option(
+        "--upstream/--no-upstream",
+        default=False,
+        help="Skips comparison with remote repositories upstream",
+    )
+    @click.option(
+        "-v",
+        "--verbosity",
+        count=True,
+        help="Displays varied levels of logging information based on verbosity level",
+    )
+    @click.option(
+        "--run-scripts/--no-run-scripts",
+        default=False,
+        help="Run the auxiliary lifecycle handler scripts.",
+    )
+    def update(
+        path,
+        library_dir,
+        expected_repo_type,
+        scripts_root_dir,
+        profile,
+        format_output,
+        exclude_target,
+        strict,
+        no_deps,
+        force,
+        upstream,
+        verbosity,
+        run_scripts,
+    ):
         settings.VERBOSITY = verbosity
         initialize_logger_handlers()
 
@@ -270,36 +421,92 @@ def update_repo_command():
         )
 
         _call_updater(config, format_output)
+
     return update
 
 
 def validate_repo_command():
-    @click.command(help="""
+    @click.command(
+        help="""
         Validates an authentication repository which is already on the file system
         and its target repositories (which are also expected to be on the file system).
         Does not clone repositories, fetch changes or merge commits.
 
         Validation can be in strict or no-strict mode. Strict mode is set by specifying --strict, which will raise errors
         during validate if any/all warnings are found. By default, --strict is disabled.
-        """)
+        """
+    )
     @find_repository
     @catch_cli_exception(handle=UpdateFailedError)
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--library-dir", default=None, help="Directory where target repositories and, "
-                  "optionally, authentication repository are located. If omitted it is "
-                  "calculated based on authentication repository's path. "
-                  "Authentication repo is presumed to be at library-dir/namespace/auth-repo-name")
-    @click.option("--from-commit", default=None, help="First commit which should be validated.")
-    @click.option("--from-latest", is_flag=True, default=False, help="Use the last validated commit as the starting point.")
-    @click.option("--exclude-target", multiple=True, help="globs defining which target repositories should be "
-                  "ignored during update.")
-    @click.option("--strict", is_flag=True, default=False, help="Enable/disable strict mode - return an error"
-                  "if warnings are raised")
-    @click.option("--no-targets", is_flag=True, default=False, help="Skips target repository validation and validates only authentication repositories")
-    @click.option("--no-deps", is_flag=True, default=False, help="Optionally disables updating of dependencies")
-    @click.option("-v", "--verbosity", count=True, help="Displays varied levels of logging information based on verbosity level")
-    @click.option("--profile", is_flag=True, help="Flag used to run profiler and generate .prof file")
-    def validate(path, library_dir, from_commit, from_latest, exclude_target, strict, no_targets, no_deps, verbosity, profile):
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
+    @click.option(
+        "--library-dir",
+        default=None,
+        help="Directory where target repositories and, "
+        "optionally, authentication repository are located. If omitted it is "
+        "calculated based on authentication repository's path. "
+        "Authentication repo is presumed to be at library-dir/namespace/auth-repo-name",
+    )
+    @click.option(
+        "--from-commit", default=None, help="First commit which should be validated."
+    )
+    @click.option(
+        "--from-latest",
+        is_flag=True,
+        default=False,
+        help="Use the last validated commit as the starting point.",
+    )
+    @click.option(
+        "--exclude-target",
+        multiple=True,
+        help="globs defining which target repositories should be "
+        "ignored during update.",
+    )
+    @click.option(
+        "--strict",
+        is_flag=True,
+        default=False,
+        help="Enable/disable strict mode - return an error" "if warnings are raised",
+    )
+    @click.option(
+        "--no-targets",
+        is_flag=True,
+        default=False,
+        help="Skips target repository validation and validates only authentication repositories",
+    )
+    @click.option(
+        "--no-deps",
+        is_flag=True,
+        default=False,
+        help="Optionally disables updating of dependencies",
+    )
+    @click.option(
+        "-v",
+        "--verbosity",
+        count=True,
+        help="Displays varied levels of logging information based on verbosity level",
+    )
+    @click.option(
+        "--profile",
+        is_flag=True,
+        help="Flag used to run profiler and generate .prof file",
+    )
+    def validate(
+        path,
+        library_dir,
+        from_commit,
+        from_latest,
+        exclude_target,
+        strict,
+        no_targets,
+        no_deps,
+        verbosity,
+        profile,
+    ):
         settings.VERBOSITY = verbosity
         initialize_logger_handlers()
         if profile:
@@ -308,30 +515,57 @@ def validate_repo_command():
         bare = auth_repo.is_bare_repository
         if from_latest:
             from_commit = auth_repo.last_validated_commit
-        validate_repository(path, library_dir, from_commit, exclude_target, strict, bare, no_targets, no_deps)
+        validate_repository(
+            path,
+            library_dir,
+            from_commit,
+            exclude_target,
+            strict,
+            bare,
+            no_targets,
+            no_deps,
+        )
+
     return validate
 
 
 def latest_commit_and_branch_command():
-    @click.command(help="""Fetch and print the last validated commit hash and the default branch.
-        Integrated into the pre-push git hook""")
+    @click.command(
+        help="""Fetch and print the last validated commit hash and the default branch.
+        Integrated into the pre-push git hook"""
+    )
     @find_repository
     @catch_cli_exception
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
     def latest_commit_and_branch(path):
         auth_repo = AuthenticationRepository(path=path)
         last_validated_commit = auth_repo.last_validated_commit or ""
         default_branch = auth_repo.default_branch
         print(f"{default_branch},{last_validated_commit}")
+
     return latest_commit_and_branch
 
 
 def status_command():
-    @click.command(help="Prints the whole state of the library, including authentication repositories and its dependencies.")
+    @click.command(
+        help="Prints the whole state of the library, including authentication repositories and its dependencies."
+    )
     @find_repository
     @catch_cli_exception
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--library-dir", default=None, help="Path to the library's root directory. Determined based on the authentication repository's path if not provided.")
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
+    @click.option(
+        "--library-dir",
+        default=None,
+        help="Path to the library's root directory. Determined based on the authentication repository's path if not provided.",
+    )
     def status(path, library_dir):
         try:
             taf_status(path, library_dir)
@@ -339,13 +573,16 @@ def status_command():
             click.echo()
             click.echo(f"Error: {e}")
             click.echo()
+
     return status
 
 
 def attach_to_group(group):
-    group.add_command(create_repo_command(), name='create')
-    group.add_command(clone_repo_command(), name='clone')
-    group.add_command(update_repo_command(), name='update')
-    group.add_command(validate_repo_command(), name='validate')
-    group.add_command(latest_commit_and_branch_command(), name='latest-commit-and-branch')
-    group.add_command(status_command(), name='status')
+    group.add_command(create_repo_command(), name="create")
+    group.add_command(clone_repo_command(), name="clone")
+    group.add_command(update_repo_command(), name="update")
+    group.add_command(validate_repo_command(), name="validate")
+    group.add_command(
+        latest_commit_and_branch_command(), name="latest-commit-and-branch"
+    )
+    group.add_command(status_command(), name="status")

--- a/taf/tools/roles/__init__.py
+++ b/taf/tools/roles/__init__.py
@@ -21,7 +21,8 @@ from taf.tools.repo import pin_managed
 
 
 def add_roles_command():
-    @click.command(help="""
+    @click.command(
+        help="""
     Add new delegated target roles. Allows optional specification of each role's properties through a JSON configuration file.
 
     Configuration file (JSON) can specify:
@@ -67,15 +68,38 @@ def add_roles_command():
         }
     }
     }
-    """)
+    """
+    )
     @find_repository
     @catch_cli_exception(handle=TAFError)
     @common_repo_edit_options
-    @click.option("--config-file", type=click.Path(exists=True), help="Path to the JSON configuration file.")
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme used for signing")
+    @click.option(
+        "--config-file",
+        type=click.Path(exists=True),
+        help="Path to the JSON configuration file.",
+    )
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
+    @click.option(
+        "--scheme",
+        default=DEFAULT_RSA_SIGNATURE_SCHEME,
+        help="A signature scheme used for signing",
+    )
     @pin_managed
-    def add_roles(config_file, path, scheme, keystore, no_commit, prompt_for_keys, pin_manager, keys_description, no_remote_check):
+    def add_roles(
+        config_file,
+        path,
+        scheme,
+        keystore,
+        no_commit,
+        prompt_for_keys,
+        pin_manager,
+        keys_description,
+        no_remote_check,
+    ):
         add_multiple_roles(
             path=path,
             pin_manager=pin_manager,
@@ -87,16 +111,23 @@ def add_roles_command():
             keys_description=keys_description,
             skip_remote_check=no_remote_check,
         )
+
     return add_roles
 
 
 def export_roles_description_command():
-    @click.command(help="""
+    @click.command(
+        help="""
         Export roles-description.json file based on the
-        """)
+        """
+    )
     @find_repository
     @catch_cli_exception(handle=TAFError)
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
     @click.option("--output", default=None, help="Output file path")
     @click.option("--keystore", default=None, help="Location of the keystore files")
     @pin_managed
@@ -116,15 +147,35 @@ def export_roles_description_command():
 
 
 def add_role_paths_command():
-    @click.command(help="Add a new delegated target role, specifying which paths are delegated to the new role. Its parent role, number of signing keys and signatures threshold can also be defined. Update and sign all metadata files and commit.")
+    @click.command(
+        help="Add a new delegated target role, specifying which paths are delegated to the new role. Its parent role, number of signing keys and signatures threshold can also be defined. Update and sign all metadata files and commit."
+    )
     @find_repository
     @catch_cli_exception(handle=TAFError)
     @click.argument("role")
     @common_repo_edit_options
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--delegated-path", multiple=True, help="Paths associated with the delegated role")
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
+    @click.option(
+        "--delegated-path",
+        multiple=True,
+        help="Paths associated with the delegated role",
+    )
     @pin_managed
-    def adding_role_paths(role, path, delegated_path, keystore, no_commit, prompt_for_keys, pin_manager, keys_description, no_remote_check):
+    def adding_role_paths(
+        role,
+        path,
+        delegated_path,
+        keystore,
+        no_commit,
+        prompt_for_keys,
+        pin_manager,
+        keys_description,
+        no_remote_check,
+    ):
         if not delegated_path:
             print("Specify at least one path")
             return
@@ -141,6 +192,7 @@ def add_role_paths_command():
             keys_description=keys_description,
             skip_remote_check=no_remote_check,
         )
+
     return adding_role_paths
 
 
@@ -148,20 +200,45 @@ def add_role_paths_command():
 # this is a TUF bug (or better said, caused by using a newer version of the updater and old repository_tool)
 # it will be addressed when we transition to metadata API
 def remove_role_command():
-    @click.command(help="""Remove a delegated target role, and, optionally, its targets (depending on the remove-targets parameter).
+    @click.command(
+        help="""Remove a delegated target role, and, optionally, its targets (depending on the remove-targets parameter).
         If targets should also be deleted, target files are remove and their corresponding entires are removed
         from repositoires.json. If targets should not get removed, the target files are signed using the
         removed role's parent role
-        """)
+        """
+    )
     @find_repository
     @catch_cli_exception(handle=TAFError)
     @click.argument("role")
     @common_repo_edit_options
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme used for signing")
-    @click.option("--remove-targets/--no-remove-targets", default=True, help="Should targets delegated to this role also be removed. If not removed, they are signed by the parent role")
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
+    @click.option(
+        "--scheme",
+        default=DEFAULT_RSA_SIGNATURE_SCHEME,
+        help="A signature scheme used for signing",
+    )
+    @click.option(
+        "--remove-targets/--no-remove-targets",
+        default=True,
+        help="Should targets delegated to this role also be removed. If not removed, they are signed by the parent role",
+    )
     @pin_managed
-    def remove(role, path, keystore, scheme, remove_targets, no_commit, prompt_for_keys, pin_manager, keys_description, no_remote_check):
+    def remove(
+        role,
+        path,
+        keystore,
+        scheme,
+        remove_targets,
+        no_commit,
+        prompt_for_keys,
+        pin_manager,
+        keys_description,
+        no_remote_check,
+    ):
         remove_role(
             path=path,
             pin_manager=pin_manager,
@@ -174,6 +251,7 @@ def remove_role_command():
             keys_description=keys_description,
             skip_remote_check=no_remote_check,
         )
+
     return remove
 
 
@@ -182,12 +260,33 @@ def remove_paths_command():
     @find_repository
     @catch_cli_exception(handle=TAFError)
     @common_repo_edit_options
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--delegated-path", multiple=True, help="A list of paths to be removed")
-    @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme used for signing")
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
+    @click.option(
+        "--delegated-path", multiple=True, help="A list of paths to be removed"
+    )
+    @click.option(
+        "--scheme",
+        default=DEFAULT_RSA_SIGNATURE_SCHEME,
+        help="A signature scheme used for signing",
+    )
     @click.option("--commit-msg", default=None, help="Commit message")
     @pin_managed
-    def remove_delegated_paths(path, delegated_path, keystore, scheme, no_commit, prompt_for_keys, pin_manager, keys_description, no_remote_check, commit_msg):
+    def remove_delegated_paths(
+        path,
+        delegated_path,
+        keystore,
+        scheme,
+        no_commit,
+        prompt_for_keys,
+        pin_manager,
+        keys_description,
+        no_remote_check,
+        commit_msg,
+    ):
         if not delegated_path:
             print("Specify at least one role")
             return
@@ -204,11 +303,13 @@ def remove_paths_command():
             skip_remote_check=no_remote_check,
             commit_msg=commit_msg,
         )
+
     return remove_delegated_paths
 
 
 def add_signing_key_command():
-    @click.command(help="""
+    @click.command(
+        help="""
         Add a new signing key. This will make it possible to a sign metadata files
         corresponding to the specified roles with another key. Although private keys are
         used for signing, key identifiers are calculated based on the public keys. This
@@ -216,17 +317,46 @@ def add_signing_key_command():
         a new signing key. Public key can be loaded from a file, in which case it is
         necessary to specify its path as the pub_key parameter's value. If this option
         is not used when calling this command, the key can be directly entered later.
-        """)
+        """
+    )
     @find_repository
     @catch_cli_exception(handle=TAFError)
     @common_repo_edit_options
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--role", multiple=True, help="A list of roles to whose list of signing keys the new key should be added")
-    @click.option("--pub-key-path", default=None, help="Path to the public key corresponding to the private key which should be registered as the role's signing key")
-    @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme used for signing")
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
+    @click.option(
+        "--role",
+        multiple=True,
+        help="A list of roles to whose list of signing keys the new key should be added",
+    )
+    @click.option(
+        "--pub-key-path",
+        default=None,
+        help="Path to the public key corresponding to the private key which should be registered as the role's signing key",
+    )
+    @click.option(
+        "--scheme",
+        default=DEFAULT_RSA_SIGNATURE_SCHEME,
+        help="A signature scheme used for signing",
+    )
     @click.option("--commit-msg", default=None, help="Commit message")
     @pin_managed
-    def adding_signing_key(path, role, pub_key_path, keystore, scheme, no_commit, prompt_for_keys, pin_manager, keys_description, no_remote_check, commit_msg):
+    def adding_signing_key(
+        path,
+        role,
+        pub_key_path,
+        keystore,
+        scheme,
+        no_commit,
+        prompt_for_keys,
+        pin_manager,
+        keys_description,
+        no_remote_check,
+        commit_msg,
+    ):
         if not role:
             print("Specify at least one role")
             return
@@ -244,23 +374,50 @@ def add_signing_key_command():
             skip_remote_check=no_remote_check,
             commit_msg=commit_msg,
         )
+
     return adding_signing_key
 
 
 def revoke_signing_key_command():
-    @click.command(help="""
+    @click.command(
+        help="""
         Revoke a signing key.
-        """)
+        """
+    )
     @find_repository
     @catch_cli_exception(handle=TAFError)
     @common_repo_edit_options
     @click.argument("keyid")
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--role", multiple=True, help="A list of roles from which to remove the key. If unspecified, the key is removed from all roles by default.")
-    @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme used for signing")
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
+    @click.option(
+        "--role",
+        multiple=True,
+        help="A list of roles from which to remove the key. If unspecified, the key is removed from all roles by default.",
+    )
+    @click.option(
+        "--scheme",
+        default=DEFAULT_RSA_SIGNATURE_SCHEME,
+        help="A signature scheme used for signing",
+    )
     @click.option("--commit-msg", default=None, help="Commit message")
     @pin_managed
-    def revoke_key(path, role, keyid, keystore, scheme, no_commit, prompt_for_keys, pin_manager, keys_description, no_remote_check, commit_msg):
+    def revoke_key(
+        path,
+        role,
+        keyid,
+        keystore,
+        scheme,
+        no_commit,
+        prompt_for_keys,
+        pin_manager,
+        keys_description,
+        no_remote_check,
+        commit_msg,
+    ):
 
         revoke_signing_key(
             path=path,
@@ -275,25 +432,60 @@ def revoke_signing_key_command():
             skip_remote_check=no_remote_check,
             commit_msg=commit_msg,
         )
+
     return revoke_key
 
 
 def rotate_signing_key_command():
-    @click.command(help="""
+    @click.command(
+        help="""
         Rotate a signing key.
-        """)
+        """
+    )
     @find_repository
     @catch_cli_exception(handle=TAFError)
     @click.argument("keyid")
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--role", multiple=True, help="A list of roles from which to rotate the key. Rotate from all by default")
-    @click.option("--pub-key-path", default=None, help="Path to the public key corresponding to the private key which should be registered as the role's signing key")
-    @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme used for signing")
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
+    @click.option(
+        "--role",
+        multiple=True,
+        help="A list of roles from which to rotate the key. Rotate from all by default",
+    )
+    @click.option(
+        "--pub-key-path",
+        default=None,
+        help="Path to the public key corresponding to the private key which should be registered as the role's signing key",
+    )
+    @click.option(
+        "--scheme",
+        default=DEFAULT_RSA_SIGNATURE_SCHEME,
+        help="A signature scheme used for signing",
+    )
     @click.option("--revoke-commit-msg", default=None, help="Revoke key commit message")
-    @click.option("--add-commit-msg", default=None, help="Add new signing key commit message")
+    @click.option(
+        "--add-commit-msg", default=None, help="Add new signing key commit message"
+    )
     @common_repo_edit_options
     @pin_managed
-    def rotate_key(path, role, keyid, pub_key_path, keystore, scheme, prompt_for_keys, revoke_commit_msg, add_commit_msg, pin_manager, keys_description, no_remote_check, no_commit):
+    def rotate_key(
+        path,
+        role,
+        keyid,
+        pub_key_path,
+        keystore,
+        scheme,
+        prompt_for_keys,
+        revoke_commit_msg,
+        add_commit_msg,
+        pin_manager,
+        keys_description,
+        no_remote_check,
+        no_commit,
+    ):
         rotate_signing_key(
             path=path,
             pin_manager=pin_manager,
@@ -307,37 +499,45 @@ def rotate_signing_key_command():
             add_commit_msg=add_commit_msg,
             keys_description=keys_description,
             skip_remote_check=no_remote_check,
-            commit=not no_commit
+            commit=not no_commit,
         )
+
     return rotate_key
 
 
 def list_keys_command():
-    @click.command(help="""
+    @click.command(
+        help="""
         List all keys of the specified role. If certs directory exists and contains certificates exported from YubiKeys,
         include additional information read from these certificates, like name or organization.
-        """)
+        """
+    )
     @find_repository
     @catch_cli_exception(handle=TAFError)
     @click.argument("role")
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
     def list_keys(role, path):
         key_infos = list_keys_of_role(
             path=path,
             role=role,
         )
         print("\n".join(key_infos))
+
     return list_keys
 
 
 def attach_to_group(group):
 
-    group.add_command(add_roles_command(), name='add')
-    group.add_command(add_role_paths_command(), name='add-role-paths')
-    group.add_command(remove_paths_command(), name='remove-paths')
+    group.add_command(add_roles_command(), name="add")
+    group.add_command(add_role_paths_command(), name="add-role-paths")
+    group.add_command(remove_paths_command(), name="remove-paths")
     # group.add_command(remove_role_command(), name='remove')
-    group.add_command(add_signing_key_command(), name='add-signing-key')
-    group.add_command(revoke_signing_key_command(), name='revoke-key')
-    group.add_command(rotate_signing_key_command(), name='rotate-key')
-    group.add_command(list_keys_command(), name='list-keys')
+    group.add_command(add_signing_key_command(), name="add-signing-key")
+    group.add_command(revoke_signing_key_command(), name="revoke-key")
+    group.add_command(rotate_signing_key_command(), name="rotate-key")
+    group.add_command(list_keys_command(), name="list-keys")
     group.add_command(export_roles_description_command(), name="export-description")

--- a/taf/tools/targets/__init__.py
+++ b/taf/tools/targets/__init__.py
@@ -9,7 +9,7 @@ from taf.api.targets import (
     remove_target_repo,
     export_targets_history,
     update_and_sign_targets,
-    update_target_repos_from_repositories_json
+    update_target_repos_from_repositories_json,
 )
 from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
 from taf.exceptions import TAFError
@@ -20,10 +20,12 @@ from taf.tools.repo import pin_managed
 
 
 def add_repo_command():
-    @click.command(context_settings=dict(
-        ignore_unknown_options=True,
-        allow_extra_args=True,
-    ), help="""Add a new repository by adding it to repositories.json, creating a delegation (if targets is not
+    @click.command(
+        context_settings=dict(
+            ignore_unknown_options=True,
+            allow_extra_args=True,
+        ),
+        help="""Add a new repository by adding it to repositories.json, creating a delegation (if targets is not
         its signing role) and adding and signing initial target files if the repository is found on the filesystem.
         All additional information that should be saved as the repository's custom content in `repositories.json`
         is specified by providing a json file containing this data. If a new role should be added, this configuration
@@ -59,18 +61,50 @@ def add_repo_command():
         to be located in the same library root directory as the authentication repository,
         in a directory whose name corresponds to its name. If authentication repository's path
         is `E:\\examples\\root\\namespace\\auth`, and the target's namespace prefixed name is
-        `namespace1\\repo1`, the target's path will be set to `E:\\examples\\root\\namespace1\\repo1`.""")
+        `namespace1\\repo1`, the target's path will be set to `E:\\examples\\root\\namespace1\\repo1`.""",
+    )
     @find_repository
     @catch_cli_exception(handle=TAFError)
     @common_repo_edit_options
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
     @click.argument("target-name")
-    @click.option("--target-path", default=None, help="Target repository's filesystem path")
-    @click.option("--role", default="targets", help="Signing role of the corresponding target file. Can be a new role, in which case it will be necessary to provide additional information")
-    @click.option("--config-file", type=click.Path(exists=True), help="Path to the JSON configuration file containing information about the new role and/or targets custom data.")
-    @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme used for signing")
+    @click.option(
+        "--target-path", default=None, help="Target repository's filesystem path"
+    )
+    @click.option(
+        "--role",
+        default="targets",
+        help="Signing role of the corresponding target file. Can be a new role, in which case it will be necessary to provide additional information",
+    )
+    @click.option(
+        "--config-file",
+        type=click.Path(exists=True),
+        help="Path to the JSON configuration file containing information about the new role and/or targets custom data.",
+    )
+    @click.option(
+        "--scheme",
+        default=DEFAULT_RSA_SIGNATURE_SCHEME,
+        help="A signature scheme used for signing",
+    )
     @pin_managed
-    def add_repo(path, target_path, target_name, role, config_file, keystore, prompt_for_keys, scheme, no_commit, pin_manager, keys_description, no_remote_check):
+    def add_repo(
+        path,
+        target_path,
+        target_name,
+        role,
+        config_file,
+        keystore,
+        prompt_for_keys,
+        scheme,
+        no_commit,
+        pin_manager,
+        keys_description,
+        no_remote_check,
+    ):
 
         config_data = {}
         if config_file:
@@ -126,11 +160,13 @@ def add_repo_command():
                 keys_description=keys_description,
                 skip_remote_check=no_remote_check,
             )
+
     return add_repo
 
 
 def export_history_command():
-    @click.command(help="""Export lists of sorted commits, grouped by branches and target repositories, based
+    @click.command(
+        help="""Export lists of sorted commits, grouped by branches and target repositories, based
         on target files stored in the authentication repository. If commit is specified,
         only return changes made at that revision and all subsequent revisions. If it is not,
         start from the initial authentication repository commit.
@@ -138,20 +174,37 @@ def export_history_command():
         data can be defined using the repo option. If no repositories are passed in, historical
         data will include all target repositories.
         to a file whose location is specified using the output option, or print it to
-        console.""")
+        console."""
+    )
     @find_repository
     @catch_cli_exception(handle=TAFError)
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--commit", default=None, help="Starting authentication repository commit")
-    @click.option("--output", default=None, help="File to which the resulting json will be written. If not provided, the output will be printed to console")
-    @click.option("--repo", multiple=True, help="Target repository whose historical data should be collected")
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
+    @click.option(
+        "--commit", default=None, help="Starting authentication repository commit"
+    )
+    @click.option(
+        "--output",
+        default=None,
+        help="File to which the resulting json will be written. If not provided, the output will be printed to console",
+    )
+    @click.option(
+        "--repo",
+        multiple=True,
+        help="Target repository whose historical data should be collected",
+    )
     def export_history(path, commit, output, repo):
         export_targets_history(path, Commitish.from_commit(commit), output, repo)
+
     return export_history
 
 
 def list_targets_command():
-    @click.command(help="""List target repositories of the specified authentication repository. All target repositories
+    @click.command(
+        help="""List target repositories of the specified authentication repository. All target repositories
         are expected to be inside the same library root dir. Only repositories that are listed in
         repositories.json and whose corresponding target files exist (files whose name matched the
         name defined in repositories.json located inside the targets directory). For each repository,
@@ -161,25 +214,45 @@ def list_targets_command():
         - if they are bare
         - if there are unsigned changes (commits not registered in the authentication repository)
         - if they are up-to-date with remote
-        - if there are uncommitted changes""")
+        - if there are uncommitted changes"""
+    )
     @find_repository
     @catch_cli_exception(handle=TAFError, print_error=True)
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
     def list(path):
         targets_status = list_targets(path)
         taf_logger.log("NOTICE", json.dumps(targets_status, indent=4))
+
     return list
 
 
 def remove_repo_command():
-    @click.command(help="Remove a target repository (from repsoitories.json and target file) and sign")
+    @click.command(
+        help="Remove a target repository (from repsoitories.json and target file) and sign"
+    )
     @find_repository
     @common_repo_edit_options
     @catch_cli_exception(handle=TAFError)
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
     @click.argument("target-name")
     @pin_managed
-    def remove_repo(path, target_name, keystore, prompt_for_keys, pin_manager, keys_description, no_remote_check):
+    def remove_repo(
+        path,
+        target_name,
+        keystore,
+        prompt_for_keys,
+        pin_manager,
+        keys_description,
+        no_remote_check,
+    ):
         remove_target_repo(
             path=path,
             pin_manager=pin_manager,
@@ -189,26 +262,58 @@ def remove_repo_command():
             keys_description=keys_description,
             skip_remote_check=no_remote_check,
         )
+
     return remove_repo
 
 
 def sign_targets_command():
-    @click.command(help="""Register and sign target files. This means that all targets metadata files corresponding
+    @click.command(
+        help="""Register and sign target files. This means that all targets metadata files corresponding
         to roles responsible for updated target files are updated. Once the targets
         files are updated, so are snapshot and timestamp. All files are then signed. If the
         keystore parameter is provided, keys stored in that directory will be used for
         signing. If a needed key is not in that directory, the file can either be signed
-        by manually entering the key or by using a Yubikey.""")
+        by manually entering the key or by using a Yubikey."""
+    )
     @find_repository
     @catch_cli_exception(handle=TAFError)
-    @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
-    @click.option("--keys-description", help="A dictionary containing information about the keys or a path to a json file which stores this information")
+    @click.option(
+        "--prompt-for-keys",
+        is_flag=True,
+        default=False,
+        help="Whether to ask the user to enter their key if not located inside the keystore directory",
+    )
+    @click.option(
+        "--keys-description",
+        help="A dictionary containing information about the keys or a path to a json file which stores this information",
+    )
     @click.option("--keystore", default=None, help="Location of the keystore files")
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme used for signing")
-    @click.option("--no-commit", is_flag=True, default=False, help="Indicates that the changes should not be committed automatically")
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
+    @click.option(
+        "--scheme",
+        default=DEFAULT_RSA_SIGNATURE_SCHEME,
+        help="A signature scheme used for signing",
+    )
+    @click.option(
+        "--no-commit",
+        is_flag=True,
+        default=False,
+        help="Indicates that the changes should not be committed automatically",
+    )
     @pin_managed
-    def sign(path, keystore, keys_description, scheme, prompt_for_keys, no_commit, pin_manager):
+    def sign(
+        path,
+        keystore,
+        keys_description,
+        scheme,
+        prompt_for_keys,
+        no_commit,
+        pin_manager,
+    ):
         try:
             register_target_files(
                 path=path,
@@ -224,11 +329,13 @@ def sign_targets_command():
             click.echo()
             click.echo(str(e))
             click.echo()
+
     return sign
 
 
 def update_and_sign_command():
-    @click.command(help="""Update target files corresponding to target repositories specified through the target type parameter
+    @click.command(
+        help="""Update target files corresponding to target repositories specified through the target type parameter
         by writing the current top commit and branch name to the target files. Sign the updated files
         and then commit. Types are expected to be defined in reposoitories.json, inside the custom data
         (Should be generalized in the future). If types are not specified, update all repositories specified
@@ -246,19 +353,59 @@ def update_and_sign_command():
         through the --library-dir option. If the --namespace option's value is not provided, it is assumed
         that the namespace of target repositories is equal to the authentication repository's namespace,
         determined based on the repository's path. E.g. Namespace of E:\\root\\namespace2\\auth-repo
-        is namespace2.""")
+        is namespace2."""
+    )
     @find_repository
     @catch_cli_exception(handle=TAFError)
-    @click.option("--path", default=".", help="Authentication repository's location. If not specified, set to the current directory")
-    @click.option("--library-dir", default=None, help="Directory where target repositories and, optionally, authentication repository are located. If omitted it is calculated based on authentication repository's path. Authentication repo is presumed to be at library-dir/namespace/auth-repo-name")
-    @click.option("--target-type", multiple=True, help="Types of target repositories whose corresponding target files should be updated and signed. Should match a target type defined in repositories.json")
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
+    @click.option(
+        "--library-dir",
+        default=None,
+        help="Directory where target repositories and, optionally, authentication repository are located. If omitted it is calculated based on authentication repository's path. Authentication repo is presumed to be at library-dir/namespace/auth-repo-name",
+    )
+    @click.option(
+        "--target-type",
+        multiple=True,
+        help="Types of target repositories whose corresponding target files should be updated and signed. Should match a target type defined in repositories.json",
+    )
     @click.option("--keystore", default=None, help="Location of the keystore files")
-    @click.option("--keys-description", help="A dictionary containing information about the keys or a path to a json file which stores the needed information")
-    @click.option("--scheme", default=DEFAULT_RSA_SIGNATURE_SCHEME, help="A signature scheme used for signing")
-    @click.option("--prompt-for-keys", is_flag=True, default=False, help="Whether to ask the user to enter their key if not located inside the keystore directory")
-    @click.option("--no-commit", is_flag=True, default=False, help="Indicates that the changes should not be committed automatically")
+    @click.option(
+        "--keys-description",
+        help="A dictionary containing information about the keys or a path to a json file which stores the needed information",
+    )
+    @click.option(
+        "--scheme",
+        default=DEFAULT_RSA_SIGNATURE_SCHEME,
+        help="A signature scheme used for signing",
+    )
+    @click.option(
+        "--prompt-for-keys",
+        is_flag=True,
+        default=False,
+        help="Whether to ask the user to enter their key if not located inside the keystore directory",
+    )
+    @click.option(
+        "--no-commit",
+        is_flag=True,
+        default=False,
+        help="Indicates that the changes should not be committed automatically",
+    )
     @pin_managed
-    def update_and_sign(path, library_dir, target_type, keystore, keys_description, scheme, prompt_for_keys, no_commit, pin_manager):
+    def update_and_sign(
+        path,
+        library_dir,
+        target_type,
+        keystore,
+        keys_description,
+        scheme,
+        prompt_for_keys,
+        no_commit,
+        pin_manager,
+    ):
         try:
             if len(target_type):
                 update_and_sign_targets(
@@ -287,14 +434,15 @@ def update_and_sign_command():
             click.echo()
             click.echo(str(e))
             click.echo()
+
     return update_and_sign
 
 
 def attach_to_group(group):
 
-    group.add_command(add_repo_command(), name='add-repo')
-    group.add_command(export_history_command(), name='export-history')
-    group.add_command(list_targets_command(), name='list')
-    group.add_command(remove_repo_command(), name='remove-repo')
-    group.add_command(sign_targets_command(), name='sign')
-    group.add_command(update_and_sign_command(), name='update-and-sign')
+    group.add_command(add_repo_command(), name="add-repo")
+    group.add_command(export_history_command(), name="export-history")
+    group.add_command(list_targets_command(), name="list")
+    group.add_command(remove_repo_command(), name="remove-repo")
+    group.add_command(sign_targets_command(), name="sign")
+    group.add_command(update_and_sign_command(), name="update-and-sign")

--- a/taf/tools/yubikey/__init__.py
+++ b/taf/tools/yubikey/__init__.py
@@ -16,14 +16,21 @@ from taf.yubikey.yubikey import list_connected_yubikeys, list_all_devices
 def check_pin_command():
     @click.command(help="Checks if the specified pin is valid")
     @click.option("--pin", default=None, help="PIN to be checked")
-    @click.option("--serial", default=None, type=int, help="Serial number of a YubiKey. Has to be provided if more than one YK is inserted")
+    @click.option(
+        "--serial",
+        default=None,
+        type=int,
+        help="Serial number of a YubiKey. Has to be provided if more than one YK is inserted",
+    )
     @catch_cli_exception(handle=YubikeyError)
     def check_pin(pin, serial):
         try:
             from taf.yubikey.yubikey import is_valid_pin, get_and_validate_pin
 
             if serial is None and len(list_all_devices()) > 1:
-                click.echo("More than one YubiKey is inserted. Please specify the serial number of the YubiKey to be used")
+                click.echo(
+                    "More than one YubiKey is inserted. Please specify the serial number of the YubiKey to be used"
+                )
                 return
             name = serial or "YubiKey"
             if pin is None:
@@ -35,13 +42,12 @@ def check_pin_command():
         except Exception as e:
             click.echo(f"Error: {e}")
             return
+
     return check_pin
 
 
 def export_pub_key_command():
-    @click.command(
-        help="Export public keys of the inserted YubiKeys"
-    )
+    @click.command(help="Export public keys of the inserted YubiKeys")
     @click.option(
         "--output",
         help="File to which the exported public key will be written. The result will be written to the console if path is not specified",
@@ -54,9 +60,7 @@ def export_pub_key_command():
 
 
 def get_roles_command():
-    @click.command(
-        help="List roles the inserted YubiKey is allowed to sign."
-    )
+    @click.command(help="List roles the inserted YubiKey is allowed to sign.")
     @catch_cli_exception(handle=YubikeyError, print_error=True)
     @click.option(
         "--path",
@@ -78,9 +82,7 @@ def get_roles_command():
 
 
 def export_certificate_command():
-    @click.command(
-        help="Export certificates of the inserted YubiKeys"
-    )
+    @click.command(help="Export certificates of the inserted YubiKeys")
     @click.option(
         "--output",
         help="File to which the exported certificate key will be written. The result will be written to the user's home directory by default",
@@ -97,6 +99,7 @@ def list_key_command():
     @catch_cli_exception(handle=YubikeyError)
     def list_keys():
         list_connected_yubikeys()
+
     return list_keys
 
 
@@ -133,10 +136,10 @@ def setup_test_key_command():
 
 
 def attach_to_group(group):
-    group.add_command(check_pin_command(), name='check-pin')
-    group.add_command(export_pub_key_command(), name='export-pub-key')
-    group.add_command(get_roles_command(), name='get-roles')
-    group.add_command(export_certificate_command(), name='export-certificate')
-    group.add_command(list_key_command(), name='list-key')
-    group.add_command(setup_signing_key_command(), name='setup-signing-key')
-    group.add_command(setup_test_key_command(), name='setup-test-key')
+    group.add_command(check_pin_command(), name="check-pin")
+    group.add_command(export_pub_key_command(), name="export-pub-key")
+    group.add_command(get_roles_command(), name="get-roles")
+    group.add_command(export_certificate_command(), name="export-certificate")
+    group.add_command(list_key_command(), name="list-key")
+    group.add_command(setup_signing_key_command(), name="setup-signing-key")
+    group.add_command(setup_test_key_command(), name="setup-test-key")


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Pin `black` formatter version to `22.12.0` to avoid errors on manual formatting when versions differ.
Run black on all files to reformat them.

Closes: #671

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
