### PR TITLE
Updater: change excluded repos handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ and this project adheres to [Semantic Versioning][semver].
 ### Changed
 
 - Use auth repo's last validated commit for reset and partial updates ([713])
+- Change excluded target repos handling ([719])
 
 ### Fixed
 
 [713]: https://github.com/openlawlibrary/taf/pull/713
+[719]: https://github.com/openlawlibrary/taf/pull/719
 
 ## [0.37.6]
 

--- a/taf/api/repository.py
+++ b/taf/api/repository.py
@@ -199,7 +199,6 @@ def reset_repository(
     commit: str,
     override_lvc: bool,
     force: bool,
-    excluded_target_globs: Optional[List[str]] = None,
 ) -> bool:
     """
     Resets auth and target repos to a snapshot in the past.
@@ -230,12 +229,11 @@ def reset_repository(
                 "An error occured during auth repo commit check - make sure you either have a valid last validated commit or specify a commitish via --commit flag."
             )
 
+        exclude_filter = auth_repo.last_validated_data.get("exclude_filter")
         # Load corresponding target repos and their commits
-        repositoriesdb.load_repositories(
-            auth_repo, excluded_target_globs=excluded_target_globs
-        )
+        repositoriesdb.load_repositories(auth_repo, exclude_filter=exclude_filter)
         target_repos = repositoriesdb.get_deduplicated_repositories(
-            auth_repo, excluded_target_globs=excluded_target_globs
+            auth_repo, exclude_filter=exclude_filter
         )
 
         _perform_checks(auth_repo, auth_commit, bare, force, target_repos)

--- a/taf/api/repository.py
+++ b/taf/api/repository.py
@@ -1,7 +1,7 @@
 import json
 from logging import ERROR, INFO
 import shutil
-from typing import Optional, Dict, List
+from typing import Optional, Dict
 import click
 from logdecorator import log_on_end, log_on_error, log_on_start
 from taf.git import GitRepository
@@ -229,7 +229,9 @@ def reset_repository(
                 "An error occured during auth repo commit check - make sure you either have a valid last validated commit or specify a commitish via --commit flag."
             )
 
-        exclude_filter = auth_repo.last_validated_data.get("exclude_filter")
+        last_validated_data = auth_repo.last_validated_data
+        if last_validated_data is not None:
+            exclude_filter = last_validated_data.get("exclude_filter")
         # Load corresponding target repos and their commits
         repositoriesdb.load_repositories(auth_repo, exclude_filter=exclude_filter)
         target_repos = repositoriesdb.get_deduplicated_repositories(

--- a/taf/auth_repo.py
+++ b/taf/auth_repo.py
@@ -417,7 +417,6 @@ class AuthenticationRepository(GitRepository):
         commits: List[Commitish],
         target_repos: Dict[str, GitRepository],
         custom_fns: Optional[Dict[str, Callable]] = None,
-        excluded_target_globs: Optional[List[str]] = None,
         last_commits_per_repos: Optional[Dict[Commitish, List]] = None,
     ) -> Dict[str, Dict[Commitish, Dict[str, Any]]]:
         """
@@ -443,14 +442,8 @@ class AuthenticationRepository(GitRepository):
             target_repos=target_repos,
             last_commits_per_repos=last_commits_per_repos,
         )
-        excluded_target_globs = excluded_target_globs or []
         for commit in commits:
             for target_path, target_data in targets[commit].items():
-                if any(
-                    fnmatch.fnmatch(target_path, excluded_target_glob)
-                    for excluded_target_glob in excluded_target_globs
-                ):
-                    continue
 
                 target_branch = target_data.get("branch")
                 target_commit = target_data.get("commit")
@@ -474,7 +467,6 @@ class AuthenticationRepository(GitRepository):
         commits: List[Commitish],
         target_repos: Optional[Dict[str, GitRepository]] = None,
         custom_fns: Optional[Dict[str, Callable]] = None,
-        excluded_target_globs: Optional[List[str]] = None,
     ) -> Dict[str, Dict[str, List[Dict[str, Any]]]]:
         """Return a dictionary consisting of branches and commits belonging
         to it for every target repository:
@@ -505,18 +497,8 @@ class AuthenticationRepository(GitRepository):
         repositories_commits: Dict = defaultdict(dict)
         targets = self.targets_at_revisions(commits, target_repos=target_repos)
         previous_commits: Dict = {}
-        skipped_targets = []
-        excluded_target_globs = excluded_target_globs or []
         for commit in commits:
             for target_path, target_data in targets[commit].items():
-                if target_path in skipped_targets:
-                    continue
-                if any(
-                    fnmatch.fnmatch(target_path, excluded_target_glob)
-                    for excluded_target_glob in excluded_target_globs
-                ):
-                    skipped_targets.append(target_path)
-                    continue
                 target_branch = target_data.get("branch")
                 target_commit = target_data.get("commit")
                 previous_data = previous_commits.get(target_path)

--- a/taf/repositoriesdb.py
+++ b/taf/repositoriesdb.py
@@ -1,7 +1,6 @@
 import ast
 import json
 from typing import Callable, Dict, List, Optional, Type
-import fnmatch
 from pathlib import Path
 from taf.auth_repo import AuthenticationRepository
 from taf.constants import TARGETS_DIRECTORY_NAME

--- a/taf/repositoriesdb.py
+++ b/taf/repositoriesdb.py
@@ -185,7 +185,7 @@ def load_repositories(
     only_load_targets: bool = True,
     commits: Optional[List[Commitish]] = None,
     roles: Optional[List[str]] = None,
-    excluded_target_globs: Optional[List[str]] = None,
+    exclude_filter: Optional[str] = None,
     raise_error_if_no_urls: bool = False,
 ) -> None:
     """
@@ -227,7 +227,7 @@ def load_repositories(
         only_load_targets=only_load_targets,
         commits=commits,
         roles=roles,
-        excluded_target_globs=excluded_target_globs,
+        exclude_filter=exclude_filter,
         raise_error_if_no_urls=raise_error_if_no_urls,
     )
     if commits is None or len(commits) == 0:
@@ -251,13 +251,11 @@ def _load_repositories(
     only_load_targets: bool = True,
     commits: Optional[List[Commitish]] = None,
     roles: Optional[List[str]] = None,
-    excluded_target_globs: Optional[List[str]] = None,
+    exclude_filter: Optional[str] = None,
     raise_error_if_no_urls: Optional[bool] = False,
 ) -> Dict:
 
     repositories = {}
-    if excluded_target_globs is None:
-        excluded_target_globs = []
 
     if commits is None:
         auth_repo_head_commit = auth_repo.head_commit()
@@ -280,7 +278,11 @@ def _load_repositories(
     if roles is not None and len(roles):
         only_load_targets = True
 
-    skipped_targets = []
+    skipped_targets = (
+        get_repository_names_by_expression(auth_repo, filter_expr=exclude_filter)
+        if exclude_filter
+        else []
+    )
     mirrors = load_mirrors_json(auth_repo, commits[-1])
     for commit in commits:
         commit_repositories: Dict = {}
@@ -301,12 +303,6 @@ def _load_repositories(
             if name in skipped_targets:
                 continue
             if name not in targets and only_load_targets:
-                continue
-            if any(
-                fnmatch.fnmatch(name, excluded_target_glob)
-                for excluded_target_glob in excluded_target_globs
-            ):
-                skipped_targets.append(name)
                 continue
             custom = _get_custom_data(repo_data, targets.get(name))
             urls = _get_urls(mirrors, name, repo_data, raise_error_if_no_urls)
@@ -596,6 +592,8 @@ def get_repository_names_by_expression(
     def _matches_filter(name):
         try:
             custom_data = _get_custom_data(repositories[name], targets.get(name))
+            # Add special case for repo['name'] filter expressions
+            custom_data["name"] = name
             # Evaluate filter expression with custom data as 'repo'
             # Safe: validated via AST + restricted namespace with no builtins
             return eval(filter_expr, safe_globals, {"repo": custom_data})  # nosec B307
@@ -638,7 +636,7 @@ def get_deduplicated_auth_repositories(
 def get_deduplicated_repositories(
     auth_repo: AuthenticationRepository,
     commits: Optional[List[Commitish]] = None,
-    excluded_target_globs: Optional[List[str]] = None,
+    exclude_filter: Optional[str] = None,
     library_dir: Optional[str] = None,
     raise_error_if_no_urls=False,
 ) -> Dict[str, GitRepository]:
@@ -646,7 +644,7 @@ def get_deduplicated_repositories(
         auth_repo,
         commits,
         False,
-        excluded_target_globs,
+        exclude_filter,
         library_dir,
         raise_error_if_no_urls,
     )
@@ -656,7 +654,7 @@ def _get_deduplicated_target_or_auth_repositories(
     auth_repo: AuthenticationRepository,
     commits: Optional[List[Commitish]],
     load_auth: Optional[bool] = False,
-    excluded_target_globs: Optional[List[str]] = None,
+    exclude_filter: Optional[str] = None,
     library_dir: Optional[str] = None,
     raise_error_if_no_urls: Optional[bool] = False,
 ):
@@ -685,7 +683,7 @@ def _get_deduplicated_target_or_auth_repositories(
                 auth_repo.path: _load_repositories(
                     auth_repo=auth_repo,
                     commits=commits,
-                    excluded_target_globs=excluded_target_globs,
+                    exclude_filter=exclude_filter,
                     library_dir=library_dir,
                     raise_error_if_no_urls=raise_error_if_no_urls,
                 )

--- a/taf/tests/test_api/repo/api/test_create_repository.py
+++ b/taf/tests/test_api/repo/api/test_create_repository.py
@@ -128,5 +128,4 @@ def test_create_repository_when_add_repositories_json(
     for role in ("targets", "delegated_role", "inner_role"):
         assert role in targets_roles
     check_if_targets_signed(auth_repo, "targets", "repositories.json", "mirrors.json")
-    # we are not validating target repositories, just the authentication repository
     validate_repository(repo_path)

--- a/taf/tests/test_api/repo/api/test_create_repository.py
+++ b/taf/tests/test_api/repo/api/test_create_repository.py
@@ -129,4 +129,4 @@ def test_create_repository_when_add_repositories_json(
         assert role in targets_roles
     check_if_targets_signed(auth_repo, "targets", "repositories.json", "mirrors.json")
     # we are not validating target repositories, just the authentication repository
-    validate_repository(repo_path, excluded_target_globs="*")
+    validate_repository(repo_path)

--- a/taf/tests/test_updater/conftest.py
+++ b/taf/tests/test_updater/conftest.py
@@ -83,6 +83,7 @@ TARGET_COMMIT_MISMATCH_PATTERN = (
 INVALID_AUTH_COMMIT_RESET_ERROR = "An error occured during auth repo commit check - make sure you either have a valid last validated commit or specify a commitish via --commit flag."
 UNCOMMITTED_CHANGES_RESET_PATTERN = r"There are uncommited changes in ([A-Za-z0-9_\-\[\]]+/[A-Za-z0-9_\-\[\]]+)\. Please commit/stash changes or run reset with force flag."
 DETACHED_HEAD_RESET_PATTERN = r"(\w+\/\w+) is in detached head state. Fix the state manually or run reset with force flag."
+OLD_LVC_FORMAT_ERROR_PATTERN = r"Failure to set excluded targets for repo (\w+\/\w+) - last_validated_commit file is in old format which is not supported anymore. Please delete the file and re-run the command."
 
 
 # Disable console logging for all tests

--- a/taf/tests/test_updater/test_clone/test_clone_partial.py
+++ b/taf/tests/test_updater/test_clone/test_clone_partial.py
@@ -2,6 +2,7 @@ import pytest
 from taf.tests.test_updater.update_utils import (
     update_and_check_commit_shas,
     verify_repos_exist,
+    verify_excluded_lvc_entries,
 )
 from taf.updater.updater import OperationType, UpdateType
 from taf.tests.test_updater.conftest import (
@@ -36,11 +37,11 @@ def test_clone_with_excluded_targets(origin_auth_repo, client_dir):
         origin_auth_repo,
         client_dir,
         expected_repo_type=expected_repo_type,
-        excluded_target_globs=["*/target_same*"],
+        exclude_filter="'target_same' in repo['name']",
     )
-    verify_repos_exist(
-        client_dir, origin_auth_repo, excluded=["target_same1", "target_same2"]
-    )
+    excluded = ["target_same1", "target_same2"]
+    verify_repos_exist(client_dir, origin_auth_repo, excluded)
+    verify_excluded_lvc_entries(client_dir, origin_auth_repo, excluded)
 
 
 @pytest.mark.parametrize(

--- a/taf/tests/test_updater/test_clone/test_clone_valid.py
+++ b/taf/tests/test_updater/test_clone/test_clone_valid.py
@@ -16,6 +16,7 @@ from taf.tests.test_updater.update_utils import (
     clone_client_target_repos_without_updater,
     update_and_check_commit_shas,
     verify_repos_exist,
+    verify_excluded_lvc_entries,
 )
 from taf.updater.types.update import OperationType, UpdateType
 
@@ -221,20 +222,20 @@ def test_clone_valid_when_root_version_skipped(origin_auth_repo, client_dir):
 
 
 @pytest.mark.parametrize(
-    "origin_auth_repo, excluded_target_globs",
+    "origin_auth_repo, exclude_filter",
     [
         (
             {
                 "targets_config": [{"name": "target1"}, {"name": "target2"}],
             },
-            ["*/target1"],
+            "'target1' in repo['name']",
         )
     ],
     indirect=["origin_auth_repo"],
 )
 def test_valid_clone_when_exclude_target(
     origin_auth_repo,
-    excluded_target_globs,
+    exclude_filter,
     client_dir,
 ):
     update_and_check_commit_shas(
@@ -242,8 +243,9 @@ def test_valid_clone_when_exclude_target(
         origin_auth_repo,
         client_dir,
         expected_repo_type=UpdateType.EITHER,
-        excluded_target_globs=excluded_target_globs,
+        exclude_filter=exclude_filter,
     )
+    verify_excluded_lvc_entries(client_dir, origin_auth_repo, excluded=["target1"])
 
 
 @pytest.mark.parametrize(

--- a/taf/tests/test_updater/test_update/test_update_invalid.py
+++ b/taf/tests/test_updater/test_update/test_update_invalid.py
@@ -6,6 +6,7 @@ from taf.tests.test_updater.conftest import (
     LVC_NOT_IN_REMOTE_PATTERN,
     TARGET_MISSMATCH_PATTERN,
     UNCOMMITTED_CHANGES,
+    OLD_LVC_FORMAT_ERROR_PATTERN,
     SetupManager,
     add_unauthenticated_commits_to_all_target_repos,
     add_valid_target_commits,
@@ -13,6 +14,7 @@ from taf.tests.test_updater.conftest import (
     set_last_commit_of_auth_repo,
     update_expiration_dates,
     update_timestamp_metadata_invalid_signature,
+    replace_with_old_last_validated_commit_format,
 )
 from taf.tests.test_updater.update_utils import (
     check_if_last_validated_commit_exists,
@@ -140,3 +142,36 @@ def test_update_invalid_target_invalid_singature(origin_auth_repo, client_dir):
     client_auth_repo = AuthenticationRepository(client_dir, origin_auth_repo.name)
     # make sure that the last validated commit does not exist
     check_if_last_validated_commit_exists(client_auth_repo, True)
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [{"name": "target1"}, {"name": "target2"}],
+        },
+    ],
+    indirect=True,
+)
+def test_update_when_old_last_validated_commit(origin_auth_repo, client_dir):
+    clone_repositories(
+        origin_auth_repo,
+        client_dir,
+    )
+
+    setup_manager = SetupManager(origin_auth_repo)
+    setup_manager.add_task(add_valid_target_commits)
+    setup_manager.execute_tasks()
+
+    client_auth_repo = AuthenticationRepository(client_dir, origin_auth_repo.name)
+    client_setup_manager = SetupManager(client_auth_repo)
+    client_setup_manager.add_task(replace_with_old_last_validated_commit_format)
+    client_setup_manager.execute_tasks()
+
+    update_invalid_repos_and_check_if_repos_exist(
+        OperationType.UPDATE,
+        origin_auth_repo,
+        client_dir,
+        OLD_LVC_FORMAT_ERROR_PATTERN,
+        True,
+    )

--- a/taf/tests/test_updater/test_update/test_update_partial.py
+++ b/taf/tests/test_updater/test_update/test_update_partial.py
@@ -15,7 +15,7 @@ from taf.tests.test_updater.update_utils import (
     clone_repositories,
     load_target_repositories,
     update_and_check_commit_shas,
-    update_invalid_repos_and_check_if_repos_exist,
+    verify_excluded_lvc_entries,
     verify_repos_exist,
 )
 from taf.updater.types.update import OperationType
@@ -88,120 +88,16 @@ def test_update_when_clone_with_excluded_update_all(origin_auth_repo, client_dir
         origin_auth_repo,
         client_dir,
         expected_repo_type=expected_repo_type,
-        excluded_target_globs=["*/target_same*"],
+        exclude_filter="'target_same' in repo['name']",
     )
+    verify_excluded_lvc_entries(client_dir, origin_auth_repo, excluded=["target_same"])
 
     update_and_check_commit_shas(
         OperationType.UPDATE,
         origin_auth_repo,
         client_dir,
         expected_repo_type=expected_repo_type,
-        excluded_target_globs=["*/target_same*"],
     )
-
-
-@pytest.mark.parametrize(
-    "origin_auth_repo",
-    [
-        {
-            "targets_config": [
-                {"name": "target_same1"},
-                {"name": "target_same2"},
-                {"name": "target_different"},
-            ],
-        },
-    ],
-    indirect=True,
-)
-def test_update_after_update_with_exclude(origin_auth_repo, client_dir):
-
-    clone_repositories(
-        origin_auth_repo,
-        client_dir,
-    )
-
-    is_test_repo = origin_auth_repo.is_test_repo
-    expected_repo_type = UpdateType.TEST if is_test_repo else UpdateType.OFFICIAL
-
-    setup_manager = SetupManager(origin_auth_repo)
-    setup_manager.add_task(add_valid_target_commits)
-    setup_manager.add_task(add_valid_target_commits)
-    setup_manager.execute_tasks()
-
-    update_and_check_commit_shas(
-        OperationType.UPDATE,
-        origin_auth_repo,
-        client_dir,
-        expected_repo_type=expected_repo_type,
-        excluded_target_globs=["*/target_same*"],
-    )
-
-    setup_manager.add_task(add_valid_target_commits)
-    setup_manager.add_task(add_valid_target_commits)
-    setup_manager.execute_tasks()
-
-    update_and_check_commit_shas(
-        OperationType.UPDATE,
-        origin_auth_repo,
-        client_dir,
-        expected_repo_type=expected_repo_type,
-        excluded_target_globs=["*/target_same*"],
-    )
-    verify_repos_exist(client_dir, origin_auth_repo)
-
-
-@pytest.mark.parametrize(
-    "origin_auth_repo",
-    [
-        {
-            "targets_config": [
-                {"name": "target_same1"},
-                {"name": "target_same2"},
-                {"name": "target_different"},
-            ],
-        },
-    ],
-    indirect=True,
-)
-def test_update_after_update_with_exclude_with_invalid_commits(
-    origin_auth_repo, client_dir
-):
-
-    clone_repositories(
-        origin_auth_repo,
-        client_dir,
-    )
-
-    is_test_repo = origin_auth_repo.is_test_repo
-    expected_repo_type = UpdateType.TEST if is_test_repo else UpdateType.OFFICIAL
-
-    setup_manager = SetupManager(origin_auth_repo)
-    setup_manager.add_task(add_valid_target_commits)
-    setup_manager.add_task(
-        add_unauthenticated_commit_to_target_repo,
-        kwargs={"target_name": "target_same1"},
-    )
-    setup_manager.add_task(add_valid_target_commits)
-    setup_manager.execute_tasks()
-
-    # this update should be successful because we are skipping the invalid repo
-    update_and_check_commit_shas(
-        OperationType.UPDATE,
-        origin_auth_repo,
-        client_dir,
-        expected_repo_type=expected_repo_type,
-        excluded_target_globs=["*/target_same*"],
-    )
-
-    # without the exclusion of the invalid repo, the update should fail
-    update_invalid_repos_and_check_if_repos_exist(
-        OperationType.UPDATE,
-        origin_auth_repo,
-        client_dir,
-        TARGET_MISSMATCH_PATTERN,
-        True,
-    )
-    verify_repos_exist(client_dir, origin_auth_repo)
 
 
 @pytest.mark.parametrize(
@@ -230,12 +126,11 @@ def test_full_update_after_partial_clone(origin_auth_repo, client_dir):
         origin_auth_repo,
         client_dir,
         expected_repo_type=expected_repo_type,
-        excluded_target_globs=["*/target_same*"],
+        exclude_filter="'target_same' in repo['name']",
     )
-    verify_repos_exist(
-        client_dir, origin_auth_repo, excluded=["target_same1", "target_same2"]
-    )
-
+    excluded = ["target_same1", "target_same2"]
+    verify_repos_exist(client_dir, origin_auth_repo, excluded)
+    verify_excluded_lvc_entries(client_dir, origin_auth_repo, excluded)
     # this update should be successful because we are skipping the invalid repo
     update_and_check_commit_shas(
         OperationType.UPDATE,
@@ -243,139 +138,8 @@ def test_full_update_after_partial_clone(origin_auth_repo, client_dir):
         client_dir,
         no_upstream=False,
         expected_repo_type=expected_repo_type,
-        excluded_target_globs=["*/target_same*"],
     )
     verify_repos_exist(
         client_dir, origin_auth_repo, excluded=["target_same1", "target_same2"]
     )
-
-
-@pytest.mark.parametrize(
-    "origin_auth_repo",
-    [
-        {
-            "targets_config": [
-                {"name": "target_same1"},
-                {"name": "target_same2"},
-                {"name": "target_different"},
-            ],
-        },
-    ],
-    indirect=True,
-)
-def test_full_update_after_partial_update(origin_auth_repo, client_dir):
-    clone_repositories(
-        origin_auth_repo,
-        client_dir,
-    )
-    setup_manager = SetupManager(origin_auth_repo)
-    setup_manager.add_task(add_valid_target_commits)
-    setup_manager.add_task(add_valid_target_commits)
-    setup_manager.execute_tasks()
-    is_test_repo = origin_auth_repo.is_test_repo
-    expected_repo_type = UpdateType.TEST if is_test_repo else UpdateType.OFFICIAL
-
-    update_and_check_commit_shas(
-        OperationType.UPDATE,
-        origin_auth_repo,
-        client_dir,
-        expected_repo_type=expected_repo_type,
-        excluded_target_globs=["*/target_same*"],
-    )
-
-    client_auth_repo_path = client_dir / origin_auth_repo.name
-    client_auth_repo = AuthenticationRepository(path=client_auth_repo_path)
-
-    assert (
-        client_auth_repo.last_validated_commit
-        != client_auth_repo.last_validated_data[client_auth_repo.name]
-    )
-    # this should update the skipped repos
-    # no upstream is set to True to make sure
-    # that it is correctly detected that the previous update
-    # was a partial one
-    update_and_check_commit_shas(
-        OperationType.UPDATE,
-        origin_auth_repo,
-        client_dir,
-        no_upstream=True,
-        expected_repo_type=expected_repo_type,
-    )
-
-    assert (
-        client_auth_repo.last_validated_commit
-        == client_auth_repo.last_validated_data[client_auth_repo.name]
-    )
-
-
-@pytest.mark.parametrize(
-    "origin_auth_repo",
-    [
-        {
-            "targets_config": [{"name": "target1"}, {"name": "target2"}],
-        },
-    ],
-    indirect=True,
-)
-def test_update_when_no_upstream_after_manual_pull_of_partial_update_restores_last_valid_commits(
-    origin_auth_repo, client_dir
-):
-    clone_repositories(origin_auth_repo, client_dir)
-
-    setup_manager = SetupManager(origin_auth_repo)
-    setup_manager.add_task(add_valid_target_commits)
-    setup_manager.add_task(
-        add_unauthenticated_commit_to_target_repo, kwargs={"target_name": "target1"}
-    )
-    setup_manager.add_task(add_valid_target_commits)
-    setup_manager.execute_tasks()
-
-    update_invalid_repos_and_check_if_repos_exist(
-        OperationType.UPDATE,
-        origin_auth_repo,
-        client_dir,
-        None,
-        True,
-    )
-
-    expected_last_validated_commit = origin_auth_repo.all_commits_on_branch()[-2]
-
-    client_auth_repo = AuthenticationRepository(path=client_dir / origin_auth_repo.name)
-    assert client_auth_repo.last_validated_commit == expected_last_validated_commit.hash
-    assert client_auth_repo.head_commit() == expected_last_validated_commit
-
-    client_target_repositories = load_target_repositories(client_auth_repo, client_dir)
-    expected_target_commits = {}
-    for target_name, target_repo in client_target_repositories.items():
-        expected_target_commits[target_name] = Commitish.from_hash(
-            client_auth_repo.get_target(target_name, expected_last_validated_commit)[
-                "commit"
-            ]
-        )
-        assert target_repo.head_commit() == expected_target_commits[target_name]
-
-    pull_client_auth_repo(origin_auth_repo, client_dir)
-    pull_all_target_repos(origin_auth_repo, client_dir)
-
-    origin_target_repositories = load_target_repositories(origin_auth_repo)
-    assert client_auth_repo.head_commit() == origin_auth_repo.head_commit()
-
-    for target_name, target_repo in client_target_repositories.items():
-        assert (
-            target_repo.head_commit()
-            == origin_target_repositories[target_name].head_commit()
-        )
-        assert target_repo.head_commit() != expected_target_commits[target_name]
-
-    update_invalid_repos_and_check_if_repos_exist(
-        OperationType.UPDATE,
-        origin_auth_repo,
-        client_dir,
-        None,
-        True,
-    )
-
-    assert client_auth_repo.head_commit() == expected_last_validated_commit
-    assert client_auth_repo.last_validated_commit == expected_last_validated_commit.hash
-    for target_name, target_repo in client_target_repositories.items():
-        assert target_repo.head_commit() == expected_target_commits[target_name]
+    verify_excluded_lvc_entries(client_dir, origin_auth_repo, excluded)

--- a/taf/tests/test_updater/test_update/test_update_partial.py
+++ b/taf/tests/test_updater/test_update/test_update_partial.py
@@ -1,9 +1,7 @@
 import pytest
 from taf.auth_repo import AuthenticationRepository
 from taf.tests.test_updater.conftest import (
-    TARGET_MISSMATCH_PATTERN,
     SetupManager,
-    add_unauthenticated_commit_to_target_repo,
     add_valid_target_commits,
     pull_all_target_repos,
     pull_client_auth_repo,

--- a/taf/tests/test_updater/test_update/test_update_partial.py
+++ b/taf/tests/test_updater/test_update/test_update_partial.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from taf.auth_repo import AuthenticationRepository
 from taf.tests.test_updater.conftest import (
@@ -137,7 +139,56 @@ def test_full_update_after_partial_clone(origin_auth_repo, client_dir):
         no_upstream=False,
         expected_repo_type=expected_repo_type,
     )
-    verify_repos_exist(
-        client_dir, origin_auth_repo, excluded=["target_same1", "target_same2"]
-    )
+    verify_repos_exist(client_dir, origin_auth_repo, excluded)
     verify_excluded_lvc_entries(client_dir, origin_auth_repo, excluded)
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [
+                {"name": "target_same1"},
+                {"name": "target_same2"},
+                {"name": "target_different"},
+            ],
+        },
+    ],
+    indirect=True,
+)
+def test_update_after_partial_clone_with_deleted_lvc(origin_auth_repo, client_dir):
+    """Clone with exclude_filter, delete last_validated_commit, then update."""
+    setup_manager = SetupManager(origin_auth_repo)
+    setup_manager.add_task(add_valid_target_commits)
+    setup_manager.execute_tasks()
+
+    is_test_repo = origin_auth_repo.is_test_repo
+    expected_repo_type = UpdateType.TEST if is_test_repo else UpdateType.OFFICIAL
+
+    update_and_check_commit_shas(
+        OperationType.CLONE,
+        origin_auth_repo,
+        client_dir,
+        expected_repo_type=expected_repo_type,
+        exclude_filter="'target_same' in repo['name']",
+    )
+
+    excluded = ["target_same1", "target_same2"]
+    verify_repos_exist(client_dir, origin_auth_repo, excluded)
+    verify_excluded_lvc_entries(client_dir, origin_auth_repo, excluded)
+
+    # Delete the last_validated_commit file
+    client_auth_repo = AuthenticationRepository(path=client_dir / origin_auth_repo.name)
+    lvc_path = Path(client_auth_repo.conf_dir, client_auth_repo.LAST_VALIDATED_FILENAME)
+    assert lvc_path.is_file()
+    lvc_path.unlink()
+
+    # Update should still succeed — re-validates from scratch
+    update_and_check_commit_shas(
+        OperationType.UPDATE,
+        origin_auth_repo,
+        client_dir,
+        expected_repo_type=expected_repo_type,
+        skip_check_last_validated=True,
+    )
+    verify_repos_exist(client_dir, origin_auth_repo)

--- a/taf/tests/test_updater/test_update/test_update_valid.py
+++ b/taf/tests/test_updater/test_update/test_update_valid.py
@@ -10,7 +10,6 @@ from taf.tests.test_updater.conftest import (
     remove_commits,
     remove_last_validated_commit,
     remove_last_validated_data,
-    replace_with_old_last_validated_commit_format,
     revert_last_validated_commit,
     update_and_sign_metadata_without_clean_check,
     update_expiration_dates,
@@ -44,37 +43,6 @@ def test_update_valid_happy_path(origin_auth_repo, client_dir):
     setup_manager = SetupManager(origin_auth_repo)
     setup_manager.add_task(add_valid_target_commits)
     setup_manager.execute_tasks()
-
-    update_and_check_commit_shas(
-        OperationType.UPDATE,
-        origin_auth_repo,
-        client_dir,
-    )
-
-
-@pytest.mark.parametrize(
-    "origin_auth_repo",
-    [
-        {
-            "targets_config": [{"name": "target1"}, {"name": "target2"}],
-        },
-    ],
-    indirect=True,
-)
-def test_update_when_old_last_validated_commit(origin_auth_repo, client_dir):
-    clone_repositories(
-        origin_auth_repo,
-        client_dir,
-    )
-
-    setup_manager = SetupManager(origin_auth_repo)
-    setup_manager.add_task(add_valid_target_commits)
-    setup_manager.execute_tasks()
-
-    client_auth_repo = AuthenticationRepository(client_dir, origin_auth_repo.name)
-    client_setup_manager = SetupManager(client_auth_repo)
-    client_setup_manager.add_task(replace_with_old_last_validated_commit_format)
-    client_setup_manager.execute_tasks()
 
     update_and_check_commit_shas(
         OperationType.UPDATE,

--- a/taf/tests/test_updater/test_update_library/test_clone_library_invalid.py
+++ b/taf/tests/test_updater/test_update_library/test_clone_library_invalid.py
@@ -56,7 +56,6 @@ def test_clone_with_invalid_dependency_repo(
             origin_dir,
             client_dir,
             expected_repo_type=UpdateType.EITHER,
-            excluded_target_globs=None,
         )
 
 
@@ -105,7 +104,6 @@ def test_clone_invalid_target_repo(
             origin_dir,
             client_dir,
             expected_repo_type=UpdateType.EITHER,
-            excluded_target_globs=None,
         )
 
 
@@ -151,5 +149,4 @@ def test_clone_with_invalid_root_repo(
             origin_dir,
             client_dir,
             expected_repo_type=UpdateType.EITHER,
-            excluded_target_globs=None,
         )

--- a/taf/tests/test_updater/test_update_library/test_clone_library_valid.py
+++ b/taf/tests/test_updater/test_update_library/test_clone_library_valid.py
@@ -41,5 +41,4 @@ def test_clone_repository_with_dependencies(
         origin_dir,
         client_dir,
         expected_repo_type=UpdateType.EITHER,
-        excluded_target_globs=None,
     )

--- a/taf/tests/test_updater/test_update_library/test_update_library_invalid.py
+++ b/taf/tests/test_updater/test_update_library/test_update_library_invalid.py
@@ -51,7 +51,6 @@ def test_update_with_invalid_dependency_repo(
         origin_dir,
         client_dir,
         expected_repo_type=UpdateType.EITHER,
-        excluded_target_globs=None,
     )
     # Invalidate one of the authentication repositories in dependencies
     dependency_auth_repo = library_with_dependencies["namespace11/auth"]["auth_repo"]
@@ -101,7 +100,6 @@ def test_update_invalid_target_repo(
         origin_dir,
         client_dir,
         expected_repo_type=UpdateType.EITHER,
-        excluded_target_globs=None,
     )
     # Invalidate one of the target repositories
     dependency_auth_repo = library_with_dependencies["namespace21/auth"]["auth_repo"]
@@ -154,7 +152,6 @@ def test_update_all_except_invalid(
         origin_dir,
         client_dir,
         expected_repo_type=UpdateType.EITHER,
-        excluded_target_globs=None,
     )
     # Invalidate one of the target repositories of a referenced authentication repository
     dependency_auth_repo = library_with_dependencies["namespace31/auth"]["auth_repo"]

--- a/taf/tests/test_updater/test_update_library/test_update_library_valid.py
+++ b/taf/tests/test_updater/test_update_library/test_update_library_valid.py
@@ -43,7 +43,6 @@ def test_update_repository_with_dependencies(
         origin_dir,
         client_dir,
         expected_repo_type=UpdateType.EITHER,
-        excluded_target_globs=None,
     )
     auth_repo = library_with_dependencies["namespace1/auth"]["auth_repo"]
     setup_manager = SetupManager(auth_repo)

--- a/taf/tests/test_updater/update_utils.py
+++ b/taf/tests/test_updater/update_utils.py
@@ -17,22 +17,22 @@ from taf.updater.updater import UpdateConfig, clone_repository, update_repositor
 
 
 def check_last_validated_commit(
-    clients_auth_repo_path, all_target_repositories=None, excluded_targets=None
+    clients_auth_repo_path, all_target_repositories=None, excluded_target_names=None
 ):
     # check if last validated commit is created and the saved commit is correct
     client_auth_repo = AuthenticationRepository(path=clients_auth_repo_path)
     head_sha = client_auth_repo.head_commit()
     last_validated_data = client_auth_repo.last_validated_data
     assert last_validated_data[client_auth_repo.name] == head_sha.value
-    if not excluded_targets:
+    if not excluded_target_names:
         assert (
             client_auth_repo.last_validated_data[client_auth_repo.LAST_VALIDATED_KEY]
             == head_sha.value
         )
 
-    if all_target_repositories and excluded_targets:
+    if all_target_repositories and excluded_target_names:
         for target_repo in all_target_repositories:
-            if target_repo.name not in excluded_targets:
+            if target_repo.name not in excluded_target_names:
                 assert last_validated_data[target_repo.name] == head_sha.value
             else:
                 assert last_validated_data.get(target_repo.name) != head_sha.value

--- a/taf/tests/test_updater/update_utils.py
+++ b/taf/tests/test_updater/update_utils.py
@@ -33,7 +33,7 @@ def check_last_validated_commit(
 
     if all_target_repositories and excluded_targets:
         for target_repo in all_target_repositories:
-            if target_repo not in excluded_targets:
+            if target_repo.name not in excluded_targets:
                 assert last_validated_data[target_repo.name] == head_sha.value
             else:
                 assert last_validated_data.get(target_repo.name) != head_sha.value
@@ -42,15 +42,19 @@ def check_last_validated_commit(
 def check_if_commits_match(
     client_repositories,
     origin_dir,
+    auth_repo,
     start_head_shas=None,
-    excluded_target_globs=None,
+    exclude_filter=None,
 ):
-    excluded_target_globs = excluded_target_globs or []
+    excluded_repo_names = (
+        repositoriesdb.get_repository_names_by_expression(
+            auth_repo, filter_expr=exclude_filter
+        )
+        if exclude_filter
+        else []
+    )
     for repo_name, client_repo in client_repositories.items():
-        if any(
-            fnmatch.fnmatch(repo_name, excluded_target_glob)
-            for excluded_target_glob in excluded_target_globs
-        ):
+        if repo_name in excluded_repo_names:
             continue
         origin_repo = GitRepository(origin_dir, repo_name)
         for branch in origin_repo.branches():
@@ -87,7 +91,7 @@ def clone_full_library(
     origin_dir,
     client_dir,
     expected_repo_type=UpdateType.EITHER,
-    excluded_target_globs=None,
+    exclude_filter=None,
 ):
     origin_root_repo = library_dict["root/auth"]["auth_repo"]
 
@@ -124,7 +128,7 @@ def clone_full_library(
         check_last_validated_commit(client_dir / repos["auth_repo"].name)
 
     check_if_commits_match(
-        repositories, origin_dir, start_head_shas, excluded_target_globs
+        repositories, origin_dir, repos["auth_repo"], start_head_shas, exclude_filter
     )
 
 
@@ -153,7 +157,7 @@ def clone_repositories(
     origin_auth_repo,
     clients_dir,
     expected_repo_type=UpdateType.EITHER,
-    excluded_target_globs=None,
+    exclude_filter=None,
 ):
 
     # there is a cleanup issue caused by a file being in use
@@ -168,7 +172,7 @@ def clone_repositories(
         path=None,
         library_dir=str(clients_dir),
         expected_repo_type=expected_repo_type,
-        excluded_target_globs=excluded_target_globs,
+        exclude_filter=exclude_filter,
     )
 
     with freeze_time(_get_valid_update_time(origin_auth_repo.path)):
@@ -224,7 +228,7 @@ def _get_head_commit_shas(client_repos, num_of_commits_to_remove=None):
 def load_target_repositories(
     auth_repo,
     library_dir=None,
-    excluded_target_globs=None,
+    exclude_filter=None,
     commits=None,
     only_load_targets=False,
 ):
@@ -236,7 +240,7 @@ def load_target_repositories(
         auth_repo,
         library_dir=library_dir,
         only_load_targets=only_load_targets,
-        excluded_target_globs=excluded_target_globs,
+        exclude_filter=exclude_filter,
         commits=commits,
     )
     return repositoriesdb.get_deduplicated_repositories(
@@ -251,14 +255,15 @@ def update_and_check_commit_shas(
     clients_dir,
     expected_repo_type=UpdateType.EITHER,
     auth_repo_name_exists=True,
-    excluded_target_globs=None,
+    exclude_filter=None,
     force=False,
     bare=False,
     no_upstream=False,
     skip_check_last_validated=False,
     num_of_commits_to_remove=None,
-    exclude_filter=None,
 ):
+    if operation == OperationType.UPDATE:
+        exclude_filter = None
     client_repos = load_target_repositories(origin_auth_repo, clients_dir)
     client_repos = {
         repo_name: repo
@@ -279,7 +284,6 @@ def update_and_check_commit_shas(
         path=str(clients_auth_repo_path) if auth_repo_name_exists else None,
         library_dir=str(clients_dir),
         expected_repo_type=expected_repo_type,
-        excluded_target_globs=excluded_target_globs,
         exclude_filter=exclude_filter,
         bare=bare,
         force=force,
@@ -295,49 +299,50 @@ def update_and_check_commit_shas(
     check_if_commits_match(
         client_repos,
         origin_root_dir,
+        origin_auth_repo,
         start_head_shas,
-        excluded_target_globs,
+        exclude_filter,
     )
 
-    excluded_targets = []
-    excluded_target_globs = excluded_target_globs or []
+    excluded_repo_names = []
+    if operation == OperationType.UPDATE:
+        exclude_filter = clients_auth_repo.last_validated_data.get("exclude_filter")
 
     if exclude_filter:
         try:
             excluded_repo_names = repositoriesdb.get_repository_names_by_expression(
                 origin_auth_repo, filter_expr=exclude_filter
             )
-            if excluded_repo_names:
-                excluded_target_globs.extend(excluded_repo_names)
         except RepositoriesNotFoundError:
             pass
 
     repositoriesdb.clear_repositories_db()
     all_target_repositories = load_target_repositories(origin_auth_repo, clients_dir)
-    if excluded_target_globs:
+    if excluded_repo_names:
         total_dirs_count = count_subdirectories_in_directory(
             clients_auth_repo_path.parent
         )
         for target_repo in all_target_repositories.values():
-            for excluded_target_glob in excluded_target_globs:
-                if fnmatch.fnmatch(target_repo.name, excluded_target_glob):
-                    excluded_targets.append(target_repo)
-                    if target_repo.name in clients_auth_repo.last_validated_data:
-                        assert target_repo.path.is_dir()
-                    else:
-                        assert not target_repo.path.is_dir()
-                    break
+            if (
+                target_repo.name in clients_auth_repo.last_validated_data
+                and target_repo.name not in excluded_repo_names
+            ):
+                assert target_repo.path.is_dir()
+            else:
+                assert not target_repo.path.is_dir()
+            break
 
-        assert len(excluded_targets) > 0
+        assert len(excluded_repo_names) > 0
         # all target repositories + auth repo + auth repo conf dir - skipped repos
         if operation == OperationType.CLONE:
             assert total_dirs_count == len(all_target_repositories) + 2 - len(
-                excluded_targets
+                excluded_repo_names
             )
-
     if not skip_check_last_validated:
         check_last_validated_commit(
-            clients_auth_repo_path, all_target_repositories.values(), excluded_targets
+            clients_auth_repo_path,
+            all_target_repositories.values(),
+            excluded_repo_names,
         )
 
     return update_ret
@@ -351,7 +356,7 @@ def update_invalid_repos_and_check_if_repos_exist(
     expect_partial_update,
     expected_repo_type=UpdateType.EITHER,
     auth_repo_name_exists=True,
-    excluded_target_globs=None,
+    exclude_filter=None,
     strict=False,
     no_upstream=False,
     sync_all=False,
@@ -374,7 +379,7 @@ def update_invalid_repos_and_check_if_repos_exist(
         path=str(clients_auth_repo_path) if auth_repo_name_exists else None,
         library_dir=str(clients_dir),
         expected_repo_type=expected_repo_type,
-        excluded_target_globs=excluded_target_globs,
+        exclude_filter=exclude_filter,
         strict=strict,
         no_upstream=no_upstream,
         sync_all=sync_all,
@@ -414,6 +419,19 @@ def verify_repos_exist(
             assert not repo.is_git_repository
         else:
             assert repo.path.is_dir()
+
+
+def verify_excluded_lvc_entries(
+    client_dir: Path, origin_auth_repo: AuthenticationRepository, excluded: list
+):
+    client_auth_repo = AuthenticationRepository(path=client_dir / origin_auth_repo.name)
+    assert client_auth_repo.last_validated_data["exclude_filter"] is not None
+    client_target_repos = load_target_repositories(
+        client_auth_repo, library_dir=client_dir
+    )
+    for repo in client_target_repos.values():
+        if repo.name.split("/")[-1] in excluded:
+            assert client_auth_repo.last_validated_data[repo.name] is None
 
 
 def verify_repo_empty(
@@ -517,7 +535,7 @@ def update_and_validate_repositories(
     origin_dir,
     client_dir,
     invalid_target_names=None,
-    excluded_target_globs=None,
+    exclude_filter=None,
 ):
     if invalid_target_names is None:
         invalid_target_names = []
@@ -539,7 +557,7 @@ def update_and_validate_repositories(
             OperationType.UPDATE,
             origin_root_repo,
             client_dir,
-            excluded_target_globs=excluded_target_globs,
+            exclude_filter=exclude_filter,
         )
     except UpdateFailedError as e:
         if any(
@@ -564,6 +582,7 @@ def update_and_validate_repositories(
                 check_if_commits_match(
                     {auth_repo_name: auth_repo, target_repo.name: target_repo},
                     origin_dir,
+                    auth_repo,
                     start_head_shas,
                 )
             else:

--- a/taf/tests/test_updater/update_utils.py
+++ b/taf/tests/test_updater/update_utils.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from freezegun import freeze_time
 from collections import defaultdict
 from datetime import datetime
-import fnmatch
 import json
 from taf import repositoriesdb
 from taf.auth_repo import AuthenticationRepository, Optional
@@ -425,13 +424,16 @@ def verify_excluded_lvc_entries(
     client_dir: Path, origin_auth_repo: AuthenticationRepository, excluded: list
 ):
     client_auth_repo = AuthenticationRepository(path=client_dir / origin_auth_repo.name)
-    assert client_auth_repo.last_validated_data["exclude_filter"] is not None
+    last_validated_data = client_auth_repo.last_validated_data
+    assert last_validated_data is not None
+    if last_validated_data.get("exclude_filter") is not None:
+        assert last_validated_data["exclude_filter"]
     client_target_repos = load_target_repositories(
         client_auth_repo, library_dir=client_dir
     )
     for repo in client_target_repos.values():
         if repo.name.split("/")[-1] in excluded:
-            assert client_auth_repo.last_validated_data[repo.name] is None
+            assert last_validated_data[repo.name] is None
 
 
 def verify_repo_empty(

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -43,20 +43,10 @@ def common_update_options(f):
         help="Return formatted output which includes information on if build was successful and error message if it was raised",
     )(f)
     f = click.option(
-        "--exclude-target",
-        multiple=True,
-        help="Globs defining which target repositories should be ignored during update.",
-    )(f)
-    f = click.option(
         "--strict",
         is_flag=True,
         default=False,
         help="Enable/disable strict mode - return an error if warnings are raised.",
-    )(f)
-    f = click.option(
-        "--exclude-filter",
-        default=None,
-        help="Exclude repositories matching Python expression. Repo available as 'repo'. Example: \"repo['type'] == 'html'\"",
     )(f)
     f = click.option(
         "--result-file",
@@ -286,6 +276,11 @@ def clone_repo_command():
         default=False,
         help="Run the auxiliary lifecycle handler scripts.",
     )
+    @click.option(
+        "--exclude-filter",
+        default=None,
+        help="Exclude repositories matching Python expression. Repo available as 'repo'. Example: \"repo['type'] == 'html'\"",
+    )
     def clone(
         path,
         url,
@@ -295,7 +290,6 @@ def clone_repo_command():
         scripts_root_dir,
         profile,
         format_output,
-        exclude_target,
         exclude_filter,
         strict,
         bare,
@@ -318,7 +312,6 @@ def clone_repo_command():
             update_from_filesystem=from_fs,
             expected_repo_type=UpdateType(expected_repo_type),
             scripts_root_dir=scripts_root_dir,
-            excluded_target_globs=exclude_target,
             exclude_filter=exclude_filter,
             strict=strict,
             bare=bare,
@@ -420,8 +413,6 @@ def update_repo_command():
         scripts_root_dir,
         profile,
         format_output,
-        exclude_target,
-        exclude_filter,
         strict,
         no_deps,
         force,
@@ -443,8 +434,6 @@ def update_repo_command():
             library_dir=library_dir,
             expected_repo_type=UpdateType(expected_repo_type),
             scripts_root_dir=scripts_root_dir,
-            excluded_target_globs=exclude_target,
-            exclude_filter=exclude_filter,
             strict=strict,
             force=force,
             no_upstream=not upstream,
@@ -494,12 +483,6 @@ def validate_repo_command():
         help="Use the last validated commit as the starting point.",
     )
     @click.option(
-        "--exclude-target",
-        multiple=True,
-        help="globs defining which target repositories should be "
-        "ignored during update.",
-    )
-    @click.option(
         "--strict",
         is_flag=True,
         default=False,
@@ -543,7 +526,6 @@ def validate_repo_command():
         library_dir,
         from_commit,
         from_latest,
-        exclude_target,
         exclude_filter,
         strict,
         no_targets,
@@ -564,7 +546,6 @@ def validate_repo_command():
             path,
             library_dir,
             from_commit,
-            exclude_target,
             exclude_filter,
             strict,
             bare,
@@ -601,15 +582,14 @@ def reset_repo_command():
     @click.option(
         "--commit",
         default=None,
-        help="Auth repo commit to reset to. "
-        "Defaults to last validated commit."
+        help="Auth repo commit to reset to. " "Defaults to last validated commit.",
     )
     @click.option(
         "--lvc",
         is_flag=True,
         default=False,
         help="Reset last validated commit to the commitish specified in --commit flag"
-        "if that commitish is an ancestor of the current last validated commit"
+        "if that commitish is an ancestor of the current last validated commit",
     )
     @click.option(
         "--force", is_flag=True, default=False, help="Force Reset repositories"

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -208,12 +208,6 @@ class UpdateConfig:
         default=None,
         metadata={"docs": "List of URLs to clone repositories from. Optional."},
     )
-    excluded_target_globs: list = field(
-        default=None,
-        metadata={
-            "docs": "Globs specifying target repositories to exclude from validation and update. Optional."
-        },
-    )
     exclude_filter: str = field(
         default=None,
         metadata={
@@ -275,6 +269,7 @@ class UpdateConfig:
                     self.library_dir = Path(".").resolve()
 
         if self.operation == OperationType.UPDATE:
+            self.exclude_filter = None
             if self.path is None:
                 self.path = Path(".").resolve()
             if self.library_dir is None:
@@ -523,7 +518,7 @@ def _process_repo_update(
         # so that it's easy to try again after fixing the handler
         if (
             not update_config.only_validate
-            and not update_config.excluded_target_globs
+            and not update_config.exclude_filter
             and not update_config.no_targets
         ):
             _execute_repo_handlers(
@@ -642,7 +637,6 @@ def validate_repository(
     auth_path,
     library_dir=None,
     validate_from_commit=None,
-    excluded_target_globs=None,
     exclude_filter=None,
     strict=False,
     bare=False,
@@ -674,7 +668,6 @@ def validate_repository(
             path=auth_path,
             library_dir=library_dir,
             validate_from_commit=validate_from_commit,
-            excluded_target_globs=excluded_target_globs,
             exclude_filter=exclude_filter,
             strict=strict,
             bare=bare,

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -1119,48 +1119,53 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
         )
 
     def set_excluded_targets(self):
-        if self.sync_all:
-            self.excluded_target_names = []
-            return UpdateStatus.SUCCESS
-
-        if self.operation == OperationType.CLONE:
-            if not self.exclude_filter:
+        try:
+            if self.sync_all:
+                self.excluded_target_names = []
                 return UpdateStatus.SUCCESS
-        else:
-            # Load exclude_filter from last_validated_data saved by a previous clone/update
+
+            if self.operation == OperationType.CLONE:
+                if not self.exclude_filter:
+                    return UpdateStatus.SUCCESS
+            else:
+                # Load exclude_filter from last_validated_data saved by a previous clone/update
+                last_validated_data = self.state.users_auth_repo.last_validated_data
+                self.exclude_filter = last_validated_data.get("exclude_filter") or None
+
+            if self.exclude_filter:
+                excluded_repo_names = repositoriesdb.get_repository_names_by_expression(
+                    self.state.users_auth_repo, filter_expr=self.exclude_filter
+                )
+                if excluded_repo_names:
+                    self.excluded_target_names.extend(excluded_repo_names)
+
             last_validated_data = self.state.users_auth_repo.last_validated_data
-            self.exclude_filter = last_validated_data.get("exclude_filter") or None
+            if last_validated_data:
+                if len(last_validated_data) == 1:
+                    # check if old last validated format
+                    # not a json file, just one commit
+                    raise UpdateFailedError(
+                        f"Failure to set excluded targets for repo {self.state.users_auth_repo.name} - "
+                        "last_validated_commit file is in old format which is not supported anymore. "
+                        "Please delete the file and re-run the command."
+                    )
 
-        if self.exclude_filter:
-            excluded_repo_names = repositoriesdb.get_repository_names_by_expression(
-                self.state.users_auth_repo, filter_expr=self.exclude_filter
-            )
-            if excluded_repo_names:
-                self.excluded_target_names.extend(excluded_repo_names)
-
-        last_validated_data = self.state.users_auth_repo.last_validated_data
-        if last_validated_data:
-            if len(last_validated_data) == 1:
-                # check if old last validated format
-                # not a json file, just one commit
-                raise UpdateFailedError(
-                    f"Failure to set excluded targets for repo {self.state.users_auth_repo.name} - \
-                      last_validated_commit file is in old format which is not supported anymore. \
-                      Please delete the file and re-run the command."
+            if self.operation == OperationType.CLONE:
+                # Save exclude_filter and set excluded targets to None
+                last_validated_data["exclude_filter"] = self.exclude_filter
+                if self.excluded_target_names:
+                    for repo_name in self.excluded_target_names:
+                        last_validated_data[repo_name] = None
+                self.state.last_validated_data = last_validated_data
+                self.state.users_auth_repo.set_last_validated_data(
+                    last_validated_data, set_last_validated_commit=False
                 )
 
-        if self.operation == OperationType.CLONE:
-            # Save exclude_filter and set excluded targets to None
-            last_validated_data["exclude_filter"] = self.exclude_filter
-            if self.excluded_target_names:
-                for repo_name in self.excluded_target_names:
-                    last_validated_data[repo_name] = None
-            self.state.last_validated_data = last_validated_data
-            self.state.users_auth_repo.set_last_validated_data(
-                last_validated_data, set_last_validated_commit=False
-            )
-
-            return UpdateStatus.SUCCESS
+                return UpdateStatus.SUCCESS
+        except Exception as e:
+            self.state.errors.append(e)
+            self.state.event = Event.FAILED
+            return UpdateStatus.FAILED
 
     def load_target_repositories(self):
         taf_logger.debug(f"{self.state.auth_repo_name}: Loading target repositories...")

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -320,7 +320,11 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                     RunMode.UPDATE,
                     self.should_update_auth_repos,
                 ),  # auth repo
-                (self.set_excluded_targets, RunMode.ALL, self.should_run_step_default),
+                (
+                    self.set_excluded_targets,
+                    RunMode.ALL,
+                    self.should_run_step_default,
+                ),
                 # should_validate_target_repos
                 (
                     self.load_target_repositories,
@@ -428,7 +432,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
         )
         self.checkout = update_config.checkout
         self.bare = update_config.bare
-        self.excluded_target_globs = update_config.excluded_target_globs or []
+        self.excluded_target_globs = []
         self.exclude_filter = update_config.exclude_filter
         self.sync_all = update_config.sync_all
         self.no_targets = update_config.no_targets
@@ -504,12 +508,12 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                     self.state.users_auth_repo,
                     library_dir=self.library_dir,
                     only_load_targets=True,
-                    excluded_target_globs=self.excluded_target_globs,
+                    exclude_filter=self.exclude_filter,
                     raise_error_if_no_urls=True,
                 )
                 target_repositories = repositoriesdb.get_deduplicated_repositories(
                     self.state.users_auth_repo,
-                    excluded_target_globs=self.excluded_target_globs,
+                    exclude_filter=self.exclude_filter,
                     raise_error_if_no_urls=True,
                 )
                 self.state.repos_on_disk = {
@@ -1118,39 +1122,59 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
     def set_excluded_targets(self):
         if self.sync_all:
             self.excluded_target_globs = []
+            return UpdateStatus.SUCCESS
+
+        if self.operation == OperationType.CLONE:
+            if not self.exclude_filter:
+                return UpdateStatus.SUCCESS
         else:
-            self.excluded_target_globs = list(self.excluded_target_globs)
-            if self.exclude_filter:
-                excluded_repo_names = repositoriesdb.get_repository_names_by_expression(
-                    self.state.users_auth_repo, filter_expr=self.exclude_filter
-                )
-                if excluded_repo_names:
-                    self.excluded_target_globs.extend(excluded_repo_names)
-
+            # Load exclude_filter from last_validated_data saved by a previous clone/update
             last_validated_data = self.state.users_auth_repo.last_validated_data
-            if last_validated_data:
-                if len(last_validated_data) == 1:
-                    # check if old last validated format
-                    # not a json file, just one commit
-                    last_validated_file_content = (
-                        self.state.users_auth_repo.get_last_validated_file_content()
-                    )
-                    try:
-                        json.loads(last_validated_file_content)
-                    except json.decoder.JSONDecodeError:
-                        return UpdateStatus.SUCCESS
+            self.exclude_filter = last_validated_data.get("exclude_filter") or None
 
-                all_repositories = repositoriesdb.load_repositories_json(
-                    self.state.users_auth_repo
+        if self.exclude_filter:
+            excluded_repo_names = repositoriesdb.get_repository_names_by_expression(
+                self.state.users_auth_repo, filter_expr=self.exclude_filter
+            )
+            if excluded_repo_names:
+                self.excluded_target_globs.extend(excluded_repo_names)
+
+        last_validated_data = self.state.users_auth_repo.last_validated_data
+        if last_validated_data:
+            if len(last_validated_data) == 1:
+                # check if old last validated format
+                # not a json file, just one commit
+                last_validated_file_content = (
+                    self.state.users_auth_repo.get_last_validated_file_content()
                 )
-                if all_repositories is not None:
-                    all_repositories = all_repositories.get("repositories")
-                    skipped_repositories = [
-                        repository
-                        for repository in all_repositories
-                        if repository not in last_validated_data
-                    ]
-                    self.excluded_target_globs.extend(skipped_repositories)
+                try:
+                    json.loads(last_validated_file_content)
+                except json.decoder.JSONDecodeError:
+                    return UpdateStatus.SUCCESS
+
+            all_repositories = repositoriesdb.load_repositories_json(
+                self.state.users_auth_repo
+            )
+            if all_repositories is not None:
+                all_repositories = all_repositories.get("repositories")
+                skipped_repositories = [
+                    repository
+                    for repository in all_repositories
+                    if repository not in last_validated_data
+                ]
+                self.excluded_target_globs.extend(skipped_repositories)
+
+        if self.operation == OperationType.CLONE:
+            # Save exclude_filter and set excluded targets to None
+            last_validated_data["exclude_filter"] = self.exclude_filter
+            if self.excluded_target_globs:
+                for repo_name in self.excluded_target_globs:
+                    last_validated_data[repo_name] = None
+            self.state.last_validated_data = last_validated_data
+            self.state.users_auth_repo.set_last_validated_data(
+                last_validated_data, set_last_validated_commit=False
+            )
+
             return UpdateStatus.SUCCESS
 
     def load_target_repositories(self):
@@ -1160,7 +1184,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                 repositoriesdb.get_deduplicated_repositories(
                     self.state.users_auth_repo,
                     self.state.auth_commits_since_last_validated[-1::],
-                    excluded_target_globs=self.excluded_target_globs,
+                    exclude_filter=self.exclude_filter,
                     library_dir=self.library_dir,
                     raise_error_if_no_urls=not self.only_validate,
                 )

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from enum import Enum
 import functools
-import json
 from pathlib import Path
 import re
 import shutil
@@ -432,7 +431,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
         )
         self.checkout = update_config.checkout
         self.bare = update_config.bare
-        self.excluded_target_globs = []
+        self.excluded_target_names = []
         self.exclude_filter = update_config.exclude_filter
         self.sync_all = update_config.sync_all
         self.no_targets = update_config.no_targets
@@ -1121,7 +1120,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
 
     def set_excluded_targets(self):
         if self.sync_all:
-            self.excluded_target_globs = []
+            self.excluded_target_names = []
             return UpdateStatus.SUCCESS
 
         if self.operation == OperationType.CLONE:
@@ -1137,38 +1136,24 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                 self.state.users_auth_repo, filter_expr=self.exclude_filter
             )
             if excluded_repo_names:
-                self.excluded_target_globs.extend(excluded_repo_names)
+                self.excluded_target_names.extend(excluded_repo_names)
 
         last_validated_data = self.state.users_auth_repo.last_validated_data
         if last_validated_data:
             if len(last_validated_data) == 1:
                 # check if old last validated format
                 # not a json file, just one commit
-                last_validated_file_content = (
-                    self.state.users_auth_repo.get_last_validated_file_content()
+                raise UpdateFailedError(
+                    f"Failure to set excluded targets for repo {self.state.users_auth_repo.name} - \
+                      last_validated_commit file is in old format which is not supported anymore. \
+                      Please delete the file and re-run the command."
                 )
-                try:
-                    json.loads(last_validated_file_content)
-                except json.decoder.JSONDecodeError:
-                    return UpdateStatus.SUCCESS
-
-            all_repositories = repositoriesdb.load_repositories_json(
-                self.state.users_auth_repo
-            )
-            if all_repositories is not None:
-                all_repositories = all_repositories.get("repositories")
-                skipped_repositories = [
-                    repository
-                    for repository in all_repositories
-                    if repository not in last_validated_data
-                ]
-                self.excluded_target_globs.extend(skipped_repositories)
 
         if self.operation == OperationType.CLONE:
             # Save exclude_filter and set excluded targets to None
             last_validated_data["exclude_filter"] = self.exclude_filter
-            if self.excluded_target_globs:
-                for repo_name in self.excluded_target_globs:
+            if self.excluded_target_names:
+                for repo_name in self.excluded_target_names:
                     last_validated_data[repo_name] = None
             self.state.last_validated_data = last_validated_data
             self.state.users_auth_repo.set_last_validated_data(
@@ -1235,7 +1220,6 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
         )
         try:
 
-            self.state.repos_not_on_disk = {}
             self.state.repos_not_on_disk = {}
 
             def clone_repo_to_temp(temp_repo, users_repo):
@@ -1908,7 +1892,7 @@ but commit not on branch {current_branch}"
             last_validated_data[self.state.users_auth_repo.name] = last_commit.value
             self.state.users_auth_repo.set_last_validated_data(
                 last_validated_data,
-                set_last_validated_commit=not bool(self.excluded_target_globs),
+                set_last_validated_commit=not bool(self.excluded_target_names),
             )
 
             return self.state.update_status


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Target repo exclusion is set only in clone operation and the pattern is stored in `last_validated_commit` file.
Excluded target repos' last validated commits are set to `None`.
`--exclude-target` is removed in favor of `--exclude-filter`.
`--exclude-filter` is extended to filter repos by name to match `--exclude-target` implementation.

In `auth_repo.py`:
Removed excluded repos handling for methods `targets_data_by_auth_commit` and `sorted_commits_and_branches_per_repositories` since it is not used anywhere. Introducing `--exclude-filter` would lead to coupling with repositoriesdb.

Tests:
Removed `test_update_after_update_with_exclude`, `test_update_after_update_with_exclude_with_invalid_commit` and `test_full_update_after_partial_update` since update with exclude is no longer feasible.
Added verification for expected `last_validated_commit` entires - `verify_excluded_lvc_entries` function.

Closes: #716 
## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
