### PR TITLE
fix: raise PygitError instead of AttributeError when pygit2 unavailable

### DIFF
--- a/taf/git.py
+++ b/taf/git.py
@@ -174,7 +174,12 @@ class GitRepository:
     @property
     def is_detached_head(self) -> bool:
         repo = self.pygit_repo
-        return repo.head_is_detached
+        try:
+            return repo.head_is_detached
+        except AttributeError:
+            raise PygitError(
+                "pygit2 repository is unavailable; cannot determine HEAD state"
+            )
 
     @property
     def is_git_repository(self) -> bool:
@@ -238,11 +243,11 @@ class GitRepository:
     @property
     def is_bare_repository(self) -> bool:
         if self._is_bare_repo is None:
-            if self.pygit_repo is not None:
+            try:
                 self._is_bare_repo = self.pygit_repo.is_bare
-            else:
-                raise GitError(
-                    "Cannot determine if repository is a bare repository. Cannot instantiate pygit repository"
+            except AttributeError:
+                raise PygitError(
+                    "pygit2 repository is unavailable; cannot determine if repository is bare"
                 )
 
         return self._is_bare_repo
@@ -384,7 +389,12 @@ class GitRepository:
         repo = self.pygit_repo
 
         if branch:
-            branch_obj = repo.branches.get(branch)
+            try:
+                branch_obj = repo.branches.get(branch)
+            except AttributeError:
+                raise PygitError(
+                    f"pygit2 repository is unavailable; cannot list commits on branch {branch}"
+                )
             if branch_obj is None:
                 raise GitError(
                     self,
@@ -490,12 +500,17 @@ class GitRepository:
         """Returns all branches."""
         repo = self.pygit_repo
 
-        if all:
-            branches = set(repo.branches)
-        elif remote:
-            branches = set(repo.branches.remote)
-        else:
-            branches = set(repo.branches.local)
+        try:
+            if all:
+                branches = set(repo.branches)
+            elif remote:
+                branches = set(repo.branches.remote)
+            else:
+                branches = set(repo.branches.local)
+        except AttributeError:
+            raise PygitError(
+                "pygit2 repository is unavailable; cannot list branches"
+            )
 
         if strip_remote:
             remotes = self.remotes
@@ -552,7 +567,12 @@ class GitRepository:
         """
         repo = self.pygit_repo
 
-        branch = repo.branches.get(branch_name)
+        try:
+            branch = repo.branches.get(branch_name)
+        except AttributeError:
+            raise PygitError(
+                f"pygit2 repository is unavailable; cannot check if branch {branch_name} exists"
+            )
         # this git command should return the branch's name if it exists
         # empty string otherwise
         if branch is not None:
@@ -1450,11 +1470,16 @@ class GitRepository:
     def list_pygit_commits(self, branch: Optional[str] = "") -> List[pygit2.Commit]:
         repo = self.pygit_repo
 
-        if branch:
-            branch_obj = repo.branches.get(branch)
-            latest_commit_id = branch_obj.target
-        else:
-            latest_commit_id = repo[repo.head.target].id
+        try:
+            if branch:
+                branch_obj = repo.branches.get(branch)
+                latest_commit_id = branch_obj.target
+            else:
+                latest_commit_id = repo[repo.head.target].id
+        except AttributeError:
+            raise PygitError(
+                "pygit2 repository is unavailable; cannot list pygit commits"
+            )
 
         return [commit for commit in repo.walk(latest_commit_id, pygit2.GIT_SORT_NONE)]
 

--- a/taf/git.py
+++ b/taf/git.py
@@ -6,7 +6,6 @@ import os
 import re
 import shutil
 import uuid
-import pygit2
 import subprocess
 import logging
 import time
@@ -33,7 +32,16 @@ from taf.exceptions import (
 from taf.log import NOTICE, taf_logger
 from taf.utils import run
 from typing import Callable, Dict, List, Optional, Tuple, Union
-from .pygit import PyGitRepository
+
+try:
+    import pygit2
+    from .pygit import PyGitRepository
+
+    PYGIT2_AVAILABLE = True
+except ImportError:
+    pygit2 = None
+    PyGitRepository = None
+    PYGIT2_AVAILABLE = False
 
 EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
@@ -113,6 +121,8 @@ class GitRepository:
 
     @property
     def pygit(self):
+        if not PYGIT2_AVAILABLE:
+            raise PygitError("pygit2 is not installed")
         if self._pygit is None:
             if not self.is_git_repository:
                 raise GitError(
@@ -174,12 +184,7 @@ class GitRepository:
     @property
     def is_detached_head(self) -> bool:
         repo = self.pygit_repo
-        try:
-            return repo.head_is_detached
-        except AttributeError:
-            raise PygitError(
-                "pygit2 repository is unavailable; cannot determine HEAD state"
-            )
+        return repo.head_is_detached
 
     @property
     def is_git_repository(self) -> bool:
@@ -243,12 +248,7 @@ class GitRepository:
     @property
     def is_bare_repository(self) -> bool:
         if self._is_bare_repo is None:
-            try:
-                self._is_bare_repo = self.pygit_repo.is_bare
-            except AttributeError:
-                raise PygitError(
-                    "pygit2 repository is unavailable; cannot determine if repository is bare"
-                )
+            self._is_bare_repo = self.pygit_repo.is_bare
 
         return self._is_bare_repo
 
@@ -389,12 +389,7 @@ class GitRepository:
         repo = self.pygit_repo
 
         if branch:
-            try:
-                branch_obj = repo.branches.get(branch)
-            except AttributeError:
-                raise PygitError(
-                    f"pygit2 repository is unavailable; cannot list commits on branch {branch}"
-                )
+            branch_obj = repo.branches.get(branch)
             if branch_obj is None:
                 raise GitError(
                     self,
@@ -500,17 +495,12 @@ class GitRepository:
         """Returns all branches."""
         repo = self.pygit_repo
 
-        try:
-            if all:
-                branches = set(repo.branches)
-            elif remote:
-                branches = set(repo.branches.remote)
-            else:
-                branches = set(repo.branches.local)
-        except AttributeError:
-            raise PygitError(
-                "pygit2 repository is unavailable; cannot list branches"
-            )
+        if all:
+            branches = set(repo.branches)
+        elif remote:
+            branches = set(repo.branches.remote)
+        else:
+            branches = set(repo.branches.local)
 
         if strip_remote:
             remotes = self.remotes
@@ -567,12 +557,7 @@ class GitRepository:
         """
         repo = self.pygit_repo
 
-        try:
-            branch = repo.branches.get(branch_name)
-        except AttributeError:
-            raise PygitError(
-                f"pygit2 repository is unavailable; cannot check if branch {branch_name} exists"
-            )
+        branch = repo.branches.get(branch_name)
         # this git command should return the branch's name if it exists
         # empty string otherwise
         if branch is not None:
@@ -802,6 +787,8 @@ class GitRepository:
         keep_remote=False,
         branches=None,
     ) -> None:
+        if not PYGIT2_AVAILABLE:
+            raise PygitError("pygit2 is not installed")
         self.path.mkdir(parents=True, exist_ok=True)
         pygit2.clone_repository(local_path, self.path, bare=is_bare)
         if not self.is_git_repository:
@@ -1470,16 +1457,11 @@ class GitRepository:
     def list_pygit_commits(self, branch: Optional[str] = "") -> List[pygit2.Commit]:
         repo = self.pygit_repo
 
-        try:
-            if branch:
-                branch_obj = repo.branches.get(branch)
-                latest_commit_id = branch_obj.target
-            else:
-                latest_commit_id = repo[repo.head.target].id
-        except AttributeError:
-            raise PygitError(
-                "pygit2 repository is unavailable; cannot list pygit commits"
-            )
+        if branch:
+            branch_obj = repo.branches.get(branch)
+            latest_commit_id = branch_obj.target
+        else:
+            latest_commit_id = repo[repo.head.target].id
 
         return [commit for commit in repo.walk(latest_commit_id, pygit2.GIT_SORT_NONE)]
 

--- a/taf/tests/test_git/test_git.py
+++ b/taf/tests/test_git/test_git.py
@@ -4,7 +4,8 @@ from pygit2 import AlreadyExistsError
 from taf.models.types import Commitish
 import pytest
 import tempfile
-from taf.exceptions import GitError, NothingToCommitError
+from taf.exceptions import GitError, NothingToCommitError, PygitError
+import taf.git as git_module
 from taf.git import GitRepository
 
 
@@ -30,6 +31,14 @@ def test_head_commit_sha_when_no_repo():
             match=f"Repo {repo.name}: The path '{repo.path.as_posix()}' is not a Git repository.",
         ):
             repo.head_commit() is not None
+
+
+def test_pygit_requires_pygit2(monkeypatch, repository):
+    monkeypatch.setattr(git_module, "PYGIT2_AVAILABLE", False)
+    repo = GitRepository(path=repository.path, default_branch=repository.default_branch)
+
+    with pytest.raises(PygitError, match="pygit2 is not installed"):
+        _ = repo.pygit
 
 
 def test_clone(origin_repo: GitRepository, clone_repository: GitRepository):
@@ -83,6 +92,14 @@ def test_clone_from_local(repository: GitRepository, clone_repository: GitReposi
     assert clone_repository.is_git_repository
     commits = clone_repository.all_commits_on_branch()
     assert len(commits)
+
+
+def test_clone_from_disk_requires_pygit2(monkeypatch, tmp_path):
+    monkeypatch.setattr(git_module, "PYGIT2_AVAILABLE", False)
+    repo = GitRepository(path=tmp_path / "clone", default_branch="main")
+
+    with pytest.raises(PygitError, match="pygit2 is not installed"):
+        repo.clone_from_disk(tmp_path / "source")
 
 
 def test_branches(repository: GitRepository):


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Fixes #728. Instead of catching `AttributeError` in individual repository accessors, this now fails at the `pygit2` integration boundary: `git.py` sets a `PYGIT2_AVAILABLE` flag during import, `pygit` raises `PygitError("pygit2 is not installed")` before touching the repository when that dependency is unavailable, and `clone_from_disk` applies the same guard before calling `pygit2` directly. Regression tests cover both guarded paths.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
