### PR TITLE
Raise clear error when default branch not found in local repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Raise clear error when default branch not found in local repo [(742)]
 - Fix false out-of-band authentication failures on update and clone ([740])
 
+[742]: https://github.com/openlawlibrary/taf/pull/742
 [740]: https://github.com/openlawlibrary/taf/pull/740
 
 

--- a/taf/tests/test_updater/conftest.py
+++ b/taf/tests/test_updater/conftest.py
@@ -83,6 +83,7 @@ INVALID_AUTH_COMMIT_RESET_ERROR = "An error occured during auth repo commit chec
 UNCOMMITTED_CHANGES_RESET_PATTERN = r"There are uncommited changes in ([A-Za-z0-9_\-\[\]]+/[A-Za-z0-9_\-\[\]]+)\. Please commit/stash changes or run reset with force flag."
 DETACHED_HEAD_RESET_PATTERN = r"(\w+\/\w+) is in detached head state. Fix the state manually or run reset with force flag."
 OLD_LVC_FORMAT_ERROR_PATTERN = r"Failure to set excluded targets for repo (\w+\/\w+) - last_validated_commit file is in old format which is not supported anymore. Please delete the file and re-run the command."
+DEFAULT_BRANCH_NOT_FOUND_PATTERN = r"Update of ([\w/]+) failed due to error: Could not find branch '[\w-]+' in local repository ([\w/]+)\. This can happen if the repository's default branch was changed after cloning\. Please re-clone the repository using 'taf repo clone'\."
 
 
 # Disable console logging for all tests

--- a/taf/tests/test_updater/test_update/test_update_invalid.py
+++ b/taf/tests/test_updater/test_update/test_update_invalid.py
@@ -2,6 +2,7 @@ from taf.models.types import Commitish
 import pytest
 from taf.auth_repo import AuthenticationRepository
 from taf.tests.test_updater.conftest import (
+    DEFAULT_BRANCH_NOT_FOUND_PATTERN,
     INVALID_KEYS_PATTERN,
     LVC_NOT_IN_REMOTE_PATTERN,
     TARGET_MISSMATCH_PATTERN,
@@ -22,6 +23,8 @@ from taf.tests.test_updater.update_utils import (
     update_invalid_repos_and_check_if_repos_exist,
 )
 from taf.updater.types.update import OperationType
+
+from taf.git import GitRepository
 
 
 @pytest.mark.parametrize(
@@ -177,5 +180,34 @@ def test_update_when_old_last_validated_commit(origin_auth_repo, client_dir):
         origin_auth_repo,
         client_dir,
         OLD_LVC_FORMAT_ERROR_PATTERN,
+        True,
+    )
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [{"name": "target1"}, {"name": "target2"}],
+        },
+    ],
+    indirect=True,
+)
+def test_update_fails_when_default_branch_not_in_local_repo(
+    origin_auth_repo, client_dir, monkeypatch
+):
+    clone_repositories(origin_auth_repo, client_dir)
+
+    monkeypatch.setattr(
+        GitRepository,
+        "get_default_branch",
+        lambda self, url=None: "non-existent-branch",
+    )
+
+    update_invalid_repos_and_check_if_repos_exist(
+        OperationType.UPDATE,
+        origin_auth_repo,
+        client_dir,
+        DEFAULT_BRANCH_NOT_FOUND_PATTERN,
         True,
     )

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -608,6 +608,16 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                 )
                 return UpdateStatus.SUCCESS
 
+            if auth_repo.default_branch and not auth_repo.branch_exists(
+                auth_repo.default_branch, include_remotes=False
+            ):
+                raise UpdateFailedError(
+                    f"Could not find branch '{auth_repo.default_branch}' in local repository "
+                    f"{auth_repo.name}. "
+                    "This can happen if the repository's default branch was changed after cloning. "
+                    "Please re-clone the repository using 'taf repo clone'."
+                )
+
             if auth_repo.something_to_commit():
                 if self.force:
                     taf_logger.info(


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

If the remote repository's default branch was changed after the local clone was made, top_commit_of_branch returns None and the updater would crash with 'NoneType' object has no attribute 'hash'.

Fix #741

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
