### PR TITLE
Fix: enable exclude filter for validation, rework partial update detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Enable `--exclude-filter` for validation ([724])
+
+[724]: https://github.com/openlawlibrary/taf/pull/724
+
 ## [0.38.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- Rework partial-update check so updates with excluded targets are not considered partial ([724])
+
 ### Fixed
 
 - Enable `--exclude-filter` for validation ([724])

--- a/taf/tests/test_updater/test_clone/test_clone_partial.py
+++ b/taf/tests/test_updater/test_clone/test_clone_partial.py
@@ -73,3 +73,4 @@ def test_clone_with_filter(origin_auth_repo, client_dir):
         exclude_filter="repo['type'] == 'html'",
     )
     verify_repos_exist(client_dir, origin_auth_repo, excluded=["target_same1"])
+    verify_excluded_lvc_entries(client_dir, origin_auth_repo, excluded=["target_same1"])

--- a/taf/tests/test_updater/test_update/test_update_partial.py
+++ b/taf/tests/test_updater/test_update/test_update_partial.py
@@ -277,7 +277,10 @@ def test_last_validated_commit_set_on_exclude_not_updated_on_partial_error(
     client_auth_repo = AuthenticationRepository(path=client_dir / origin_auth_repo.name)
     lvc_data = client_auth_repo.last_validated_data
     assert client_auth_repo.LAST_VALIDATED_KEY in lvc_data
-    assert lvc_data[client_auth_repo.LAST_VALIDATED_KEY] == client_auth_repo.head_commit().hash
+    assert (
+        lvc_data[client_auth_repo.LAST_VALIDATED_KEY]
+        == client_auth_repo.head_commit().hash
+    )
 
     # Sandwich target_xml2: valid → unsigned → valid again, so there is an unsigned commit
     setup_manager.add_task(add_valid_target_commits)
@@ -287,7 +290,9 @@ def test_last_validated_commit_set_on_exclude_not_updated_on_partial_error(
     setup_manager.add_task(add_valid_target_commits)
     setup_manager.execute_tasks()
 
-    client_target_repos = load_target_repositories(origin_auth_repo, library_dir=client_dir)
+    client_target_repos = load_target_repositories(
+        origin_auth_repo, library_dir=client_dir
+    )
     client_xml1 = next(
         repo for name, repo in client_target_repos.items() if "target_xml1" in name
     )

--- a/taf/tests/test_updater/test_update/test_update_partial.py
+++ b/taf/tests/test_updater/test_update/test_update_partial.py
@@ -2,8 +2,11 @@ from pathlib import Path
 
 import pytest
 from taf.auth_repo import AuthenticationRepository
+from taf.git import GitRepository
 from taf.tests.test_updater.conftest import (
+    TARGET_MISSMATCH_PATTERN,
     SetupManager,
+    add_unauthenticated_commit_to_target_repo,
     add_valid_target_commits,
     set_head_commit,
     update_target_repo_without_committing,
@@ -11,7 +14,9 @@ from taf.tests.test_updater.conftest import (
 from taf.tests.test_updater.update_utils import (
     UpdateType,
     clone_repositories,
+    load_target_repositories,
     update_and_check_commit_shas,
+    update_invalid_repos_and_check_if_repos_exist,
     verify_excluded_lvc_entries,
     verify_repos_exist,
 )
@@ -236,3 +241,73 @@ def test_update_after_clone_with_html_filter_remove_exclude_from_lvc(
         expected_repo_type=expected_repo_type,
     )
     verify_repos_exist(client_dir, origin_auth_repo)
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [
+                {"name": "target_html", "custom": {"type": "html"}},
+                {"name": "target_xml1"},
+                {"name": "target_xml2"},
+            ],
+        },
+    ],
+    indirect=True,
+)
+def test_last_validated_commit_set_on_exclude_not_updated_on_partial_error(
+    origin_auth_repo, client_dir
+):
+    setup_manager = SetupManager(origin_auth_repo)
+    setup_manager.add_task(add_valid_target_commits)
+    setup_manager.execute_tasks()
+
+    is_test_repo = origin_auth_repo.is_test_repo
+    expected_repo_type = UpdateType.TEST if is_test_repo else UpdateType.OFFICIAL
+
+    update_and_check_commit_shas(
+        OperationType.CLONE,
+        origin_auth_repo,
+        client_dir,
+        expected_repo_type=expected_repo_type,
+        exclude_filter="repo['type'] == 'html'",
+    )
+
+    client_auth_repo = AuthenticationRepository(path=client_dir / origin_auth_repo.name)
+    lvc_data = client_auth_repo.last_validated_data
+    assert client_auth_repo.LAST_VALIDATED_KEY in lvc_data
+    assert lvc_data[client_auth_repo.LAST_VALIDATED_KEY] == client_auth_repo.head_commit().hash
+
+    # Sandwich target_xml2: valid → unsigned → valid again, so there is an unsigned commit
+    setup_manager.add_task(add_valid_target_commits)
+    setup_manager.add_task(
+        add_unauthenticated_commit_to_target_repo, kwargs={"target_name": "target_xml2"}
+    )
+    setup_manager.add_task(add_valid_target_commits)
+    setup_manager.execute_tasks()
+
+    client_target_repos = load_target_repositories(origin_auth_repo, library_dir=client_dir)
+    client_xml1 = next(
+        repo for name, repo in client_target_repos.items() if "target_xml1" in name
+    )
+
+    # Update partially fails: xml2 has an unsigned commit sandwiched between two signed commits
+    update_invalid_repos_and_check_if_repos_exist(
+        OperationType.UPDATE,
+        origin_auth_repo,
+        client_dir,
+        TARGET_MISSMATCH_PATTERN,
+        expect_partial_update=True,
+    )
+
+    # target_xml1 (only valid commits) was fully updated to match the origin
+    origin_xml1 = GitRepository(origin_auth_repo.path.parent.parent, client_xml1.name)
+    assert client_xml1.head_commit() == origin_xml1.head_commit()
+
+    # last_validated_commit was not updated to the latest origin auth head —
+    # it reflects only the last auth commit where all repos were fully consistent
+    assert (
+        client_auth_repo.last_validated_data[client_auth_repo.LAST_VALIDATED_KEY]
+        != origin_auth_repo.head_commit().hash
+    )

--- a/taf/tests/test_updater/test_update/test_update_partial.py
+++ b/taf/tests/test_updater/test_update/test_update_partial.py
@@ -188,3 +188,51 @@ def test_update_after_partial_clone_with_deleted_lvc(origin_auth_repo, client_di
         skip_check_last_validated=True,
     )
     verify_repos_exist(client_dir, origin_auth_repo)
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [
+                {"name": "target_html", "custom": {"type": "html"}},
+                {"name": "target_xml", "custom": {"type": "xml"}},
+            ],
+        },
+    ],
+    indirect=True,
+)
+def test_update_after_clone_with_html_filter_remove_exclude_from_lvc(
+    origin_auth_repo, client_dir
+):
+    setup_manager = SetupManager(origin_auth_repo)
+    setup_manager.add_task(add_valid_target_commits)
+    setup_manager.execute_tasks()
+
+    is_test_repo = origin_auth_repo.is_test_repo
+    expected_repo_type = UpdateType.TEST if is_test_repo else UpdateType.OFFICIAL
+
+    update_and_check_commit_shas(
+        OperationType.CLONE,
+        origin_auth_repo,
+        client_dir,
+        expected_repo_type=expected_repo_type,
+        exclude_filter="repo['type'] == 'html'",
+    )
+    verify_repos_exist(client_dir, origin_auth_repo, excluded=["target_html"])
+    verify_excluded_lvc_entries(client_dir, origin_auth_repo, excluded=["target_html"])
+
+    # Remove exclude_filter from LVC so the next update includes all repos
+    client_auth_repo = AuthenticationRepository(path=client_dir / origin_auth_repo.name)
+    lvc_data = client_auth_repo.last_validated_data
+    lvc_data.pop("exclude_filter", None)
+    client_auth_repo.set_last_validated_data(lvc_data, set_last_validated_commit=False)
+
+    # Update should now clone and validate all repos, including html
+    update_and_check_commit_shas(
+        OperationType.UPDATE,
+        origin_auth_repo,
+        client_dir,
+        expected_repo_type=expected_repo_type,
+    )
+    verify_repos_exist(client_dir, origin_auth_repo)

--- a/taf/tests/test_updater/test_update/test_validate_from_commit.py
+++ b/taf/tests/test_updater/test_update/test_validate_from_commit.py
@@ -1,0 +1,56 @@
+import pytest
+from taf.updater.updater import validate_repository
+from taf.tests.test_updater.conftest import (
+    SetupManager,
+    add_valid_target_commits,
+    create_new_target_orphan_branches,
+)
+from taf.tests.test_updater.update_utils import (
+    clone_repositories,
+    update_and_check_commit_shas,
+)
+from taf.updater.types.update import OperationType
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [{"name": "target1"}, {"name": "target2"}],
+        },
+    ],
+    indirect=True,
+)
+def test_validate_from_commit_preserved_after_branch_switch(
+    origin_auth_repo, client_dir
+):
+    # 1. Clone and add initial target commits
+    clone_repositories(origin_auth_repo, client_dir)
+
+    setup_manager = SetupManager(origin_auth_repo)
+    setup_manager.add_task(add_valid_target_commits)
+    setup_manager.execute_tasks()
+
+    # 2. Update client so it's in sync
+    update_and_check_commit_shas(
+        OperationType.UPDATE,
+        origin_auth_repo,
+        client_dir,
+    )
+
+    # Record the commit BEFORE we switch branches
+    mid_point_commit = origin_auth_repo.head_commit()
+
+    # 3. Switch targets to a new orphan branch and add more commits
+    setup_manager.add_task(
+        create_new_target_orphan_branches, kwargs={"branch_name": "branch1"}
+    )
+    setup_manager.add_task(add_valid_target_commits)
+    setup_manager.execute_tasks()
+
+    # 4. Validate from mid_point_commit on the ORIGIN repo (no last_validated_data)
+    validate_repository(
+        str(origin_auth_repo.path),
+        library_dir=str(origin_auth_repo.path.parent.parent),
+        validate_from_commit=mid_point_commit.value,
+    )

--- a/taf/tests/test_updater/test_update/test_validate_from_commit.py
+++ b/taf/tests/test_updater/test_update/test_validate_from_commit.py
@@ -24,31 +24,27 @@ from taf.updater.types.update import OperationType
 def test_validate_from_commit_preserved_after_branch_switch(
     origin_auth_repo, client_dir
 ):
-    # 1. Clone and add initial target commits
     clone_repositories(origin_auth_repo, client_dir)
 
     setup_manager = SetupManager(origin_auth_repo)
     setup_manager.add_task(add_valid_target_commits)
     setup_manager.execute_tasks()
 
-    # 2. Update client so it's in sync
     update_and_check_commit_shas(
         OperationType.UPDATE,
         origin_auth_repo,
         client_dir,
     )
 
-    # Record the commit BEFORE we switch branches
+    # Validate later from the last commit prior to rewriting target history.
     mid_point_commit = origin_auth_repo.head_commit()
 
-    # 3. Switch targets to a new orphan branch and add more commits
     setup_manager.add_task(
         create_new_target_orphan_branches, kwargs={"branch_name": "branch1"}
     )
     setup_manager.add_task(add_valid_target_commits)
     setup_manager.execute_tasks()
 
-    # 4. Validate from mid_point_commit on the ORIGIN repo (no last_validated_data)
     validate_repository(
         str(origin_auth_repo.path),
         library_dir=str(origin_auth_repo.path.parent.parent),

--- a/taf/tests/test_updater/update_utils.py
+++ b/taf/tests/test_updater/update_utils.py
@@ -425,7 +425,11 @@ def verify_excluded_lvc_entries(
 ):
     client_auth_repo = AuthenticationRepository(path=client_dir / origin_auth_repo.name)
     last_validated_data = client_auth_repo.last_validated_data
+    head_commit = client_auth_repo.head_commit()
+
     assert last_validated_data is not None
+    assert head_commit is not None
+    assert client_auth_repo.last_validated_commit == head_commit.hash
     if last_validated_data.get("exclude_filter") is not None:
         assert last_validated_data["exclude_filter"]
     client_target_repos = load_target_repositories(

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -269,7 +269,8 @@ class UpdateConfig:
                     self.library_dir = Path(".").resolve()
 
         if self.operation == OperationType.UPDATE:
-            self.exclude_filter = None
+            if not self.only_validate:
+                self.exclude_filter = None
             if self.path is None:
                 self.path = Path(".").resolve()
             if self.library_dir is None:

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -639,6 +639,9 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
         """
 
         def _previous_update_partial() -> bool:
+            if self.operation == OperationType.CLONE:
+                return False
+
             last_validated_data = self.state.users_auth_repo.last_validated_data
             auth_repo_last_validated_commit = (
                 self.state.users_auth_repo.last_validated_commit
@@ -646,15 +649,10 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
 
             # validate from last_validated_commit if last_validated_data does not exist
             # (if last_validated_data was deleted)
-            if (
-                not last_validated_data
-                or not auth_repo_last_validated_commit
-            ):
+            if not last_validated_data or not auth_repo_last_validated_commit:
                 return True
 
-            auth_repo_commit = last_validated_data.get(
-                self.state.users_auth_repo.name
-            )
+            auth_repo_commit = last_validated_data.get(self.state.users_auth_repo.name)
             if (
                 auth_repo_commit is None
                 or auth_repo_commit != auth_repo_last_validated_commit
@@ -1896,7 +1894,6 @@ but commit not on branch {current_branch}"
             last_validated_data[self.state.users_auth_repo.name] = last_commit.value
             self.state.users_auth_repo.set_last_validated_data(
                 last_validated_data,
-                set_last_validated_commit=not bool(self.excluded_target_names),
             )
 
             return self.state.update_status

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -305,11 +305,6 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                     self.should_update_auth_repos,
                 ),  # auth repo
                 (
-                    self.check_if_previous_update_partial,
-                    RunMode.ALL,
-                    self.should_run_step_default,
-                ),
-                (
                     self.validate_last_validated_commit,
                     RunMode.ALL,
                     self.should_update_auth_repos,
@@ -327,6 +322,11 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                 # should_validate_target_repos
                 (
                     self.load_target_repositories,
+                    RunMode.ALL,
+                    self.should_run_step_default,
+                ),
+                (
+                    self.check_if_previous_update_partial,
                     RunMode.ALL,
                     self.should_run_step_default,
                 ),
@@ -639,39 +639,38 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
         """
 
         def _previous_update_partial() -> bool:
-            if not self.state.users_auth_repo.last_validated_commit:
-                return True
+            last_validated_data = self.state.users_auth_repo.last_validated_data
+            auth_repo_last_validated_commit = (
+                self.state.users_auth_repo.last_validated_commit
+            )
 
             # validate from last_validated_commit if last_validated_data does not exist
             # (if last_validated_data was deleted)
-            if not self.state.users_auth_repo.last_validated_data:
-                return True
             if (
-                self.state.users_auth_repo.last_validated_commit
-                != self.state.users_auth_repo.last_validated_data.get(
-                    self.state.users_auth_repo.name
-                )
+                not last_validated_data
+                or not auth_repo_last_validated_commit
             ):
                 return True
 
-            last_validated_commits = set()
-            for repo_name in self.state.users_target_repositories:
-                if self.state.users_auth_repo.last_validated_data:
-                    if repo_name not in self.state.users_auth_repo.last_validated_data:
-                        return True
-                    last_validated_commits.add(
-                        self.state.users_auth_repo.last_validated_data[repo_name]
-                    )
-            return len(last_validated_commits) > 1
-
-        is_partial = _previous_update_partial()
-        self.state.is_partially_updated = is_partial
-        if is_partial and not self.only_validate and not self.validate_from_commit:
-            self.state.last_validated_commit = (
-                self.state.users_auth_repo.last_validated_data.get(
-                    self.state.users_auth_repo.name
-                )
+            auth_repo_commit = last_validated_data.get(
+                self.state.users_auth_repo.name
             )
+            if (
+                auth_repo_commit is None
+                or auth_repo_commit != auth_repo_last_validated_commit
+            ):
+                return True
+
+            for repo_name in self.state.users_target_repositories:
+                if repo_name in self.excluded_target_names:
+                    continue
+                if repo_name not in last_validated_data:
+                    return True
+                if last_validated_data[repo_name] != auth_repo_commit:
+                    return True
+            return False
+
+        self.state.is_partially_updated = _previous_update_partial()
 
     def _check_if_target_repos_clean(self, target_repos, branches_per_repo):
         dirty_index_repos = []

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -666,7 +666,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
 
         is_partial = _previous_update_partial()
         self.state.is_partially_updated = is_partial
-        if is_partial:
+        if is_partial and not self.only_validate and not self.validate_from_commit:
             self.state.last_validated_commit = (
                 self.state.users_auth_repo.last_validated_data.get(
                     self.state.users_auth_repo.name


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Reworks partial-update detection for exclude-filter flows. Updates with excluded targets are no longer treated as partial when all included repositories validate successfully, and last_validated_commit is now persisted for those runs.

Tested the following:
- Cloned with `repo clone --exclude-filter "repo['type']=='html'" git@github.com:oll-test-repos/mohicanlaw-law.git`
- Ran `taf repo update` and confirmed that the html repo was not cloned
- Deleted the `exclude-filter` entry from `last_validated_commit` and confirmed that the repo was cloned as expected
- Deleted `last_validated_commit` and ran update, condifrming that the validation started from the beginning and was completed successfully.
- Ran integration tests


- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
~Docstrings have been included and/or updated, as appropriate~
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
