### PR TITLE
Minor validate repository fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Add the missing `exclude-filter` option to the validate command
+
+[697]: https://github.com/openlawlibrary/taf/pull/697
+
 ## [0.37.0]
 
 ### Added

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -515,6 +515,11 @@ def validate_repo_command():
         is_flag=True,
         help="Flag used to run profiler and generate .prof file",
     )
+    @click.option(
+        "--exclude-filter",
+        default=None,
+        help="Exclude repositories matching Python expression. Repo available as 'repo'. Example: \"repo['type'] == 'html'\"",
+    )
     def validate(
         path,
         library_dir,

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -499,6 +499,11 @@ def validate_repo_command():
         help="Skips target repository validation and validates only authentication repositories",
     )
     @click.option(
+        "--upstream/--no-upstream",
+        default=False,
+        help="Skips comparison with remote repositories upstream",
+    )
+    @click.option(
         "--no-deps",
         is_flag=True,
         default=False,
@@ -532,6 +537,7 @@ def validate_repo_command():
         no_deps,
         verbosity,
         profile,
+        upstream,
     ):
         settings.VERBOSITY = verbosity
         initialize_logger_handlers()
@@ -551,6 +557,7 @@ def validate_repo_command():
             bare,
             no_targets,
             no_deps,
+            not upstream,
         )
 
     return validate

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -648,6 +648,7 @@ def validate_repository(
     bare=False,
     no_targets=False,
     no_deps=False,
+    no_upstream=True,
 ):
     update_from_filesystem = settings.update_from_filesystem
     settings.strict = strict
@@ -682,6 +683,7 @@ def validate_repository(
             expected_repo_type=expected_repo_type,
             update_from_filesystem=True,
             only_validate=True,
+            no_upstream=no_upstream,
         )
         updater_pipeline = AuthenticationRepositoryUpdatePipeline(config)
         updater_pipeline.run()


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

The previous PR broke the `taf repo validate` command, as `exclude-filter` cli option was missing.
Additionally, due to #696, validation never fails if there are additional commits, just logs them.
The error is only raised when the `upstream` flag is provided. Until the broader issue is addressed,
make it possible to call validation with `upstream`.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
