### PR TITLE
fix: explicitly delete TUF Updater after each iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+## [0.37.6]
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Delete TUF Updater after each commit iteration as an attempt to fix file lock errors on Windows  [718]
+
+[718]: https://github.com/openlawlibrary/taf/pull/718
 
 ## [0.37.5]
 
@@ -1750,7 +1761,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 [keepachangelog]: https://keepachangelog.com/en/1.0.0/
 [semver]: https://semver.org/spec/v2.0.0.html
-[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.37.5...HEAD
+[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.37.6...HEAD
+[0.37.6]:https://github.com/openlawlibrary/taf/compare/v0.37.5...v0.37.6
 [0.37.5]: https://github.com/openlawlibrary/taf/compare/v0.37.4...v0.37.5
 [0.37.4]: https://github.com/openlawlibrary/taf/compare/v0.37.3...v0.37.4
 [0.37.3]: https://github.com/openlawlibrary/taf/compare/v0.37.2...v0.37.3

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 PACKAGE_NAME = "taf"
-VERSION = "0.37.5"
+VERSION = "0.37.6"
 AUTHOR = "Open Law Library"
 AUTHOR_EMAIL = "info@openlawlib.org"
 DESCRIPTION = "Implementation of archival authentication"

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -2179,6 +2179,7 @@ def _run_tuf_updater(git_fetcher, auth_repo_name):
             current_commit = _update_tuf_current_revision(
                 git_fetcher, updater, auth_repo_name
             )
+            del updater
             if current_commit is not None:
                 last_validated_commit = current_commit
     except UpdateFailedError as e:


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.) 

On Windows, abandoned objects may not have their file handles released until GC runs. Explicitly deleting the updater after each commit iteration should ensure metadata filess are not locked when the next iteration tries to write to them.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
