### PR TITLE
feat: support writing structured clone/update results to a JSON file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
+-  Support writing structured clone/update results to a JSON file
+
 ### Changed
 
 ### Fixed
+
+[705]: https://github.com/openlawlibrary/taf/pull/705
 
 ## [0.37.2]
 


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

This change adds a `--result-file` option to `clone` and `update` command. While this their output is fine when the command is run directly, it becomes difficult to reliably read and interpret when the command is executed as a subprocess.

Writing the result to a file is a much simpler and more robust approach. It allows the calling process to read the result explicitly after the command completes and handle cleanup as needed, without having to parse tandard output.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
