### PR TITLE
fix: use taf repo auth path to find taf directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+## [0.37.2]
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Use auth path to detect taf directory ([704])
+
+[704]: https://github.com/openlawlibrary/taf/pull/704
 
 ## [0.37.1]
 
@@ -1694,7 +1705,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 [keepachangelog]: https://keepachangelog.com/en/1.0.0/
 [semver]: https://semver.org/spec/v2.0.0.html
-[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.37.1...HEAD
+[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.37.2...HEAD
+[0.37.1]: https://github.com/openlawlibrary/platform/compare/v0.37.1...v0.37.2
 [0.37.1]: https://github.com/openlawlibrary/platform/compare/v0.37.0...v0.37.1
 [0.37.0]: https://github.com/openlawlibrary/taf/compare/v0.36.3...v0.37.0
 [0.36.3]: https://github.com/openlawlibrary/taf/compare/v0.36.2...v0.36.3

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 PACKAGE_NAME = "taf"
-VERSION = "0.37.1"
+VERSION = "0.37.2"
 AUTHOR = "Open Law Library"
 AUTHOR_EMAIL = "info@openlawlib.org"
 DESCRIPTION = "Implementation of archival authentication"

--- a/taf/yubikey/yubikey.py
+++ b/taf/yubikey/yubikey.py
@@ -470,7 +470,7 @@ def _read_and_check_single_yubikey(
             pin = get_pin_for(key_name, pin_confirm, pin_repeat)
             taf_logger.debug("Attempting to load key pin from environment variables")
 
-        taf_dir = find_taf_directory(Path().cwd())
+        taf_dir = find_taf_directory(taf_repo.path)
         pin = get_pin_from_env(public_key, serial_num, taf_dir)
 
         if pin is None:
@@ -537,7 +537,7 @@ def _read_and_check_yubikeys(
     invalid_keys = []
     all_loaded = True
 
-    taf_dir = find_taf_directory(Path().cwd())
+    taf_dir = find_taf_directory(taf_repo.path)
 
     for index, serial_num in enumerate(serials):
         if not taf_repo.yubikey_store.is_loaded_for_role(serial_num, role):


### PR DESCRIPTION
Relying on Path.cwd() is often unreliable because auth repo more often than not is not in the current working directory

## Description (e.g. "Related to ...", etc.)

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
