### PR TITLE
fix: revert changes to update_from_filesystem after running local validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Revert changes to global update_from_filesystem after running local validation ([693])
 - Fix `commit_exists` ([689])
 - Attempt to remove `index.lock` if branch checkout fails ([684])
 
+[693]: https://github.com/openlawlibrary/taf/pull/693
 [689]: https://github.com/openlawlibrary/taf/pull/689
 [684]: https://github.com/openlawlibrary/taf/pull/684
 

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -632,6 +632,7 @@ def validate_repository(
     no_targets=False,
     no_deps=False,
 ):
+    update_from_filesystem = settings.update_from_filesystem
     settings.strict = strict
 
     auth_path = Path(auth_path).resolve()
@@ -680,3 +681,4 @@ def validate_repository(
             f"Validation of repository {auth_repo_name or ''} failed due to error: {e}"
         )
     settings.last_validated_commit = {}
+    settings.update_from_filesystem = update_from_filesystem

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -787,7 +787,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                     error_msg = (
                         f"The newest commit of repository {self.state.users_auth_repo.name} is no longer "
                         f"on branch {default_branch} of the remote repository. This could "
-                        "either mean that    there was an unauthorized push to the remote "
+                        f"either mean that there was an unauthorized push to the remote ({self.state.validation_auth_repo.urls[0]}) "
                         "or an invalid modification of the local repository."
                     )
                     # this is always an error, force or no force


### PR DESCRIPTION

## Description (e.g. "Related to ...", etc.)

Revert changes to update_from_filesystem after running local validation
Also clarify an error message saying that there could've been an unauthorized push


## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
