### PR TITLE
taf repo reset: handle `excluded_target_globs` and detached head target repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,13 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Reset: Handle excluded_target_globs and detached head target ([711])
 - Fix traverse taf directory ([708])
 - Fix reset to commit bug ([703])
 
 [703]: https://github.com/openlawlibrary/taf/pull/703
 [708]: https://github.com/openlawlibrary/taf/pull/708
+[711]: https://github.com/openlawlibrary/taf/pull/711
 
 ## [0.37.3]
 

--- a/taf/api/repository.py
+++ b/taf/api/repository.py
@@ -1,7 +1,7 @@
 import json
 from logging import ERROR, INFO
 import shutil
-from typing import Optional, Dict
+from typing import Optional, Dict, List
 import click
 from logdecorator import log_on_end, log_on_error, log_on_start
 from taf.git import GitRepository
@@ -195,7 +195,11 @@ def taf_status(path: str, library_dir: Optional[str] = None, indent: int = 0) ->
 
 
 def reset_repository(
-    auth_repo: AuthenticationRepository, commit: str, override_lvc: bool, force: bool
+    auth_repo: AuthenticationRepository,
+    commit: str,
+    override_lvc: bool,
+    force: bool,
+    excluded_target_globs: Optional[List[str]] = None,
 ) -> bool:
     """
     Resets auth and target repos to a snapshot in the past.
@@ -223,8 +227,12 @@ def reset_repository(
             )
 
         # Load corresponding target repos and their commits
-        repositoriesdb.load_repositories(auth_repo)
-        target_repos = repositoriesdb.get_deduplicated_repositories(auth_repo)
+        repositoriesdb.load_repositories(
+            auth_repo, excluded_target_globs=excluded_target_globs
+        )
+        target_repos = repositoriesdb.get_deduplicated_repositories(
+            auth_repo, excluded_target_globs=excluded_target_globs
+        )
 
         _perform_checks(auth_repo, auth_commit, bare, force, target_repos)
 
@@ -328,6 +336,13 @@ def _perform_checks(
                     f"There are uncommited changes in {repo.name}. Please commit/stash changes or run reset with force flag."
                 )
 
+        # Fail early if repo is in detached head state:
+        if repo.is_detached_head:
+            if not force:
+                raise ResetFailedError(
+                    f"{repo.name} is in detached head state. Fix the state manually or run reset with force flag."
+                )
+
     # If repo is in detached head and force flag is set, reset it to the specified commit
     # This check is put at the last place since it modifies the state of the repository and there might be
     # target repo changes that would lead to early failure and therefore exit before these changes
@@ -336,10 +351,15 @@ def _perform_checks(
     # Fail early if commit is not on the branch:
     current_branch = auth_repo.get_current_branch()
     if auth_commit not in auth_repo.all_commits_on_branch(current_branch):
-        taf_logger.error()
-        raise ResetFailedError(
-            f"Auth repo commit {auth_commit.hash} not found on current branch ({current_branch})."
-        )
+        if not force:
+            raise ResetFailedError(
+                f"Auth repo commit {auth_commit.hash} not found on current branch ({current_branch})."
+            )
+        else:
+            try:
+                auth_repo.reset_to_commit(auth_commit, hard=True)
+            except Exception as e:
+                raise ResetFailedError(e)
 
 
 def _should_override_lvc(

--- a/taf/tests/test_updater/test_reset/test_reset_repository.py
+++ b/taf/tests/test_updater/test_reset/test_reset_repository.py
@@ -434,3 +434,66 @@ def test_reset_repo_auth_repo_detached_head_expect_fail(origin_auth_repo, client
     client_auth_repo.checkout_commit(all_commits[-1])
     with pytest.raises(ResetFailedError, match=DETACHED_HEAD_RESET_PATTERN):
         reset_repository(client_auth_repo, commit_to_reset_to, False, False)
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [{"name": "target1"}, {"name": "target2"}],
+        },
+    ],
+    indirect=True,
+)
+def test_force_reset_repo_target_repo_detached_head_expect_success(
+    origin_auth_repo, client_dir
+):
+    client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir)
+    commit_to_reset_to = client_auth_repo.all_commits_on_branch()[-2]
+
+    all_target_repositories = load_target_repositories(client_auth_repo, client_dir)
+    target_commits = {}
+    for target_name, target_repo in all_target_repositories.items():
+        target_commits[target_name] = Commitish.from_hash(
+            client_auth_repo.get_target(target_name, commit_to_reset_to)["commit"]
+        )
+        if "target1" in target_name:
+            all_target_commits = target_repo.all_commits_on_branch()
+            target_repo.checkout_commit(all_target_commits[-1])
+            assert target_repo.is_detached_head
+
+    result = reset_repository(client_auth_repo, commit_to_reset_to, False, True)
+    assert_reset_successful(
+        result,
+        client_auth_repo,
+        commit_to_reset_to,
+        all_target_repositories,
+        target_commits,
+    )
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [{"name": "target1"}, {"name": "target2"}],
+        },
+    ],
+    indirect=True,
+)
+def test_reset_repo_target_repo_detached_head_expect_fail(origin_auth_repo, client_dir):
+    client_auth_repo = prepare_repo_for_reset(origin_auth_repo, client_dir)
+    commit_to_reset_to = client_auth_repo.all_commits_on_branch()[-2]
+
+    all_target_repositories = load_target_repositories(client_auth_repo, client_dir)
+    target_commits = {}
+    for target_name, target_repo in all_target_repositories.items():
+        target_commits[target_name] = Commitish.from_hash(
+            client_auth_repo.get_target(target_name, commit_to_reset_to)["commit"]
+        )
+        if "target1" in target_name:
+            all_target_commits = target_repo.all_commits_on_branch()
+            target_repo.checkout_commit(all_target_commits[-1])
+            assert target_repo.is_detached_head
+    with pytest.raises(ResetFailedError, match=DETACHED_HEAD_RESET_PATTERN):
+        reset_repository(client_auth_repo, commit_to_reset_to, False, False)


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Handle target repos in detached head state.
Add excluded target globs handling.

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- ~[ ] Docstrings have been included and/or updated, as appropriate~
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
