### PR TITLE
Updater and valiation fixes. Release 0.38.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][keepachangelog],
 and this project adheres to [Semantic Versioning][semver].
 
+
 ## [Unreleased]
 
 ### Added
@@ -12,6 +13,19 @@ and this project adheres to [Semantic Versioning][semver].
 ### Changed
 
 ### Fixed
+
+
+## [0.38.2]
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Do not overwrite exclude filter when running local validation
+
+[724]: https://github.com/openlawlibrary/taf/pull/724
 
 
 ## [0.38.1]
@@ -1793,7 +1807,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 [keepachangelog]: https://keepachangelog.com/en/1.0.0/
 [semver]: https://semver.org/spec/v2.0.0.html
-[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.38.1...HEAD
+[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.38.2...HEAD
+[0.38.2]: https://github.com/openlawlibrary/taf/compare/v0.38.1...v0.38.2
 [0.38.1]: https://github.com/openlawlibrary/taf/compare/v0.38.0...v0.38.1
 [0.38.0]: https://github.com/openlawlibrary/taf/compare/v0.37.6...v0.38.0
 [0.37.6]: https://github.com/openlawlibrary/taf/compare/v0.37.5...v0.37.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,11 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
-- Do not overwrite exclude filter when running local validation
+- Do not overwrite exclude filter when running local validation ([727])
+- Clear cached repositories before update and validation flows so exclude filters do not reuse stale repository state ([727])
+- Allow set literals in exclude_filter expressions ([727])
 
-[724]: https://github.com/openlawlibrary/taf/pull/724
+[727]: https://github.com/openlawlibrary/taf/pull/727
 
 
 ## [0.38.1]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 PACKAGE_NAME = "taf"
-VERSION = "0.38.1"
+VERSION = "0.38.2"
 AUTHOR = "Open Law Library"
 AUTHOR_EMAIL = "info@openlawlib.org"
 DESCRIPTION = "Implementation of archival authentication"

--- a/taf/repositoriesdb.py
+++ b/taf/repositoriesdb.py
@@ -30,6 +30,8 @@ from taf.models.types import Commitish
 
 _repositories_dict: Dict = {}
 _dependencies_dict: Dict = {}
+
+
 REPOSITORIES_JSON_NAME = "repositories.json"
 DEPENDENCIES_JSON_NAME = "dependencies.json"
 MIRRORS_JSON_NAME = "mirrors.json"
@@ -190,9 +192,10 @@ def load_repositories(
     """
     Creates target repositories by reading repositories.json and targets.json files
     at the specified revisions, given an authentication repo.
-    If the the commits are not specified, targets will be created based on the HEAD pointer
+    If the commits are not specified, targets will be created based on the HEAD pointer
     of the authentication repository. It is possible to specify git repository class that
     will be created per target.
+
     Args:
         auth_repo: the authentication repository
         target_classes: a single git repository class, or a dictionary whose keys are
@@ -216,6 +219,9 @@ def load_repositories(
         roles: a list of roles whose repositories should be loaded. The repositories linked to a specific
         role are determined based on its targets, so there is no need to set only_load_targets to True.
         If only_load_targets is True and roles is not set, all roles will be taken into consideration.
+        exclude_filter: an optional Python expression string evaluated against each repository's
+        custom metadata. Repositories for which the expression is truthy are excluded from the
+        loaded set.
     """
     global _repositories_dict
     new_reps = _load_repositories(
@@ -761,7 +767,8 @@ def get_auth_repositories(
 
 
 def get_repositories(
-    auth_repo: AuthenticationRepository, commit: Optional[Commitish] = None
+    auth_repo: AuthenticationRepository,
+    commit: Optional[Commitish] = None,
 ) -> Dict[str, GitRepository]:
     return _get_repositories(auth_repo, commit)
 
@@ -1003,6 +1010,9 @@ def _validate_filter_expression(filter_expr: str) -> None:
     """
     if not filter_expr:
         return
+
+    taf_logger.debug("Validating filter Python expression: {}", filter_expr)
+
     try:
         tree = ast.parse(filter_expr, mode="eval")
     except SyntaxError as e:
@@ -1044,6 +1054,7 @@ def _validate_filter_expression(filter_expr: str) -> None:
         ast.Attribute,
         ast.List,
         ast.Tuple,
+        ast.Set,
         ast.Dict,
         # Comparison operators
         ast.Eq,
@@ -1087,3 +1098,5 @@ def _validate_filter_expression(filter_expr: str) -> None:
                     "Function calls not allowed in filter expressions "
                     "(except dict methods like .get())"
                 )
+
+    taf_logger.debug("Validated safe filter expression: {}", filter_expr)

--- a/taf/tests/test_repositoriesdb/test_repositoriesdb.py
+++ b/taf/tests/test_repositoriesdb/test_repositoriesdb.py
@@ -120,16 +120,17 @@ def test_safe_filter_expressions_are_allowed():
     """Test that safe filter expressions do not raise errors."""
 
     safe_expressions = [
-        "repo['type'] == 'html'",
-        "repo['type'] != 'html'",
+        "repo['type'] == 'type1'",
+        "repo['type'] != 'type1'",
         "repo.get('serve') == 'latest'",
         "repo.get('serve') == 'historical'",
         "not repo.get('archived')",
-        "repo['type'] == 'html' and repo['serve'] == 'latest'",
-        "repo['type'] == 'html' or repo.get('archived')",
+        "repo['type'] == 'type1' and repo['serve'] == 'latest'",
+        "repo['type'] == 'type1' or repo.get('archived')",
         "repo.get('nonexistent', 'default') == 'default'",
         "'type' in repo",
         "repo.get('archived') is None",
+        "repo['type'] in {'type1', 'type2'}",
     ]
 
     for expr in safe_expressions:

--- a/taf/tests/test_updater/test_clone/test_clone_partial.py
+++ b/taf/tests/test_updater/test_clone/test_clone_partial.py
@@ -16,8 +16,8 @@ from taf.tests.test_updater.conftest import (
     [
         {
             "targets_config": [
-                {"name": "target_same1", "custom": {"type": "html"}},
-                {"name": "target_same2", "custom": {"type": "xml"}},
+                {"name": "target_same1", "custom": {"type": "type1"}},
+                {"name": "target_same2", "custom": {"type": "type2"}},
                 {"name": "target_different", "custom": {"random": "value"}},
             ],
         },
@@ -49,8 +49,8 @@ def test_clone_with_excluded_targets(origin_auth_repo, client_dir):
     [
         {
             "targets_config": [
-                {"name": "target_same1", "custom": {"type": "html"}},
-                {"name": "target_same2", "custom": {"type": "xml"}},
+                {"name": "target_same1", "custom": {"type": "type1"}},
+                {"name": "target_same2", "custom": {"type": "type2"}},
                 {"name": "target_different", "custom": {"random": "value"}},
             ],
         },
@@ -70,7 +70,7 @@ def test_clone_with_filter(origin_auth_repo, client_dir):
         origin_auth_repo,
         client_dir,
         expected_repo_type=expected_repo_type,
-        exclude_filter="repo['type'] == 'html'",
+        exclude_filter="repo['type'] == 'type1'",
     )
     verify_repos_exist(client_dir, origin_auth_repo, excluded=["target_same1"])
     verify_excluded_lvc_entries(client_dir, origin_auth_repo, excluded=["target_same1"])

--- a/taf/tests/test_updater/test_clone/test_clone_valid.py
+++ b/taf/tests/test_updater/test_clone/test_clone_valid.py
@@ -249,6 +249,39 @@ def test_valid_clone_when_exclude_target(
 
 
 @pytest.mark.parametrize(
+    "origin_auth_repo, exclude_filter",
+    [
+        (
+            {
+                "targets_config": [
+                    {"name": "target_type1", "custom": {"type": "type1"}},
+                    {"name": "target_type2", "custom": {"type": "type2"}},
+                    {"name": "target_type3", "custom": {"type": "type3"}},
+                ],
+            },
+            "repo['type'] in {'type1', 'type2'}",
+        )
+    ],
+    indirect=["origin_auth_repo"],
+)
+def test_valid_clone_when_exclude_target_with_set_literal(
+    origin_auth_repo,
+    exclude_filter,
+    client_dir,
+):
+    update_and_check_commit_shas(
+        OperationType.CLONE,
+        origin_auth_repo,
+        client_dir,
+        expected_repo_type=UpdateType.EITHER,
+        exclude_filter=exclude_filter,
+    )
+    verify_excluded_lvc_entries(
+        client_dir, origin_auth_repo, excluded=["target_type1", "target_type2"]
+    )
+
+
+@pytest.mark.parametrize(
     "origin_auth_repo, existing_target_repositories",
     [
         (

--- a/taf/tests/test_updater/test_update/test_update_partial.py
+++ b/taf/tests/test_updater/test_update/test_update_partial.py
@@ -200,14 +200,14 @@ def test_update_after_partial_clone_with_deleted_lvc(origin_auth_repo, client_di
     [
         {
             "targets_config": [
-                {"name": "target_html", "custom": {"type": "html"}},
-                {"name": "target_xml", "custom": {"type": "xml"}},
+                {"name": "target_type1", "custom": {"type": "type1"}},
+                {"name": "target_type2", "custom": {"type": "type2"}},
             ],
         },
     ],
     indirect=True,
 )
-def test_update_after_clone_with_html_filter_remove_exclude_from_lvc(
+def test_update_after_clone_with_type1_filter_remove_exclude_from_lvc(
     origin_auth_repo, client_dir
 ):
     setup_manager = SetupManager(origin_auth_repo)
@@ -222,10 +222,10 @@ def test_update_after_clone_with_html_filter_remove_exclude_from_lvc(
         origin_auth_repo,
         client_dir,
         expected_repo_type=expected_repo_type,
-        exclude_filter="repo['type'] == 'html'",
+        exclude_filter="repo['type'] == 'type1'",
     )
-    verify_repos_exist(client_dir, origin_auth_repo, excluded=["target_html"])
-    verify_excluded_lvc_entries(client_dir, origin_auth_repo, excluded=["target_html"])
+    verify_repos_exist(client_dir, origin_auth_repo, excluded=["target_type1"])
+    verify_excluded_lvc_entries(client_dir, origin_auth_repo, excluded=["target_type1"])
 
     # Remove exclude_filter from LVC so the next update includes all repos
     client_auth_repo = AuthenticationRepository(path=client_dir / origin_auth_repo.name)
@@ -233,7 +233,7 @@ def test_update_after_clone_with_html_filter_remove_exclude_from_lvc(
     lvc_data.pop("exclude_filter", None)
     client_auth_repo.set_last_validated_data(lvc_data, set_last_validated_commit=False)
 
-    # Update should now clone and validate all repos, including html
+    # Update should now clone and validate all repos, including type1
     update_and_check_commit_shas(
         OperationType.UPDATE,
         origin_auth_repo,
@@ -248,9 +248,9 @@ def test_update_after_clone_with_html_filter_remove_exclude_from_lvc(
     [
         {
             "targets_config": [
-                {"name": "target_html", "custom": {"type": "html"}},
-                {"name": "target_xml1"},
-                {"name": "target_xml2"},
+                {"name": "target_type1", "custom": {"type": "type1"}},
+                {"name": "target_type2a"},
+                {"name": "target_type2b"},
             ],
         },
     ],
@@ -271,7 +271,7 @@ def test_last_validated_commit_set_on_exclude_not_updated_on_partial_error(
         origin_auth_repo,
         client_dir,
         expected_repo_type=expected_repo_type,
-        exclude_filter="repo['type'] == 'html'",
+        exclude_filter="repo['type'] == 'type1'",
     )
 
     client_auth_repo = AuthenticationRepository(path=client_dir / origin_auth_repo.name)
@@ -282,10 +282,11 @@ def test_last_validated_commit_set_on_exclude_not_updated_on_partial_error(
         == client_auth_repo.head_commit().hash
     )
 
-    # Sandwich target_xml2: valid → unsigned → valid again, so there is an unsigned commit
+    # Sandwich target_type2b: valid -> unsigned -> valid again, so there is an unsigned commit
     setup_manager.add_task(add_valid_target_commits)
     setup_manager.add_task(
-        add_unauthenticated_commit_to_target_repo, kwargs={"target_name": "target_xml2"}
+        add_unauthenticated_commit_to_target_repo,
+        kwargs={"target_name": "target_type2b"},
     )
     setup_manager.add_task(add_valid_target_commits)
     setup_manager.execute_tasks()
@@ -293,11 +294,11 @@ def test_last_validated_commit_set_on_exclude_not_updated_on_partial_error(
     client_target_repos = load_target_repositories(
         origin_auth_repo, library_dir=client_dir
     )
-    client_xml1 = next(
-        repo for name, repo in client_target_repos.items() if "target_xml1" in name
+    client_type2a = next(
+        repo for name, repo in client_target_repos.items() if "target_type2a" in name
     )
 
-    # Update partially fails: xml2 has an unsigned commit sandwiched between two signed commits
+    # Update partially fails: type2b has an unsigned commit sandwiched between two signed commits
     update_invalid_repos_and_check_if_repos_exist(
         OperationType.UPDATE,
         origin_auth_repo,
@@ -306,9 +307,11 @@ def test_last_validated_commit_set_on_exclude_not_updated_on_partial_error(
         expect_partial_update=True,
     )
 
-    # target_xml1 (only valid commits) was fully updated to match the origin
-    origin_xml1 = GitRepository(origin_auth_repo.path.parent.parent, client_xml1.name)
-    assert client_xml1.head_commit() == origin_xml1.head_commit()
+    # target_type2a (only valid commits) was fully updated to match the origin
+    origin_type2a = GitRepository(
+        origin_auth_repo.path.parent.parent, client_type2a.name
+    )
+    assert client_type2a.head_commit() == origin_type2a.head_commit()
 
     # last_validated_commit was not updated to the latest origin auth head —
     # it reflects only the last auth commit where all repos were fully consistent

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -339,6 +339,7 @@ def update_repository(config: UpdateConfig):
     Returns:
         None
     """
+    repositoriesdb.clear_repositories_db()
     settings.strict = config.strict
     settings.run_scripts = config.run_scripts
 
@@ -645,6 +646,7 @@ def validate_repository(
     no_deps=False,
     no_upstream=True,
 ):
+    repositoriesdb.clear_repositories_db()
     update_from_filesystem = settings.update_from_filesystem
     settings.strict = strict
 

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -1278,7 +1278,11 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
             else:
                 # Load exclude_filter from last_validated_data saved by a previous clone/update
                 last_validated_data = self.state.users_auth_repo.last_validated_data
-                self.exclude_filter = last_validated_data.get("exclude_filter") or None
+                # exclude filter can be specified if running local validation
+                if not self.exclude_filter:
+                    self.exclude_filter = (
+                        last_validated_data.get("exclude_filter") or None
+                    )
 
             if self.exclude_filter:
                 excluded_repo_names = repositoriesdb.get_repository_names_by_expression(

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -659,6 +659,12 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                 )
             return UpdateStatus.SUCCESS
         except Exception as e:
+            taf_logger.error(
+                "{}: Failed to set excluded targets with exclude_filter {}: {}",
+                self.state.users_auth_repo.name,
+                repr(self.exclude_filter),
+                e,
+            )
             self.state.errors.append(e)
             self.state.event = Event.FAILED
             return UpdateStatus.FAILED
@@ -674,11 +680,10 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
         local_repos_consistent=False and the full update runs unconditionally.
         """
         try:
-            self.local_repos_consistent = False
-
             if not self.state.existing_repo:
                 return UpdateStatus.SUCCESS
 
+            self.local_repos_consistent = False
             auth_repo = self.state.users_auth_repo
             taf_logger.info(
                 f"{auth_repo.name}: Checking if local state is consistent with last validated data"
@@ -763,6 +768,10 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                 f"{self.state.users_auth_repo.name}: Reset to last validated commit failed, "
                 f"proceeding with full validation. Reason: {e}"
             )
+        except Exception as e:
+            self.state.errors.append(e)
+            self.state.event = Event.FAILED
+            return UpdateStatus.FAILED
 
         return UpdateStatus.SUCCESS
 


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

- Preserve a caller-provided exclude_filter during local validation instead of always overwriting it from last_validated_data
- Clear repositoriesdb before update and validation entrypoints so stale cached repository state from unrelated earlier calls does not affect later filtered loads
- Allow set literals in exclude_filter Python expressions

Release 0.38.2

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
