### PR TITLE
fix: fix traverse to detect taf repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][keepachangelog],
 and this project adheres to [Semantic Versioning][semver].
 
-
 ## [Unreleased]
 
 ### Added
@@ -13,6 +12,18 @@ and this project adheres to [Semantic Versioning][semver].
 ### Changed
 
 ### Fixed
+
+## [0.37.4]
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Fix traverse taf directory ([708])
+
+[708]: https://github.com/openlawlibrary/taf/pull/708
 
 ## [0.37.3]
 
@@ -1717,7 +1728,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 [keepachangelog]: https://keepachangelog.com/en/1.0.0/
 [semver]: https://semver.org/spec/v2.0.0.html
-[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.37.3...HEAD
+[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.37.4...HEAD
+[0.37.4]: https://github.com/openlawlibrary/taf/compare/v0.37.3...v0.37.4
 [0.37.3]: https://github.com/openlawlibrary/taf/compare/v0.37.2...v0.37.3
 [0.37.2]: https://github.com/openlawlibrary/platform/compare/v0.37.1...v0.37.2
 [0.37.1]: https://github.com/openlawlibrary/platform/compare/v0.37.0...v0.37.1

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 PACKAGE_NAME = "taf"
-VERSION = "0.37.3"
+VERSION = "0.37.4"
 AUTHOR = "Open Law Library"
 AUTHOR_EMAIL = "info@openlawlib.org"
 DESCRIPTION = "Implementation of archival authentication"

--- a/taf/api/utils/_conf.py
+++ b/taf/api/utils/_conf.py
@@ -18,20 +18,15 @@ def find_taf_directory(path: Union[Path, str]) -> Optional[Path]:
     """
     # Check the parent directory of the authentication repository
     current_dir = Path(path).absolute()
-    while current_dir != current_dir.root:
+    while True:
         taf_directory = current_dir / ".taf"
         if taf_directory.exists() and taf_directory.is_dir():
             return taf_directory
-        current_dir = current_dir.parent
 
-    # If not found, check the archive root
-    archive_root = Path(path).parent.parent
-    current_dir = archive_root
-    while current_dir != current_dir.root:
-        taf_directory = current_dir / ".taf"
-        if taf_directory.exists() and taf_directory.is_dir():
-            return taf_directory
-        current_dir = current_dir.parent
+        parent = current_dir.parent
+        if parent == current_dir:
+            break
+        current_dir = parent
 
     taf_logger.debug(f"No .taf directory found starting from {Path(path)}")
     return None


### PR DESCRIPTION
Current loop will exit when at root disk volume. Previous loop was stuck when current working directory is not the same as path.

## Description (e.g. "Related to ...", etc.)

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
