### PR TITLE
Sbojanic/implement taf repo reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
+- Implement taf repo reset ([703])
+
 ### Changed
 
 ### Fixed
@@ -22,14 +24,16 @@ and this project adheres to [Semantic Versioning][semver].
 ### Fixed
 
 - Fix traverse taf directory ([708])
+- Fix reset to commit bug ([703])
 
+[703]: https://github.com/openlawlibrary/taf/pull/703
 [708]: https://github.com/openlawlibrary/taf/pull/708
 
 ## [0.37.3]
 
 ### Added
 
--  Support writing structured clone/update results to a JSON file ([705])
+- Support writing structured clone/update results to a JSON file ([705])
 
 ### Changed
 

--- a/taf/api/repository.py
+++ b/taf/api/repository.py
@@ -196,25 +196,34 @@ def taf_status(path: str, library_dir: Optional[str] = None, indent: int = 0) ->
 
 def reset_repository(
     auth_repo: AuthenticationRepository, commit: str, lvc: bool, force: bool
-):
-    # Check specified commit:
-    last_validated_commit = Commitish.from_hash(auth_repo.last_validated_commit)
+) -> bool:
+    """
+    Resets auth and target repos to a snapshot in the past.
+    Arguments:
+        auth_repo: authentication repository
+        commit: auth commit to reset to
+        lvc: override last validated commit
+        force: forcefully reset (clean repositories if dirty)
+    """
     bare = auth_repo.is_bare_repository
 
+    # Handle auth repo:
+    # Check specified commit:
+    last_validated_commit = Commitish.from_hash(auth_repo.last_validated_commit)
     if commit is None:
         auth_commit = last_validated_commit
     else:
         auth_commit = auth_repo.resolve_commit(commit)
 
+    # Fail early if auth commit is not resolved properly or LVC is invalid:
     if auth_commit is None:
         print(
             "An error occured during auth repo commit check - make sure you either have a valid last validated commit or specify a commitish via --commit flag."
         )
         return False
 
+    # Fail early if commit is not on the branch:
     current_branch = auth_repo.get_current_branch()
-
-    # Check if commit on current branch
     if not auth_repo.is_commit_an_ancestor_of_a_commit_or_branch(
         auth_commit, current_branch
     ):
@@ -223,81 +232,98 @@ def reset_repository(
         )
         return False
 
-    if not bare:
-        if not force:
-            # Check if there are uncommited changes or unstaged files
-            if auth_repo.something_to_commit():
-                print(
-                    f"There are uncommited changes in {auth_repo.name}. Please commit/stash changes or run reset with force flag."
-                )
-                return False
-        else:
-            # Remove uncommited changes and untracked files if any
-            auth_repo.clean_and_reset()
+    # Fail early if there are uncommited changes or unstaged files:
+    if not bare and not force:
+        if auth_repo.something_to_commit():
+            print(
+                f"There are uncommited changes in {auth_repo.name}. Please commit/stash changes or run reset with force flag."
+            )
+            return False
 
-    # Reset to the specified commit
-    auth_repo.reset_to_commit(auth_commit, hard=False if bare else True)
-    print(f"{auth_repo.name} successfully reset to commit {auth_commit.hash}")
-
-    should_override_lvc = lvc and auth_repo.is_commit_an_ancestor_of_a_commit_or_branch(
-        auth_commit, last_validated_commit
-    )
-    if should_override_lvc:
-        # Override LVC
-        auth_repo.set_last_validated_of_repo(auth_repo.name, auth_commit, True)
-        print(
-            f"Last validated commit successfully overridden to value {auth_commit.hash} for repository {auth_repo.name}"
-        )
-
+    # Handle target repos:
     # Load corresponding target repos and their commits
     repositoriesdb.load_repositories(auth_repo)
     target_repos = repositoriesdb.get_deduplicated_repositories(auth_repo)
 
-    # For each target repo:
+    # Perform checks for each target repo:
     for repo_name, repo in target_repos.items():
-        target = auth_repo.get_target(repo_name)
+        target = auth_repo.get_target(repo_name, auth_commit)
+        # Fail early if target repo can't be loaded:
         if target is None:
             print(f"Error, target {repo_name} could not be loaded!")
+            return False
+
+        if not bare and not force:
+            # Fail early if there are uncommited changes or unstaged files
+            if repo.something_to_commit():
+                print(
+                    f"There are uncommited changes in {repo.name}. Please commit/stash changes or run reset with force flag."
+                )
+                return False
+
+    # All checks passed, reset repositories:
+    if force and not bare:
+        # Remove uncommited changes and untracked files if any
+        auth_repo.clean_and_reset()
+    # Reset to the specified commit
+    auth_repo.reset_to_commit(auth_commit, hard=False if bare else True)
+    print(f"{auth_repo.name} successfully reset to commit {auth_commit.hash}")
+
+    should_override_lvc = _should_override_lvc(
+        lvc, auth_repo, auth_commit, last_validated_commit.hash
+    )
+
+    # Override LVC:
+    if should_override_lvc:
+        auth_repo.set_last_validated_of_repo(auth_repo.name, auth_commit, True)
+        print(
+            f"Last validated commit successfully overridden to {auth_commit.hash} for repository {auth_repo.name}"
+        )
+
+    # Reset target repos:
+    for repo_name, repo in target_repos.items():
+        target = auth_repo.get_target(repo_name, auth_commit)
+        if target is None:
+            print(f"Target repository {repo_name} could not be loaded, aborting reset.")
             return False
 
         target_branch = target["branch"]
         target_commit = Commitish.from_hash(target["commit"])
 
-        if not repo.is_commit_an_ancestor_of_a_commit_or_branch(
-            target_commit, target_branch
-        ):
-            print(
-                f"{repo_name} commit {target_commit} not found on current branch ({target_branch})."
-            )
-            return False
-
-        if not bare:
-            if not force:
-                # Check if there are uncommited changes or unstaged files
-                if repo.something_to_commit():
-                    print(
-                        f"There are uncommited changes in {repo.name}. Please commit/stash changes or run reset with force flag."
-                    )
-                    return False
-            else:
+        if bare:
+            # Set HEAD to the target branch, since checkout is not possible in bare repo:
+            repo._git(f"symbolic-ref HEAD refs/heads/{target_branch}")
+        else:
+            if force:
                 # Remove uncommited changes and untracked files if any
                 auth_repo.clean_and_reset()
-
-            # Find proper branch and check it out
             repo.checkout_branch(target_branch)
-        else:
-            # Checkout is not possible in bare repo, set HEAD to the target branch instead
-            repo._git(f"symbolic-ref HEAD refs/heads/{target_branch}")
 
         # Reset to the specified commit
         repo.reset_to_commit(target_commit, hard=False if bare else True)
         print(f"{repo_name} successfully reset to commit {target_commit.hash}")
 
+        # Override LVC:
         if should_override_lvc:
-            # Override LVC
             auth_repo.set_last_validated_of_repo(repo_name, auth_commit, True)
             print(
                 f"Last validated commit successfully overridden to value {auth_commit.hash} for repository {repo_name}"
             )
 
     return True
+
+
+def _should_override_lvc(
+    lvc_flag: bool,
+    auth_repo: AuthenticationRepository,
+    auth_commit: Commitish,
+    lvc: str,
+):
+    if lvc_flag:
+        if not auth_repo.is_commit_an_ancestor_of_a_commit_or_branch(auth_commit, lvc):
+            print(
+                "Specified commit is not the ancestor of last validated commit. Last validated commit will not be overriden."
+            )
+        else:
+            return True
+    return False

--- a/taf/api/repository.py
+++ b/taf/api/repository.py
@@ -262,7 +262,7 @@ def reset_repository(
 
         target_branch = target["branch"]
         target_commit = Commitish.from_hash(target["commit"])
-        
+
         if not repo.is_commit_an_ancestor_of_a_commit_or_branch(
             target_commit, target_branch
         ):
@@ -282,7 +282,7 @@ def reset_repository(
             else:
                 # Remove uncommited changes and untracked files if any
                 auth_repo.clean_and_reset()
-                
+
             # Find proper branch and check it out
             repo.checkout_branch(target_branch)
         else:

--- a/taf/api/repository.py
+++ b/taf/api/repository.py
@@ -207,7 +207,7 @@ def reset_repository(
 
     if auth_commit is None:
         print(
-            f"An error occured during auth repo commit check - make sure you either have a valid last validated commit or specify a commitish via --commit flag."
+            "An error occured during auth repo commit check - make sure you either have a valid last validated commit or specify a commitish via --commit flag."
         )
         return False
 
@@ -253,7 +253,12 @@ def reset_repository(
 
     # For each target repo:
     for repo_name, repo in target_repos.items():
-        target_commit = Commitish.from_hash(auth_repo.get_target(repo_name)["commit"])
+        target = auth_repo.get_target(repo_name)
+        if target is None:
+            print(f"Error, target {repo_name} could not be loaded!")
+            return False
+
+        target_commit = Commitish.from_hash(target["commit"])
         # Find proper branch and check it out
         current_target_repo_branch = repo.get_current_branch()
         if not repo.is_commit_an_ancestor_of_a_commit_or_branch(

--- a/taf/api/repository.py
+++ b/taf/api/repository.py
@@ -16,7 +16,7 @@ from taf.api.roles import (
 from taf.api.targets import list_targets, register_target_files
 
 from taf.auth_repo import AuthenticationRepository
-from taf.exceptions import TAFError
+from taf.exceptions import TAFError, ResetFailedError
 from taf.keys import load_sorted_keys_of_new_roles
 import taf.repositoriesdb as repositoriesdb
 from taf.api.utils._conf import find_keystore
@@ -217,34 +217,23 @@ def reset_repository(
 
     # Fail early if auth commit is not resolved properly or LVC is invalid:
     if auth_commit is None:
-        taf_logger.error(
+        raise ResetFailedError(
             "An error occured during auth repo commit check - make sure you either have a valid last validated commit or specify a commitish via --commit flag."
         )
-        return False
 
     # Fail early if there are uncommited changes or unstaged files:
     if not bare and not force:
         if auth_repo.something_to_commit():
-            taf_logger.error(
+            raise ResetFailedError(
                 f"There are uncommited changes in {auth_repo.name}. Please commit/stash changes or run reset with force flag."
             )
-            return False
-    
+
     # Fail early if repo is in detached head state:
     if auth_repo.is_detached_head:
         if not force:
-            taf_logger.error(
+            raise ResetFailedError(
                 f"{auth_repo.name} is in detached head state. Fix the state manually or run reset with force flag."
             )
-            return False
-
-    # Fail early if commit is not on the branch:
-    current_branch = auth_repo.get_current_branch()
-    if auth_commit not in  auth_repo.all_commits_on_branch(current_branch):
-        taf_logger.error(
-            f"Auth repo commit {auth_commit.hash} not found on current branch ({current_branch})."
-        )
-        return False
 
     # Handle target repos:
     # Load corresponding target repos and their commits
@@ -256,16 +245,27 @@ def reset_repository(
         target = auth_repo.get_target(repo_name, auth_commit)
         # Fail early if target repo can't be loaded:
         if target is None:
-            taf_logger.error(f"Error, target {repo_name} could not be loaded!")
-            return False
+            raise ResetFailedError(f"Error, target {repo_name} could not be loaded!")
 
         if not bare and not force:
             # Fail early if there are uncommited changes or unstaged files
             if repo.something_to_commit():
-                taf_logger.error(
+                raise ResetFailedError(
                     f"There are uncommited changes in {repo.name}. Please commit/stash changes or run reset with force flag."
                 )
-                return False
+
+    # If repo is in detached head and force flag is set, reset it to the specified commit
+    # This check is put at the last place since it modifies the state of the repository and there might be
+    # target repo changes that would lead to early failure and therefore exit before these changes
+    if auth_repo.is_detached_head:
+        auth_repo.reset_to_commit(auth_commit, hard=True)
+    # Fail early if commit is not on the branch:
+    current_branch = auth_repo.get_current_branch()
+    if auth_commit not in auth_repo.all_commits_on_branch(current_branch):
+        taf_logger.error()
+        raise ResetFailedError(
+            f"Auth repo commit {auth_commit.hash} not found on current branch ({current_branch})."
+        )
 
     # All checks passed, reset repositories:
     if force and not bare:
@@ -290,10 +290,9 @@ def reset_repository(
     for repo_name, repo in target_repos.items():
         target = auth_repo.get_target(repo_name, auth_commit)
         if target is None:
-            taf_logger.error(
+            raise ResetFailedError(
                 f"Target repository {repo_name} could not be loaded, aborting reset."
             )
-            return False
 
         target_branch = target["branch"]
         target_commit = Commitish.from_hash(target["commit"])

--- a/taf/api/repository.py
+++ b/taf/api/repository.py
@@ -205,121 +205,130 @@ def reset_repository(
         lvc: override last validated commit
         force: forcefully reset (clean repositories if dirty)
     """
-    bare = auth_repo.is_bare_repository
+    try:
+        bare = auth_repo.is_bare_repository
 
-    # Handle auth repo:
-    # Check specified commit:
-    last_validated_commit = Commitish.from_hash(auth_repo.last_validated_commit)
-    if commit is None:
-        auth_commit = last_validated_commit
-    else:
-        auth_commit = auth_repo.resolve_commit(commit)
+        # Handle auth repo:
+        # Check specified commit:
+        last_validated_commit = Commitish.from_hash(auth_repo.last_validated_commit)
+        if commit is None:
+            auth_commit = last_validated_commit
+        else:
+            auth_commit = auth_repo.resolve_commit(commit)
 
-    # Fail early if auth commit is not resolved properly or LVC is invalid:
-    if auth_commit is None:
-        raise ResetFailedError(
-            "An error occured during auth repo commit check - make sure you either have a valid last validated commit or specify a commitish via --commit flag."
-        )
-
-    # Fail early if there are uncommited changes or unstaged files:
-    if not bare and not force:
-        if auth_repo.something_to_commit():
+        # Fail early if auth commit is not resolved properly or LVC is invalid:
+        if auth_commit is None:
             raise ResetFailedError(
-                f"There are uncommited changes in {auth_repo.name}. Please commit/stash changes or run reset with force flag."
+                "An error occured during auth repo commit check - make sure you either have a valid last validated commit or specify a commitish via --commit flag."
             )
 
-    # Fail early if repo is in detached head state:
-    if auth_repo.is_detached_head:
-        if not force:
-            raise ResetFailedError(
-                f"{auth_repo.name} is in detached head state. Fix the state manually or run reset with force flag."
-            )
-
-    # Handle target repos:
-    # Load corresponding target repos and their commits
-    repositoriesdb.load_repositories(auth_repo)
-    target_repos = repositoriesdb.get_deduplicated_repositories(auth_repo)
-
-    # Perform checks for each target repo:
-    for repo_name, repo in target_repos.items():
-        target = auth_repo.get_target(repo_name, auth_commit)
-        # Fail early if target repo can't be loaded:
-        if target is None:
-            raise ResetFailedError(f"Error, target {repo_name} could not be loaded!")
-
+        # Fail early if there are uncommited changes or unstaged files:
         if not bare and not force:
-            # Fail early if there are uncommited changes or unstaged files
-            if repo.something_to_commit():
+            if auth_repo.something_to_commit():
                 raise ResetFailedError(
-                    f"There are uncommited changes in {repo.name}. Please commit/stash changes or run reset with force flag."
+                    f"There are uncommited changes in {auth_repo.name}. Please commit/stash changes or run reset with force flag."
                 )
 
-    # If repo is in detached head and force flag is set, reset it to the specified commit
-    # This check is put at the last place since it modifies the state of the repository and there might be
-    # target repo changes that would lead to early failure and therefore exit before these changes
-    if auth_repo.is_detached_head:
-        auth_repo.reset_to_commit(auth_commit, hard=True)
-    # Fail early if commit is not on the branch:
-    current_branch = auth_repo.get_current_branch()
-    if auth_commit not in auth_repo.all_commits_on_branch(current_branch):
-        taf_logger.error()
-        raise ResetFailedError(
-            f"Auth repo commit {auth_commit.hash} not found on current branch ({current_branch})."
-        )
+        # Fail early if repo is in detached head state:
+        if auth_repo.is_detached_head:
+            if not force:
+                raise ResetFailedError(
+                    f"{auth_repo.name} is in detached head state. Fix the state manually or run reset with force flag."
+                )
 
-    # All checks passed, reset repositories:
-    if force and not bare:
-        # Remove uncommited changes and untracked files if any
-        auth_repo.clean_and_reset()
-    # Reset to the specified commit
-    auth_repo.reset_to_commit(auth_commit, hard=False if bare else True)
-    taf_logger.info(f"{auth_repo.name} successfully reset to commit {auth_commit.hash}")
+        # Handle target repos:
+        # Load corresponding target repos and their commits
+        repositoriesdb.load_repositories(auth_repo)
+        target_repos = repositoriesdb.get_deduplicated_repositories(auth_repo)
 
-    should_override_lvc = _should_override_lvc(
-        override_lvc, auth_repo, auth_commit, last_validated_commit.hash
-    )
+        # Perform checks for each target repo:
+        for repo_name, repo in target_repos.items():
+            target = auth_repo.get_target(repo_name, auth_commit)
+            # Fail early if target repo can't be loaded:
+            if target is None:
+                raise ResetFailedError(
+                    f"Error, target {repo_name} could not be loaded!"
+                )
 
-    # Override LVC:
-    if should_override_lvc:
-        auth_repo.set_last_validated_of_repo(auth_repo.name, auth_commit, True)
-        taf_logger.info(
-            f"Last validated commit successfully overridden to {auth_commit.hash} for repository {auth_repo.name}"
-        )
+            if not bare and not force:
+                # Fail early if there are uncommited changes or unstaged files
+                if repo.something_to_commit():
+                    raise ResetFailedError(
+                        f"There are uncommited changes in {repo.name}. Please commit/stash changes or run reset with force flag."
+                    )
 
-    # Reset target repos:
-    for repo_name, repo in target_repos.items():
-        target = auth_repo.get_target(repo_name, auth_commit)
-        if target is None:
+        # If repo is in detached head and force flag is set, reset it to the specified commit
+        # This check is put at the last place since it modifies the state of the repository and there might be
+        # target repo changes that would lead to early failure and therefore exit before these changes
+        if auth_repo.is_detached_head:
+            auth_repo.reset_to_commit(auth_commit, hard=True)
+        # Fail early if commit is not on the branch:
+        current_branch = auth_repo.get_current_branch()
+        if auth_commit not in auth_repo.all_commits_on_branch(current_branch):
+            taf_logger.error()
             raise ResetFailedError(
-                f"Target repository {repo_name} could not be loaded, aborting reset."
+                f"Auth repo commit {auth_commit.hash} not found on current branch ({current_branch})."
             )
 
-        target_branch = target["branch"]
-        target_commit = Commitish.from_hash(target["commit"])
-
-        if bare:
-            # Set HEAD to the target branch, since checkout is not possible in bare repo:
-            repo._git(f"symbolic-ref HEAD refs/heads/{target_branch}")
-        else:
-            if force:
-                # Remove uncommited changes and untracked files if any
-                auth_repo.clean_and_reset()
-            repo.checkout_branch(target_branch)
-
+        # All checks passed, reset repositories:
+        if force and not bare:
+            # Remove uncommited changes and untracked files if any
+            auth_repo.clean_and_reset()
         # Reset to the specified commit
-        repo.reset_to_commit(target_commit, hard=False if bare else True)
+        auth_repo.reset_to_commit(auth_commit, hard=False if bare else True)
         taf_logger.info(
-            f"{repo_name} successfully reset to commit {target_commit.hash}"
+            f"{auth_repo.name} successfully reset to commit {auth_commit.hash}"
+        )
+
+        should_override_lvc = _should_override_lvc(
+            override_lvc, auth_repo, auth_commit, last_validated_commit.hash
         )
 
         # Override LVC:
         if should_override_lvc:
-            auth_repo.set_last_validated_of_repo(repo_name, auth_commit, True)
+            auth_repo.set_last_validated_of_repo(auth_repo.name, auth_commit, True)
             taf_logger.info(
-                f"Last validated commit successfully overridden to value {auth_commit.hash} for repository {repo_name}"
+                f"Last validated commit successfully overridden to {auth_commit.hash} for repository {auth_repo.name}"
             )
 
-    return True
+        # Reset target repos:
+        for repo_name, repo in target_repos.items():
+            target = auth_repo.get_target(repo_name, auth_commit)
+            if target is None:
+                raise ResetFailedError(
+                    f"Target repository {repo_name} could not be loaded, aborting reset."
+                )
+
+            target_branch = target["branch"]
+            target_commit = Commitish.from_hash(target["commit"])
+
+            if bare:
+                # Set HEAD to the target branch, since checkout is not possible in bare repo:
+                repo._git(f"symbolic-ref HEAD refs/heads/{target_branch}")
+            else:
+                if force:
+                    # Remove uncommited changes and untracked files if any
+                    auth_repo.clean_and_reset()
+                repo.checkout_branch(target_branch)
+
+            # Reset to the specified commit
+            repo.reset_to_commit(target_commit, hard=False if bare else True)
+            taf_logger.info(
+                f"{repo_name} successfully reset to commit {target_commit.hash}"
+            )
+
+            # Override LVC:
+            if should_override_lvc:
+                auth_repo.set_last_validated_of_repo(repo_name, auth_commit, True)
+                taf_logger.info(
+                    f"Last validated commit successfully overridden to value {auth_commit.hash} for repository {repo_name}"
+                )
+
+        return True
+    except Exception as e:
+        raise ResetFailedError(
+            f"Reset of repository {auth_repo.name or ''} failed due to error: {e}"
+        )
 
 
 def _should_override_lvc(

--- a/taf/api/repository.py
+++ b/taf/api/repository.py
@@ -222,16 +222,6 @@ def reset_repository(
         )
         return False
 
-    # Fail early if commit is not on the branch:
-    current_branch = auth_repo.get_current_branch()
-    if not auth_repo.is_commit_an_ancestor_of_a_commit_or_branch(
-        auth_commit, current_branch
-    ):
-        taf_logger.error(
-            f"Auth repo commit {auth_commit.hash} not found on current branch ({current_branch})."
-        )
-        return False
-
     # Fail early if there are uncommited changes or unstaged files:
     if not bare and not force:
         if auth_repo.something_to_commit():
@@ -239,6 +229,22 @@ def reset_repository(
                 f"There are uncommited changes in {auth_repo.name}. Please commit/stash changes or run reset with force flag."
             )
             return False
+    
+    # Fail early if repo is in detached head state:
+    if auth_repo.is_detached_head:
+        if not force:
+            taf_logger.error(
+                f"{auth_repo.name} is in detached head state. Fix the state manually or run reset with force flag."
+            )
+            return False
+
+    # Fail early if commit is not on the branch:
+    current_branch = auth_repo.get_current_branch()
+    if auth_commit not in  auth_repo.all_commits_on_branch(current_branch):
+        taf_logger.error(
+            f"Auth repo commit {auth_commit.hash} not found on current branch ({current_branch})."
+        )
+        return False
 
     # Handle target repos:
     # Load corresponding target repos and their commits

--- a/taf/api/repository.py
+++ b/taf/api/repository.py
@@ -1,7 +1,7 @@
 import json
 from logging import ERROR, INFO
 import shutil
-from typing import Optional
+from typing import Optional, Dict
 import click
 from logdecorator import log_on_end, log_on_error, log_on_start
 from taf.git import GitRepository
@@ -222,53 +222,11 @@ def reset_repository(
                 "An error occured during auth repo commit check - make sure you either have a valid last validated commit or specify a commitish via --commit flag."
             )
 
-        # Fail early if there are uncommited changes or unstaged files:
-        if not bare and not force:
-            if auth_repo.something_to_commit():
-                raise ResetFailedError(
-                    f"There are uncommited changes in {auth_repo.name}. Please commit/stash changes or run reset with force flag."
-                )
-
-        # Fail early if repo is in detached head state:
-        if auth_repo.is_detached_head:
-            if not force:
-                raise ResetFailedError(
-                    f"{auth_repo.name} is in detached head state. Fix the state manually or run reset with force flag."
-                )
-
-        # Handle target repos:
         # Load corresponding target repos and their commits
         repositoriesdb.load_repositories(auth_repo)
         target_repos = repositoriesdb.get_deduplicated_repositories(auth_repo)
 
-        # Perform checks for each target repo:
-        for repo_name, repo in target_repos.items():
-            target = auth_repo.get_target(repo_name, auth_commit)
-            # Fail early if target repo can't be loaded:
-            if target is None:
-                raise ResetFailedError(
-                    f"Error, target {repo_name} could not be loaded!"
-                )
-
-            if not bare and not force:
-                # Fail early if there are uncommited changes or unstaged files
-                if repo.something_to_commit():
-                    raise ResetFailedError(
-                        f"There are uncommited changes in {repo.name}. Please commit/stash changes or run reset with force flag."
-                    )
-
-        # If repo is in detached head and force flag is set, reset it to the specified commit
-        # This check is put at the last place since it modifies the state of the repository and there might be
-        # target repo changes that would lead to early failure and therefore exit before these changes
-        if auth_repo.is_detached_head:
-            auth_repo.reset_to_commit(auth_commit, hard=True)
-        # Fail early if commit is not on the branch:
-        current_branch = auth_repo.get_current_branch()
-        if auth_commit not in auth_repo.all_commits_on_branch(current_branch):
-            taf_logger.error()
-            raise ResetFailedError(
-                f"Auth repo commit {auth_commit.hash} not found on current branch ({current_branch})."
-            )
+        _perform_checks(auth_repo, auth_commit, bare, force, target_repos)
 
         # All checks passed, reset repositories:
         if force and not bare:
@@ -331,12 +289,65 @@ def reset_repository(
         )
 
 
+def _perform_checks(
+    auth_repo: AuthenticationRepository,
+    auth_commit: Commitish,
+    bare: bool,
+    force: bool,
+    target_repos: Dict[str, GitRepository],
+):
+    """
+    Perform auth and target repos checks so we can exit early if repos are in an inconsistent state.
+    """
+    # Fail early if there are uncommited changes or unstaged files:
+    if not bare and not force:
+        if auth_repo.something_to_commit():
+            raise ResetFailedError(
+                f"There are uncommited changes in {auth_repo.name}. Please commit/stash changes or run reset with force flag."
+            )
+
+    # Fail early if repo is in detached head state:
+    if auth_repo.is_detached_head:
+        if not force:
+            raise ResetFailedError(
+                f"{auth_repo.name} is in detached head state. Fix the state manually or run reset with force flag."
+            )
+
+    # Handle target repos:
+    # Perform checks for each target repo:
+    for repo_name, repo in target_repos.items():
+        target = auth_repo.get_target(repo_name, auth_commit)
+        # Fail early if target repo can't be loaded:
+        if target is None:
+            raise ResetFailedError(f"Error, target {repo_name} could not be loaded!")
+
+        if not bare and not force:
+            # Fail early if there are uncommited changes or unstaged files
+            if repo.something_to_commit():
+                raise ResetFailedError(
+                    f"There are uncommited changes in {repo.name}. Please commit/stash changes or run reset with force flag."
+                )
+
+    # If repo is in detached head and force flag is set, reset it to the specified commit
+    # This check is put at the last place since it modifies the state of the repository and there might be
+    # target repo changes that would lead to early failure and therefore exit before these changes
+    if auth_repo.is_detached_head:
+        auth_repo.reset_to_commit(auth_commit, hard=True)
+    # Fail early if commit is not on the branch:
+    current_branch = auth_repo.get_current_branch()
+    if auth_commit not in auth_repo.all_commits_on_branch(current_branch):
+        taf_logger.error()
+        raise ResetFailedError(
+            f"Auth repo commit {auth_commit.hash} not found on current branch ({current_branch})."
+        )
+
+
 def _should_override_lvc(
     lvc_flag: bool,
     auth_repo: AuthenticationRepository,
     auth_commit: Commitish,
     lvc: str,
-):
+) -> bool:
     if lvc_flag:
         if not auth_repo.is_commit_an_ancestor_of_a_commit_or_branch(auth_commit, lvc):
             print(

--- a/taf/api/repository.py
+++ b/taf/api/repository.py
@@ -195,7 +195,7 @@ def taf_status(path: str, library_dir: Optional[str] = None, indent: int = 0) ->
 
 
 def reset_repository(
-    auth_repo: AuthenticationRepository, commit: str, lvc: bool, force: bool
+    auth_repo: AuthenticationRepository, commit: str, override_lvc: bool, force: bool
 ) -> bool:
     """
     Resets auth and target repos to a snapshot in the past.
@@ -276,7 +276,7 @@ def reset_repository(
     taf_logger.info(f"{auth_repo.name} successfully reset to commit {auth_commit.hash}")
 
     should_override_lvc = _should_override_lvc(
-        lvc, auth_repo, auth_commit, last_validated_commit.hash
+        override_lvc, auth_repo, auth_commit, last_validated_commit.hash
     )
 
     # Override LVC:

--- a/taf/exceptions.py
+++ b/taf/exceptions.py
@@ -242,5 +242,9 @@ class ValidationFailedError(TAFError):
     pass
 
 
+class ResetFailedError(TAFError):
+    pass
+
+
 class YubikeyError(TAFError):
     pass

--- a/taf/git.py
+++ b/taf/git.py
@@ -1706,7 +1706,8 @@ class GitRepository:
         self._git(f"update-ref refs/remotes/origin/{branch_name} {commit}")
 
     def reset_to_head(self) -> None:
-        self._git("reset --hard HEAD")
+        mode = "--soft" if self.is_bare_repository else "--hard"
+        self._git(f"reset {mode} HEAD")
 
     def safely_get_json(self, commit: Commitish, path: str) -> Optional[Dict]:
         try:

--- a/taf/git.py
+++ b/taf/git.py
@@ -1663,7 +1663,7 @@ class GitRepository:
             self.update_branch_refs(branch, commit)
 
         if hard:
-            self._git(f"reset {flag} HEAD")
+            self._git(f"reset {flag} {commit.hash}")
 
     def restore(self, file_paths: List[str]) -> None:
         if not file_paths:

--- a/taf/git.py
+++ b/taf/git.py
@@ -992,11 +992,13 @@ class GitRepository:
         Check if a specified commit is an ancestor of another commit or branch.
         """
         try:
-            output = self._git(f"merge-base --is-ancestor {commit.hash} {commit_hash_or_branch_name}")
+            output = self._git(
+                f"merge-base --is-ancestor {commit.hash} {commit_hash_or_branch_name}"
+            )
             return True if output == "" else False
-        except:
+        except Exception as e:
             print(
-                f"An error occured during ancestor check for commit {commit.hash} and branch/commit {commit_hash_or_branch_name}."
+                f"An error occured during ancestor check for commit {commit.hash} and branch/commit {commit_hash_or_branch_name}. Error message: {e}"
             )
             return False
 
@@ -1166,7 +1168,7 @@ class GitRepository:
         except Exception:
             return None
 
-    def resolve_commit(self, commitish: str) -> Commitish:
+    def resolve_commit(self, commitish: str) -> Optional[Commitish]:
         """
         Resolves commitish string to a Commitish object with proper hash.
         """

--- a/taf/git.py
+++ b/taf/git.py
@@ -985,6 +985,21 @@ class GitRepository:
         except KeyError:
             return False
 
+    def is_commit_an_ancestor_of_a_commit_or_branch(
+        self, commit: Commitish, commit_hash_or_branch_name: str
+    ) -> bool:
+        """
+        Check if a specified commit is an ancestor of another commit or branch.
+        """
+        try:
+            output = self._git(f"merge-base --is-ancestor {commit.hash} {commit_hash_or_branch_name}")
+            return True if output == "" else False
+        except:
+            print(
+                f"An error occured during ancestor check for commit {commit.hash} and branch/commit {commit_hash_or_branch_name}."
+            )
+            return False
+
     def commits_on_branch_and_not_other(
         self, branch1: str, branch2: str
     ) -> List[Commitish]:
@@ -1148,6 +1163,17 @@ class GitRepository:
 
         try:
             return Commitish.from_hash(repo.revparse_single("HEAD").id.hex)
+        except Exception:
+            return None
+
+    def resolve_commit(self, commitish: str) -> Commitish:
+        """
+        Resolves commitish string to a Commitish object with proper hash.
+        """
+        try:
+            return Commitish.from_hash(
+                self.pygit_repo.revparse_single(commitish).id.hex
+            )
         except Exception:
             return None
 

--- a/taf/git.py
+++ b/taf/git.py
@@ -1168,10 +1168,12 @@ class GitRepository:
         except Exception:
             return None
 
-    def resolve_commit(self, commitish: str) -> Optional[Commitish]:
+    def resolve_commit(self, commitish: str | Commitish) -> Optional[Commitish]:
         """
         Resolves commitish string to a Commitish object with proper hash.
         """
+        if isinstance(commitish, Commitish):
+            return commitish
         try:
             return Commitish.from_hash(
                 self.pygit_repo.revparse_single(commitish).id.hex

--- a/taf/tests/test_updater/conftest.py
+++ b/taf/tests/test_updater/conftest.py
@@ -226,16 +226,18 @@ def origin_auth_repo(
     is_test_repo = request.param.get("is_test_repo", False)
     date = request.param.get("data")
     setup_type = request.param.get("setup_type", SetupState.ALL_FILES_INITIALLY)
+    # When parametrizing tests, there are unsupported symbols added "[" and "]"
+    clean_test_name = test_name.replace("[", "_").replace("]", "")
     targets_config = [
         RepositoryConfig(
-            f"{test_name}/{targets_config['name']}",
+            f"{clean_test_name}/{targets_config['name']}",
             targets_config.get("allow_unauthenticated_commits", False),
             targets_config.get("is_empty", False),
             targets_config.get("custom"),
         )
         for targets_config in targets_config_list
     ]
-    repo_name = f"{test_name}/auth"
+    repo_name = f"{clean_test_name}/auth"
 
     if date is not None:
         with freeze_time(date):

--- a/taf/tests/test_updater/conftest.py
+++ b/taf/tests/test_updater/conftest.py
@@ -80,6 +80,9 @@ TARGET_COMMIT_MISMATCH_PATTERN = (
     r"([0-9a-f]{40}) committed on (\d{4}-\d{2}-\d{2}): data repository (\w+\/\w+) was "
     r"supposed to be at commit ([0-9a-f]{40}) but (repo was at|commit not on branch) (\w+)"
 )
+INVALID_AUTH_COMMIT_RESET_ERROR = "An error occured during auth repo commit check - make sure you either have a valid last validated commit or specify a commitish via --commit flag."
+UNCOMMITTED_CHANGES_RESET_PATTERN = r"There are uncommited changes in ([A-Za-z0-9_\-\[\]]+/[A-Za-z0-9_\-\[\]]+)\. Please commit/stash changes or run reset with force flag."
+DETACHED_HEAD_RESET_PATTERN = r"(\w+\/\w+) is in detached head state. Fix the state manually or run reset with force flag."
 
 
 # Disable console logging for all tests

--- a/taf/tests/test_updater/test_reset/test_reset_repository.py
+++ b/taf/tests/test_updater/test_reset/test_reset_repository.py
@@ -18,7 +18,10 @@ from taf.updater.types.update import OperationType
 from taf.models.types import Commitish
 from pathlib import Path
 
-def prepare_repo_for_reset(origin_auth_repo: AuthenticationRepository, client_dir: Path) -> AuthenticationRepository:
+
+def prepare_repo_for_reset(
+    origin_auth_repo: AuthenticationRepository, client_dir: Path
+) -> AuthenticationRepository:
     clone_repositories(
         origin_auth_repo,
         client_dir,
@@ -38,7 +41,7 @@ def prepare_repo_for_reset(origin_auth_repo: AuthenticationRepository, client_di
     )
 
     assert not len(update_output["auth_repos"][client_auth_repo.name]["warnings"])
-    
+
     return client_auth_repo
 
 
@@ -59,13 +62,15 @@ def test_reset_repo_happy_path(origin_auth_repo, client_dir, lvc):
     all_target_repositories = load_target_repositories(client_auth_repo, client_dir)
     if lvc:
         assert client_auth_repo.last_validated_commit != commit_to_reset_to.hash
-    
+
     target_commits = {}
     for target_name in all_target_repositories:
-        target_commits[target_name] = Commitish.from_hash(client_auth_repo.get_target(target_name, commit_to_reset_to)['commit'])
-    
+        target_commits[target_name] = Commitish.from_hash(
+            client_auth_repo.get_target(target_name, commit_to_reset_to)["commit"]
+        )
+
     result = reset_repository(client_auth_repo, commit_to_reset_to.hash, False, lvc)
-    
+
     assert result is True
     assert client_auth_repo.head_commit() == commit_to_reset_to
     for target_name, target_repo in all_target_repositories.items():
@@ -73,7 +78,7 @@ def test_reset_repo_happy_path(origin_auth_repo, client_dir, lvc):
     if lvc:
         assert client_auth_repo.last_validated_commit == commit_to_reset_to.hash
 
-    
+
 @pytest.mark.parametrize(
     "origin_auth_repo",
     [
@@ -83,7 +88,9 @@ def test_reset_repo_happy_path(origin_auth_repo, client_dir, lvc):
     ],
     indirect=True,
 )
-def test_reset_repo_commit_flag_missing_lvc_is_none_expect_fail(origin_auth_repo, client_dir):
+def test_reset_repo_commit_flag_missing_lvc_is_none_expect_fail(
+    origin_auth_repo, client_dir
+):
     client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir)
     client_setup_manager = SetupManager(client_auth_repo)
     client_setup_manager.add_task(remove_last_validated_commit)
@@ -102,10 +109,14 @@ def test_reset_repo_commit_flag_missing_lvc_is_none_expect_fail(origin_auth_repo
     indirect=True,
 )
 @pytest.mark.parametrize("commit", [None, "not_None"])
-def test_reset_repo_auth_repo_has_untracked_file_expect_fail(origin_auth_repo, client_dir, commit):
+def test_reset_repo_auth_repo_has_untracked_file_expect_fail(
+    origin_auth_repo, client_dir, commit
+):
     # TODO: check exception handling and catch specific printouts
     client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir)
-    commit_to_reset_to = client_auth_repo.all_commits_on_branch()[-2] if commit is not None else None
+    commit_to_reset_to = (
+        client_auth_repo.all_commits_on_branch()[-2] if commit is not None else None
+    )
     add_file_to_repository(client_auth_repo, "test")
     result = reset_repository(client_auth_repo, commit_to_reset_to, False, False)
     assert result is False
@@ -121,9 +132,13 @@ def test_reset_repo_auth_repo_has_untracked_file_expect_fail(origin_auth_repo, c
     indirect=True,
 )
 @pytest.mark.parametrize("commit", [None, "not_None"])
-def test_reset_repo_auth_repo_has_uncommitted_changes_expect_fail(origin_auth_repo, client_dir, commit):
+def test_reset_repo_auth_repo_has_uncommitted_changes_expect_fail(
+    origin_auth_repo, client_dir, commit
+):
     client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir)
-    commit_to_reset_to = client_auth_repo.all_commits_on_branch()[-2] if commit is not None else None
+    commit_to_reset_to = (
+        client_auth_repo.all_commits_on_branch()[-2] if commit is not None else None
+    )
     setup_manager = SetupManager(client_auth_repo)
     setup_manager.add_task(update_auth_repo_without_committing)
     setup_manager.execute_tasks()
@@ -141,15 +156,19 @@ def test_reset_repo_auth_repo_has_uncommitted_changes_expect_fail(origin_auth_re
     indirect=True,
 )
 @pytest.mark.parametrize("commit", [None, "not_None"])
-def test_reset_repo_target_repo_has_untracked_file_expect_fail(origin_auth_repo, client_dir, commit):
+def test_reset_repo_target_repo_has_untracked_file_expect_fail(
+    origin_auth_repo, client_dir, commit
+):
     client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir)
-    commit_to_reset_to = client_auth_repo.all_commits_on_branch()[-2] if commit is not None else None
+    commit_to_reset_to = (
+        client_auth_repo.all_commits_on_branch()[-2] if commit is not None else None
+    )
     all_target_repositories = load_target_repositories(client_auth_repo, client_dir)
     target_repo = next(iter(all_target_repositories.values()))
     add_file_to_repository(target_repo, "test")
     result = reset_repository(client_auth_repo, commit_to_reset_to, False, False)
     assert result is False
-    
+
 
 @pytest.mark.parametrize(
     "origin_auth_repo",
@@ -161,11 +180,17 @@ def test_reset_repo_target_repo_has_untracked_file_expect_fail(origin_auth_repo,
     indirect=True,
 )
 @pytest.mark.parametrize("commit", [None, "not_None"])
-def test_reset_repo_target_repo_has_uncommitted_changes_expect_fail(origin_auth_repo, client_dir, commit):
+def test_reset_repo_target_repo_has_uncommitted_changes_expect_fail(
+    origin_auth_repo, client_dir, commit
+):
     client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir)
-    commit_to_reset_to = client_auth_repo.all_commits_on_branch()[-2] if commit is not None else None
+    commit_to_reset_to = (
+        client_auth_repo.all_commits_on_branch()[-2] if commit is not None else None
+    )
     setup_manager = SetupManager(client_auth_repo)
-    setup_manager.add_task(update_target_repo_without_committing, kwargs={"target_name": "target1"})
+    setup_manager.add_task(
+        update_target_repo_without_committing, kwargs={"target_name": "target1"}
+    )
     setup_manager.execute_tasks()
     result = reset_repository(client_auth_repo, commit_to_reset_to, False, False)
     assert result is False

--- a/taf/tests/test_updater/test_reset/test_reset_repository.py
+++ b/taf/tests/test_updater/test_reset/test_reset_repository.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 
 def prepare_repo_for_reset(
-    origin_auth_repo: AuthenticationRepository, client_dir: Path
+    origin_auth_repo: AuthenticationRepository, client_dir: Path, bare=False
 ) -> AuthenticationRepository:
     clone_repositories(
         origin_auth_repo,
@@ -38,6 +38,7 @@ def prepare_repo_for_reset(
         origin_auth_repo,
         client_dir,
         force=True,
+        bare=bare,
     )
 
     assert not len(update_output["auth_repos"][client_auth_repo.name]["warnings"])
@@ -55,9 +56,10 @@ def prepare_repo_for_reset(
     indirect=True,
 )
 @pytest.mark.parametrize("lvc", [True, False])
-def test_reset_repo_happy_path(origin_auth_repo, client_dir, lvc):
+@pytest.mark.parametrize("bare", [True, False])
+def test_reset_repo_happy_path(origin_auth_repo, client_dir, lvc, bare):
     # Set up a scenario where repositories
-    client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir)
+    client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir, bare)
     commit_to_reset_to = client_auth_repo.all_commits_on_branch()[-2]
     all_target_repositories = load_target_repositories(client_auth_repo, client_dir)
     if lvc:
@@ -69,7 +71,7 @@ def test_reset_repo_happy_path(origin_auth_repo, client_dir, lvc):
             client_auth_repo.get_target(target_name, commit_to_reset_to)["commit"]
         )
 
-    result = reset_repository(client_auth_repo, commit_to_reset_to.hash, False, lvc)
+    result = reset_repository(client_auth_repo, commit_to_reset_to.hash, lvc, False)
 
     assert result is True
     assert client_auth_repo.head_commit() == commit_to_reset_to

--- a/taf/tests/test_updater/test_reset/test_reset_repository.py
+++ b/taf/tests/test_updater/test_reset/test_reset_repository.py
@@ -97,8 +97,10 @@ def test_reset_repo_commit_flag_missing_lvc_is_none_expect_fail(
     client_setup_manager = SetupManager(client_auth_repo)
     client_setup_manager.add_task(remove_last_validated_commit)
     client_setup_manager.execute_tasks()
+    commit_before_reset = client_auth_repo.head_commit()
     result = reset_repository(client_auth_repo, None, False, False)
     assert result is False
+    assert commit_before_reset == client_auth_repo.head_commit()
 
 
 @pytest.mark.parametrize(
@@ -120,8 +122,10 @@ def test_reset_repo_auth_repo_has_untracked_file_expect_fail(
         client_auth_repo.all_commits_on_branch()[-2] if commit is not None else None
     )
     add_file_to_repository(client_auth_repo, "test")
+    commit_before_reset = client_auth_repo.head_commit()
     result = reset_repository(client_auth_repo, commit_to_reset_to, False, False)
     assert result is False
+    assert commit_before_reset == client_auth_repo.head_commit()
 
 
 @pytest.mark.parametrize(
@@ -144,8 +148,10 @@ def test_reset_repo_auth_repo_has_uncommitted_changes_expect_fail(
     setup_manager = SetupManager(client_auth_repo)
     setup_manager.add_task(update_auth_repo_without_committing)
     setup_manager.execute_tasks()
+    commit_before_reset = client_auth_repo.head_commit()
     result = reset_repository(client_auth_repo, commit_to_reset_to, False, False)
     assert result is False
+    assert commit_before_reset == client_auth_repo.head_commit()
 
 
 @pytest.mark.parametrize(
@@ -168,8 +174,10 @@ def test_reset_repo_target_repo_has_untracked_file_expect_fail(
     all_target_repositories = load_target_repositories(client_auth_repo, client_dir)
     target_repo = next(iter(all_target_repositories.values()))
     add_file_to_repository(target_repo, "test")
+    commit_before_reset = client_auth_repo.head_commit()
     result = reset_repository(client_auth_repo, commit_to_reset_to, False, False)
     assert result is False
+    assert commit_before_reset == client_auth_repo.head_commit()
 
 
 @pytest.mark.parametrize(
@@ -194,5 +202,7 @@ def test_reset_repo_target_repo_has_uncommitted_changes_expect_fail(
         update_target_repo_without_committing, kwargs={"target_name": "target1"}
     )
     setup_manager.execute_tasks()
+    commit_before_reset = client_auth_repo.head_commit()
     result = reset_repository(client_auth_repo, commit_to_reset_to, False, False)
     assert result is False
+    assert commit_before_reset == client_auth_repo.head_commit()

--- a/taf/tests/test_updater/test_reset/test_reset_repository.py
+++ b/taf/tests/test_updater/test_reset/test_reset_repository.py
@@ -1,0 +1,171 @@
+from taf.api.repository import reset_repository
+import pytest
+from taf.auth_repo import AuthenticationRepository
+from taf.tests.test_updater.conftest import (
+    SetupManager,
+    add_valid_target_commits,
+    add_file_to_repository,
+    update_auth_repo_without_committing,
+    update_target_repo_without_committing,
+    remove_last_validated_commit,
+)
+from taf.tests.test_updater.update_utils import (
+    clone_repositories,
+    update_and_check_commit_shas,
+    load_target_repositories,
+)
+from taf.updater.types.update import OperationType
+from taf.models.types import Commitish
+from pathlib import Path
+
+def prepare_repo_for_reset(origin_auth_repo: AuthenticationRepository, client_dir: Path) -> AuthenticationRepository:
+    clone_repositories(
+        origin_auth_repo,
+        client_dir,
+    )
+    client_auth_repo_path = client_dir / origin_auth_repo.name
+    client_auth_repo = AuthenticationRepository(path=client_auth_repo_path)
+
+    setup_manager = SetupManager(origin_auth_repo)
+    setup_manager.add_task(add_valid_target_commits)
+    setup_manager.execute_tasks()
+
+    update_output = update_and_check_commit_shas(
+        OperationType.UPDATE,
+        origin_auth_repo,
+        client_dir,
+        force=True,
+    )
+
+    assert not len(update_output["auth_repos"][client_auth_repo.name]["warnings"])
+    
+    return client_auth_repo
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [{"name": "target1"}, {"name": "target2"}],
+        },
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("lvc", [True, False])
+def test_reset_repo_happy_path(origin_auth_repo, client_dir, lvc):
+    # Set up a scenario where repositories
+    client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir)
+    commit_to_reset_to = client_auth_repo.all_commits_on_branch()[-2]
+    all_target_repositories = load_target_repositories(client_auth_repo, client_dir)
+    if lvc:
+        assert client_auth_repo.last_validated_commit != commit_to_reset_to.hash
+    
+    target_commits = {}
+    for target_name in all_target_repositories:
+        target_commits[target_name] = Commitish.from_hash(client_auth_repo.get_target(target_name, commit_to_reset_to)['commit'])
+    
+    result = reset_repository(client_auth_repo, commit_to_reset_to.hash, False, lvc)
+    
+    assert result is True
+    assert client_auth_repo.head_commit() == commit_to_reset_to
+    for target_name, target_repo in all_target_repositories.items():
+        assert target_repo.head_commit() == target_commits[target_name]
+    if lvc:
+        assert client_auth_repo.last_validated_commit == commit_to_reset_to.hash
+
+    
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [{"name": "target1"}, {"name": "target2"}],
+        },
+    ],
+    indirect=True,
+)
+def test_reset_repo_commit_flag_missing_lvc_is_none_expect_fail(origin_auth_repo, client_dir):
+    client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir)
+    client_setup_manager = SetupManager(client_auth_repo)
+    client_setup_manager.add_task(remove_last_validated_commit)
+    client_setup_manager.execute_tasks()
+    result = reset_repository(client_auth_repo, None, False, False)
+    assert result is False
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [{"name": "target1"}, {"name": "target2"}],
+        },
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("commit", [None, "not_None"])
+def test_reset_repo_auth_repo_has_untracked_file_expect_fail(origin_auth_repo, client_dir, commit):
+    # TODO: check exception handling and catch specific printouts
+    client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir)
+    commit_to_reset_to = client_auth_repo.all_commits_on_branch()[-2] if commit is not None else None
+    add_file_to_repository(client_auth_repo, "test")
+    result = reset_repository(client_auth_repo, commit_to_reset_to, False, False)
+    assert result is False
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [{"name": "target1"}, {"name": "target2"}],
+        },
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("commit", [None, "not_None"])
+def test_reset_repo_auth_repo_has_uncommitted_changes_expect_fail(origin_auth_repo, client_dir, commit):
+    client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir)
+    commit_to_reset_to = client_auth_repo.all_commits_on_branch()[-2] if commit is not None else None
+    setup_manager = SetupManager(client_auth_repo)
+    setup_manager.add_task(update_auth_repo_without_committing)
+    setup_manager.execute_tasks()
+    result = reset_repository(client_auth_repo, commit_to_reset_to, False, False)
+    assert result is False
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [{"name": "target1"}, {"name": "target2"}],
+        },
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("commit", [None, "not_None"])
+def test_reset_repo_target_repo_has_untracked_file_expect_fail(origin_auth_repo, client_dir, commit):
+    client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir)
+    commit_to_reset_to = client_auth_repo.all_commits_on_branch()[-2] if commit is not None else None
+    all_target_repositories = load_target_repositories(client_auth_repo, client_dir)
+    target_repo = next(iter(all_target_repositories.values()))
+    add_file_to_repository(target_repo, "test")
+    result = reset_repository(client_auth_repo, commit_to_reset_to, False, False)
+    assert result is False
+    
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [{"name": "target1"}, {"name": "target2"}],
+        },
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("commit", [None, "not_None"])
+def test_reset_repo_target_repo_has_uncommitted_changes_expect_fail(origin_auth_repo, client_dir, commit):
+    client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir)
+    commit_to_reset_to = client_auth_repo.all_commits_on_branch()[-2] if commit is not None else None
+    setup_manager = SetupManager(client_auth_repo)
+    setup_manager.add_task(update_target_repo_without_committing, kwargs={"target_name": "target1"})
+    setup_manager.execute_tasks()
+    result = reset_repository(client_auth_repo, commit_to_reset_to, False, False)
+    assert result is False

--- a/taf/tests/test_updater/test_reset/test_reset_repository.py
+++ b/taf/tests/test_updater/test_reset/test_reset_repository.py
@@ -1,6 +1,7 @@
 from taf.api.repository import reset_repository
 import pytest
 from taf.auth_repo import AuthenticationRepository
+from taf.git import GitRepository
 from taf.tests.test_updater.conftest import (
     SetupManager,
     add_valid_target_commits,
@@ -8,6 +9,9 @@ from taf.tests.test_updater.conftest import (
     update_auth_repo_without_committing,
     update_target_repo_without_committing,
     remove_last_validated_commit,
+    INVALID_AUTH_COMMIT_RESET_ERROR,
+    UNCOMMITTED_CHANGES_RESET_PATTERN,
+    DETACHED_HEAD_RESET_PATTERN,
 )
 from taf.tests.test_updater.update_utils import (
     clone_repositories,
@@ -17,6 +21,8 @@ from taf.tests.test_updater.update_utils import (
 from taf.updater.types.update import OperationType
 from taf.models.types import Commitish
 from pathlib import Path
+from taf.exceptions import ResetFailedError
+from typing import Dict, Optional
 
 
 def prepare_repo_for_reset(
@@ -46,6 +52,22 @@ def prepare_repo_for_reset(
     return client_auth_repo
 
 
+def assert_reset_successful(
+    result,
+    client_auth_repo: AuthenticationRepository,
+    commit_to_reset_to: Commitish,
+    target_repos: Dict[str, GitRepository],
+    target_commits: Dict,
+    lvc: Optional[bool] = False,
+):
+    assert result is True
+    assert client_auth_repo.head_commit() == commit_to_reset_to
+    for target_name, target_repo in target_repos.items():
+        assert target_repo.head_commit() == target_commits[target_name]
+    if lvc:
+        assert client_auth_repo.last_validated_commit == commit_to_reset_to.hash
+
+
 @pytest.mark.parametrize(
     "origin_auth_repo",
     [
@@ -58,7 +80,6 @@ def prepare_repo_for_reset(
 @pytest.mark.parametrize("lvc", [True, False])
 @pytest.mark.parametrize("bare", [True, False])
 def test_reset_repo_happy_path(origin_auth_repo, client_dir, lvc, bare):
-    # Set up a scenario where repositories
     client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir, bare)
     commit_to_reset_to = client_auth_repo.all_commits_on_branch()[-2]
     all_target_repositories = load_target_repositories(client_auth_repo, client_dir)
@@ -72,13 +93,14 @@ def test_reset_repo_happy_path(origin_auth_repo, client_dir, lvc, bare):
         )
 
     result = reset_repository(client_auth_repo, commit_to_reset_to.hash, lvc, False)
-
-    assert result is True
-    assert client_auth_repo.head_commit() == commit_to_reset_to
-    for target_name, target_repo in all_target_repositories.items():
-        assert target_repo.head_commit() == target_commits[target_name]
-    if lvc:
-        assert client_auth_repo.last_validated_commit == commit_to_reset_to.hash
+    assert_reset_successful(
+        result,
+        client_auth_repo,
+        commit_to_reset_to,
+        all_target_repositories,
+        target_commits,
+        lvc,
+    )
 
 
 @pytest.mark.parametrize(
@@ -98,9 +120,43 @@ def test_reset_repo_commit_flag_missing_lvc_is_none_expect_fail(
     client_setup_manager.add_task(remove_last_validated_commit)
     client_setup_manager.execute_tasks()
     commit_before_reset = client_auth_repo.head_commit()
-    result = reset_repository(client_auth_repo, None, False, False)
-    assert result is False
+    with pytest.raises(ResetFailedError, match=INVALID_AUTH_COMMIT_RESET_ERROR):
+        reset_repository(client_auth_repo, None, False, False)
     assert commit_before_reset == client_auth_repo.head_commit()
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [{"name": "target1"}, {"name": "target2"}],
+        },
+    ],
+    indirect=True,
+)
+def test_force_reset_repo_auth_repo_has_untracked_file_expect_success(
+    origin_auth_repo, client_dir
+):
+    client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir)
+    commit_to_reset_to = client_auth_repo.all_commits_on_branch()[-2]
+    add_file_to_repository(client_auth_repo, "test")
+    assert client_auth_repo.something_to_commit()
+
+    all_target_repositories = load_target_repositories(client_auth_repo, client_dir)
+    target_commits = {}
+    for target_name in all_target_repositories:
+        target_commits[target_name] = Commitish.from_hash(
+            client_auth_repo.get_target(target_name, commit_to_reset_to)["commit"]
+        )
+
+    result = reset_repository(client_auth_repo, commit_to_reset_to, False, True)
+    assert_reset_successful(
+        result,
+        client_auth_repo,
+        commit_to_reset_to,
+        all_target_repositories,
+        target_commits,
+    )
 
 
 @pytest.mark.parametrize(
@@ -116,16 +172,59 @@ def test_reset_repo_commit_flag_missing_lvc_is_none_expect_fail(
 def test_reset_repo_auth_repo_has_untracked_file_expect_fail(
     origin_auth_repo, client_dir, commit
 ):
-    # TODO: check exception handling and catch specific printouts
     client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir)
     commit_to_reset_to = (
         client_auth_repo.all_commits_on_branch()[-2] if commit is not None else None
     )
     add_file_to_repository(client_auth_repo, "test")
+
     commit_before_reset = client_auth_repo.head_commit()
-    result = reset_repository(client_auth_repo, commit_to_reset_to, False, False)
-    assert result is False
+    all_target_repositories = load_target_repositories(client_auth_repo, client_dir)
+    target_commits = {}
+    for target_name in all_target_repositories:
+        target_commits[target_name] = Commitish.from_hash(
+            client_auth_repo.get_target(target_name, commit_to_reset_to)["commit"]
+        )
+
+    with pytest.raises(ResetFailedError, match=UNCOMMITTED_CHANGES_RESET_PATTERN):
+        reset_repository(client_auth_repo, commit_to_reset_to, False, False)
     assert commit_before_reset == client_auth_repo.head_commit()
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [{"name": "target1"}, {"name": "target2"}],
+        },
+    ],
+    indirect=True,
+)
+def test_force_reset_repo_auth_repo_has_uncommitted_changes_expect_success(
+    origin_auth_repo, client_dir
+):
+    client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir)
+    commit_to_reset_to = client_auth_repo.all_commits_on_branch()[-2]
+    setup_manager = SetupManager(client_auth_repo)
+    setup_manager.add_task(update_auth_repo_without_committing)
+    setup_manager.execute_tasks()
+    assert client_auth_repo.something_to_commit()
+
+    all_target_repositories = load_target_repositories(client_auth_repo, client_dir)
+    target_commits = {}
+    for target_name in all_target_repositories:
+        target_commits[target_name] = Commitish.from_hash(
+            client_auth_repo.get_target(target_name, commit_to_reset_to)["commit"]
+        )
+
+    result = reset_repository(client_auth_repo, commit_to_reset_to, False, True)
+    assert_reset_successful(
+        result,
+        client_auth_repo,
+        commit_to_reset_to,
+        all_target_repositories,
+        target_commits,
+    )
 
 
 @pytest.mark.parametrize(
@@ -149,9 +248,46 @@ def test_reset_repo_auth_repo_has_uncommitted_changes_expect_fail(
     setup_manager.add_task(update_auth_repo_without_committing)
     setup_manager.execute_tasks()
     commit_before_reset = client_auth_repo.head_commit()
-    result = reset_repository(client_auth_repo, commit_to_reset_to, False, False)
-    assert result is False
+    with pytest.raises(ResetFailedError, match=UNCOMMITTED_CHANGES_RESET_PATTERN):
+        reset_repository(client_auth_repo, commit_to_reset_to, False, False)
     assert commit_before_reset == client_auth_repo.head_commit()
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [{"name": "target1"}, {"name": "target2"}],
+        },
+    ],
+    indirect=True,
+)
+def test_force_reset_repo_target_repo_has_untracked_file_expect_success(
+    origin_auth_repo, client_dir
+):
+    client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir)
+    commit_to_reset_to = client_auth_repo.all_commits_on_branch()[-2]
+    all_target_repositories = load_target_repositories(client_auth_repo, client_dir)
+    target_repo = next(iter(all_target_repositories.values()))
+    add_file_to_repository(target_repo, "test")
+
+    all_target_repositories = load_target_repositories(client_auth_repo, client_dir)
+    target_commits = {}
+    for target_name, target_repo in all_target_repositories.items():
+        if "target1" in target_name:
+            assert target_repo.something_to_commit()
+        target_commits[target_name] = Commitish.from_hash(
+            client_auth_repo.get_target(target_name, commit_to_reset_to)["commit"]
+        )
+
+    result = reset_repository(client_auth_repo, commit_to_reset_to, False, True)
+    assert_reset_successful(
+        result,
+        client_auth_repo,
+        commit_to_reset_to,
+        all_target_repositories,
+        target_commits,
+    )
 
 
 @pytest.mark.parametrize(
@@ -175,9 +311,48 @@ def test_reset_repo_target_repo_has_untracked_file_expect_fail(
     target_repo = next(iter(all_target_repositories.values()))
     add_file_to_repository(target_repo, "test")
     commit_before_reset = client_auth_repo.head_commit()
-    result = reset_repository(client_auth_repo, commit_to_reset_to, False, False)
-    assert result is False
+    with pytest.raises(ResetFailedError, match=UNCOMMITTED_CHANGES_RESET_PATTERN):
+        reset_repository(client_auth_repo, commit_to_reset_to, False, False)
     assert commit_before_reset == client_auth_repo.head_commit()
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [{"name": "target1"}, {"name": "target2"}],
+        },
+    ],
+    indirect=True,
+)
+def test_force_reset_repo_target_repo_has_uncommitted_changes_expect_success(
+    origin_auth_repo, client_dir
+):
+    client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir)
+    commit_to_reset_to = client_auth_repo.all_commits_on_branch()[-2]
+    setup_manager = SetupManager(client_auth_repo)
+    setup_manager.add_task(
+        update_target_repo_without_committing, kwargs={"target_name": "target1"}
+    )
+    setup_manager.execute_tasks()
+
+    all_target_repositories = load_target_repositories(client_auth_repo, client_dir)
+    target_commits = {}
+    for target_name, target_repo in all_target_repositories.items():
+        if "target1" in target_name:
+            assert target_repo.something_to_commit()
+        target_commits[target_name] = Commitish.from_hash(
+            client_auth_repo.get_target(target_name, commit_to_reset_to)["commit"]
+        )
+
+    result = reset_repository(client_auth_repo, commit_to_reset_to, False, True)
+    assert_reset_successful(
+        result,
+        client_auth_repo,
+        commit_to_reset_to,
+        all_target_repositories,
+        target_commits,
+    )
 
 
 @pytest.mark.parametrize(
@@ -203,6 +378,59 @@ def test_reset_repo_target_repo_has_uncommitted_changes_expect_fail(
     )
     setup_manager.execute_tasks()
     commit_before_reset = client_auth_repo.head_commit()
-    result = reset_repository(client_auth_repo, commit_to_reset_to, False, False)
-    assert result is False
+    with pytest.raises(ResetFailedError, match=UNCOMMITTED_CHANGES_RESET_PATTERN):
+        reset_repository(client_auth_repo, commit_to_reset_to, False, False)
     assert commit_before_reset == client_auth_repo.head_commit()
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [{"name": "target1"}, {"name": "target2"}],
+        },
+    ],
+    indirect=True,
+)
+def test_force_reset_repo_auth_repo_detached_head_expect_success(
+    origin_auth_repo, client_dir
+):
+    client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir)
+    all_commits = client_auth_repo.all_commits_on_branch()
+    commit_to_reset_to = all_commits[-2]
+    client_auth_repo.checkout_commit(all_commits[-1])
+    assert client_auth_repo.is_detached_head
+
+    all_target_repositories = load_target_repositories(client_auth_repo, client_dir)
+    target_commits = {}
+    for target_name in all_target_repositories:
+        target_commits[target_name] = Commitish.from_hash(
+            client_auth_repo.get_target(target_name, commit_to_reset_to)["commit"]
+        )
+
+    result = reset_repository(client_auth_repo, commit_to_reset_to, False, True)
+    assert_reset_successful(
+        result,
+        client_auth_repo,
+        commit_to_reset_to,
+        all_target_repositories,
+        target_commits,
+    )
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [{"name": "target1"}, {"name": "target2"}],
+        },
+    ],
+    indirect=True,
+)
+def test_reset_repo_auth_repo_detached_head_expect_fail(origin_auth_repo, client_dir):
+    client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir)
+    all_commits = client_auth_repo.all_commits_on_branch()
+    commit_to_reset_to = all_commits[-2]
+    client_auth_repo.checkout_commit(all_commits[-1])
+    with pytest.raises(ResetFailedError, match=DETACHED_HEAD_RESET_PATTERN):
+        reset_repository(client_auth_repo, commit_to_reset_to, False, False)

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -600,7 +600,7 @@ def reset_repo_command():
     )
     @click.option(
         "--commit",
-        default=None, 
+        default=None,
         help="Commitish of auth repo commit to reset to. "
         "Defaults to last validated commit."
     )
@@ -638,8 +638,7 @@ def reset_repo_command():
         if profile:
             start_profiling()
         auth_repo = AuthenticationRepository(path=path)
-        bare = auth_repo.is_bare_repository
-        
+
         try:
             reset_successful = reset_repository(auth_repo, commit, force, lvc)
             if not reset_successful:
@@ -648,8 +647,9 @@ def reset_repo_command():
             click.echo()
             click.echo(f"Error: {e}")
             click.echo()
-        
+
     return reset
+
 
 def latest_commit_and_branch_command():
     @click.command(

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -640,7 +640,7 @@ def reset_repo_command():
         auth_repo = AuthenticationRepository(path=path)
 
         try:
-            reset_successful = reset_repository(auth_repo, commit, force, lvc)
+            reset_successful = reset_repository(auth_repo, commit, lvc, force)
             if not reset_successful:
                 sys.exit(1)
         except Exception as e:

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -601,7 +601,7 @@ def reset_repo_command():
     @click.option(
         "--commit",
         default=None,
-        help="Commitish of auth repo commit to reset to. "
+        help="Auth repo commit to reset to. "
         "Defaults to last validated commit."
     )
     @click.option(


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Implement `taf repo reset` functionality and add tests for it.

Fixes a bug in `reset_to_commit` method.
Closes: #687

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
