### PR TITLE
fix: out-of-band fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Fix false out-of-band authentication failures on update and clone
+
 
 ## [0.38.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
-- Fix false out-of-band authentication failures on update and clone
+- Fix false out-of-band authentication failures on update and clone ([740])
+
+[740]: https://github.com/openlawlibrary/taf/pull/740
 
 
 ## [0.38.3]

--- a/taf/auth_repo.py
+++ b/taf/auth_repo.py
@@ -169,11 +169,9 @@ class AuthenticationRepository(GitRepository):
         Last validated commit across the entire set of repositories, including authentication and target repositories.
         It is only validated if the update process does not skip any repository
         """
-        try:
-            if self.last_validated_data is not None:
-                return self.last_validated_data[self.LAST_VALIDATED_KEY]
-        except KeyError:
-            return None
+        data = self.last_validated_data
+        if data is not None:
+            return data.get(self.LAST_VALIDATED_KEY) or data.get(self.name)
         return None
 
     @property

--- a/taf/repositoriesdb.py
+++ b/taf/repositoriesdb.py
@@ -732,13 +732,6 @@ def _get_deduplicated_target_or_auth_repositories(
             # will overwrite older repo with newer
             repositories[name] = repo
 
-    # Drop repos absent from the latest commit so stale historical entries
-    # don't survive after a dependency is removed or moved.
-    latest_repos = set(all_repositories.get(commits[-1], {}).keys())
-    repositories = {
-        name: repo for name, repo in repositories.items() if name in latest_repos
-    }
-
     taf_logger.debug(
         "Auth repo {}: deduplicated list of {} repositories {}",
         auth_repo.path,

--- a/taf/repositoriesdb.py
+++ b/taf/repositoriesdb.py
@@ -732,6 +732,13 @@ def _get_deduplicated_target_or_auth_repositories(
             # will overwrite older repo with newer
             repositories[name] = repo
 
+    # Drop repos absent from the latest commit so stale historical entries
+    # don't survive after a dependency is removed or moved.
+    latest_repos = set(all_repositories.get(commits[-1], {}).keys())
+    repositories = {
+        name: repo for name, repo in repositories.items() if name in latest_repos
+    }
+
     taf_logger.debug(
         "Auth repo {}: deduplicated list of {} repositories {}",
         auth_repo.path,

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -476,17 +476,16 @@ def _process_repo_update(
     if commits_data.after_pull is not None and not update_config.no_deps:
 
         if update_status != Event.FAILED:
-            # for now, just take the newest commit and do not worry about updated definitions
-            # latest_commit = commits[-1::]
+            latest_commit = commits[-1:]
             repositoriesdb.load_dependencies(
                 auth_repo,
                 library_dir=update_config.library_dir,
-                commits=commits,
+                commits=latest_commit,
             )
 
             # load the repositories from dependencies.json and update these repositories
             child_auth_repos = repositoriesdb.get_deduplicated_auth_repositories(
-                auth_repo, commits
+                auth_repo, latest_commit
             ).values()
             outputs, errors = _update_dependencies(update_config, child_auth_repos)
             if len(errors):


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

1. Fall back to the per-repo key when the global last_validated_commit key is missing from the validated-commit file (written without it by older TAF on partial updates).
2. Drop deps absent from the latest commit during deduplication so a moved dependency doesn't get validated against its old out of band hash from the originating repo's history.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
