### PR TITLE
refact: Performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Changed
 
+- Reduce `taf repo clone` and `taf repo update` execution time by eliminating redundant network fetches ([743])
+- Improve TAF performance by roughly two thirds for both `clone` and `update` ([743])
+
 ### Fixed
 
 
@@ -28,6 +31,7 @@ and this project adheres to [Semantic Versioning][semver].
 - Fix false out-of-band authentication failures on update and clone ([740])
 
 [744]: https://github.com/openlawlibrary/taf/pull/744
+[743]: https://github.com/openlawlibrary/taf/pull/743
 [742]: https://github.com/openlawlibrary/taf/pull/742
 [740]: https://github.com/openlawlibrary/taf/pull/740
 

--- a/taf/git.py
+++ b/taf/git.py
@@ -179,6 +179,8 @@ class GitRepository:
 
     _is_bare_repo = None
 
+    _is_git_repository = None
+
     @property
     def remotes(self) -> List[str]:
         if self._remotes is None:
@@ -195,17 +197,44 @@ class GitRepository:
 
     @property
     def is_git_repository(self) -> bool:
-        """Check if the given path is the root of a Git repository."""
+        """Check if the given path is inside a Git repository (work tree or bare)."""
         # This is used when instantiating a PyGitRepository repo, so do not use
-        # it here
+        # self.pygit / self.pygit_repo here (would recurse via the pygit property).
+        #
+        # Only a positive result is cached. A path that is not (yet) a repository
+        # can become one later - e.g. a GitRepository instance is created for a
+        # path before init_repo()/clone() runs, or before the updater (a
+        # different instance, or an external process) materializes it on disk.
+        # Caching the negative result would make this instance permanently report
+        # the path as a non-repository even after a valid .git appears, so we
+        # recompute until the answer is True.
+        if self._is_git_repository:
+            return True
+        # pygit2.discover_repository is a module-level function that searches
+        # upward for a repository, matching the semantics of the subprocess
+        # `rev-parse --is-inside-work-tree` / `--is-bare-repository` checks but
+        # without spawning a process (~150-400ms each on Windows).
+        if PYGIT2_AVAILABLE and not self.allow_unsafe:
+            try:
+                if pygit2.discover_repository(str(self.path)) is not None:
+                    self._is_git_repository = True
+                    return True
+                return False
+            except Exception:
+                # fall back to the subprocess check (e.g. ownership errors)
+                pass
+        # subprocess fallback: pygit2 unavailable, or allow_unsafe is set
+        # (libgit2 does not honor the `-c safe.directory` override the
+        # subprocess path uses)
         try:
             result = self._git("rev-parse --is-inside-work-tree", reraise_error=True)
             if result == "true":
+                self._is_git_repository = True
                 return True
             result = self._git("rev-parse --is-bare-repository", reraise_error=True)
             if result == "true":
+                self._is_git_repository = True
                 return True
-
         except GitError:
             return False
         return False
@@ -213,8 +242,6 @@ class GitRepository:
     @property
     def is_git_repository_root(self) -> bool:
         try:
-            if not self.is_git_repository:
-                return False
             repo = self.pygit_repo
             if repo is None:
                 return False
@@ -225,7 +252,7 @@ class GitRepository:
                 return Path(repo.path).resolve() == git_path.resolve() and (
                     git_path.is_dir() or git_path.is_file()
                 )
-        except PygitError:
+        except (PygitError, GitError):
             return False
 
     @property
@@ -321,7 +348,16 @@ class GitRepository:
         In those cases, get the default branch from `git remote show origin`.
 
         If the repository does not have a remote set, use `symbolic-ref` HEAD
+
+        The cheap symbolic-ref reads (steps 1 and 3) are done in-process via
+        pygit2 when possible to avoid spawning subprocesses (~150-400ms each on
+        Windows); each falls back to the subprocess equivalent on any failure,
+        so behavior is a strict superset of the previous implementation.
         """
+        # step 1: refs/remotes/origin/HEAD
+        branch = self._symbolic_ref_branch_via_pygit("refs/remotes/origin/HEAD")
+        if branch is not None:
+            return branch
         try:
             branch = self._git(
                 "symbolic-ref refs/remotes/origin/HEAD --short", reraise_error=True
@@ -330,6 +366,7 @@ class GitRepository:
         except GitError as e:
             self._log_debug(f"Could not get remote HEAD at {self.path}: {e}")
             pass
+        # step 2: git remote show origin (may contact the network; subprocess only)
         try:
             result = self._git("remote show origin", reraise_error=True)
             match = re.search(r"HEAD branch:(.*)", result)
@@ -340,6 +377,10 @@ class GitRepository:
                 f"Could not get HEAD branch with git remote show origin at {self.path}: {e}"
             )
             pass
+        # step 3: HEAD
+        branch = self._symbolic_ref_branch_via_pygit("HEAD")
+        if branch is not None:
+            return branch
         try:
             return self._git("symbolic-ref HEAD --short", reraise_error=True)
         except GitError as e:
@@ -349,6 +390,45 @@ class GitRepository:
             self,
             message="Could not determine default branch from local repository",
         )
+
+    def _symbolic_ref_branch_via_pygit(self, ref_name: str) -> Optional[str]:
+        """Return the short branch name a symbolic ref points to, read in-process
+        via pygit2, or None on any failure (so the caller falls back to the
+        subprocess equivalent). Only symbolic refs yield a branch name.
+
+        Opens a throwaway pygit2.Repository instead of using self.pygit_repo:
+        this method can run before the repository exists on disk (e.g. during
+        construction, ahead of init_repo()/clone()), and discover_repository
+        walks upward, so a not-yet-initialized path nested inside another
+        repository (e.g. a test fixture under this checkout) would otherwise
+        resolve to - and permanently cache on self - that unrelated parent
+        repository.
+        """
+        if not PYGIT2_AVAILABLE:
+            return None
+        try:
+            discovered = pygit2.discover_repository(str(self.path))
+            if discovered is None:
+                return None
+            discovered_path = Path(discovered).resolve()
+            self_path = self.path.resolve()
+            if (
+                discovered_path != self_path
+                and self_path not in discovered_path.parents
+            ):
+                # discovered a different (e.g. parent) repository
+                return None
+            repo = pygit2.Repository(discovered)
+            ref = repo.references.get(ref_name)
+            if ref is None or ref.type != pygit2.GIT_REF_SYMBOLIC:
+                return None
+            target = ref.target  # e.g. "refs/remotes/origin/main" or "refs/heads/main"
+            for prefix in ("refs/remotes/origin/", "refs/heads/"):
+                if target.startswith(prefix):
+                    return target[len(prefix) :]
+            return target
+        except Exception:
+            return None
 
     def _get_default_branch_from_remote(self, url: str) -> str:
         if not self.is_git_repository:
@@ -783,6 +863,10 @@ class GitRepository:
         if not cloned:
             self.raise_git_access_error(CloneRepoException)
 
+        # the path is now a repository; drop any cached negative result from
+        # before the clone
+        self._is_git_repository = None
+
         if self.default_branch is None:
             self.default_branch = self._determine_default_branch()
 
@@ -799,6 +883,9 @@ class GitRepository:
             raise PygitError("pygit2 is not installed")
         self.path.mkdir(parents=True, exist_ok=True)
         pygit2.clone_repository(local_path, self.path, bare=is_bare)
+        # the path is now a repository; drop any cached negative result from
+        # before the clone
+        self._is_git_repository = None
         if not self.is_git_repository:
             raise GitError(
                 self, message=f"Could not clone repository from local path {local_path}"
@@ -1438,6 +1525,7 @@ class GitRepository:
             self.path.mkdir(exist_ok=True, parents=True)
         flag = "--bare" if bare else ""
         self._git(f"init {flag}", error_if_not_exists=False)
+        self._is_git_repository = None
         if self.urls is not None and len(self.urls):
             self._git("remote add origin {}", self.urls[0])
 
@@ -1808,10 +1896,22 @@ class GitRepository:
         if self.is_bare_repository:
             # For bare repositories, use `git diff` to check for uncommitted changes
             uncommitted_changes = self._git("diff --name-only --cached")
-        else:
-            # For non-bare repositories, use `git status`
-            uncommitted_changes = self._git("status --porcelain")
-        return bool(uncommitted_changes)
+            return bool(uncommitted_changes)
+        # For non-bare repositories, check status in-process via pygit2 first.
+        # The common case is a clean repo, which we can confirm without spawning
+        # a subprocess. If pygit2 reports any change, fall back to
+        # `git status --porcelain` as the source of truth (avoids libgit2
+        # stat-cache / CRLF false positives).
+        # pygit2's status() includes untracked and modified files by default
+        # (same set `git status --porcelain` reports), so an empty result means
+        # the working tree is clean.
+        if PYGIT2_AVAILABLE:
+            try:
+                if not self.pygit_repo.status():
+                    return False
+            except Exception:
+                pass
+        return bool(self._git("status --porcelain"))
 
     def synced_with_remote(
         self,
@@ -1935,6 +2035,9 @@ class GitRepository:
             raise PygitError("pygit2 is not installed")
         self.path.mkdir(parents=True, exist_ok=True)
         pygit2.clone_repository(str(local_path), str(self.path), bare=True)
+        # the path is now a repository; drop any cached negative result from
+        # before the clone
+        self._is_git_repository = None
         # Clear cache and reset so the caller's post-setup detection runs cleanly.
         _default_branch_cache.pop(str(self.path), None)
         self.default_branch = None

--- a/taf/git.py
+++ b/taf/git.py
@@ -882,7 +882,16 @@ class GitRepository:
         if not PYGIT2_AVAILABLE:
             raise PygitError("pygit2 is not installed")
         self.path.mkdir(parents=True, exist_ok=True)
-        pygit2.clone_repository(local_path, self.path, bare=is_bare)
+        # `git clone --local` hardlinks objects when source and destination share
+        # a volume (TempPartition guarantees this), which is far cheaper than the
+        # file-by-file object copy pygit2 performs. git silently falls back to
+        # copying when hardlinks are not possible, so this is never slower.
+        bare_flag = "--bare " if is_bare else ""
+        self._git(
+            f"clone --local {bare_flag}{local_path} .",
+            error_if_not_exists=False,
+            reraise_error=True,
+        )
         # the path is now a repository; drop any cached negative result from
         # before the clone
         self._is_git_repository = None
@@ -891,6 +900,10 @@ class GitRepository:
                 self, message=f"Could not clone repository from local path {local_path}"
             )
         repo = self.pygit_repo
+        if is_bare:
+            # `git clone --bare` creates no origin remote (pygit2 did); add it for
+            # parity so the remote handling below behaves identically
+            self.add_remote("origin", str(local_path))
 
         if not keep_remote:
             if remote_url is not None:
@@ -2024,20 +2037,26 @@ class GitRepository:
         return None
 
     def clone_bare_from_local(self, local_path: Path) -> None:
-        """Seed a bare repo from a local path using pygit2 (no network).
+        """Seed a bare repo from a local path (no network).
 
-        Does NOT detect default_branch — the caller must do that after updating
-        origin to the real remote URL, otherwise remote show origin contacts
-        local_path which may be in detached HEAD and returns a bogus branch name
-        that then gets cached and blocks the correct subsequent detection.
+        Uses `git clone --local`, which hardlinks objects on the same volume
+        instead of copying them. Does NOT detect default_branch — the caller
+        must do that after updating origin to the real remote URL, otherwise
+        remote show origin contacts local_path which may be in detached HEAD and
+        returns a bogus branch name that then gets cached and blocks the correct
+        subsequent detection.
         """
-        if not PYGIT2_AVAILABLE:
-            raise PygitError("pygit2 is not installed")
         self.path.mkdir(parents=True, exist_ok=True)
-        pygit2.clone_repository(str(local_path), str(self.path), bare=True)
-        # the path is now a repository; drop any cached negative result from
-        # before the clone
+        self._git(
+            "clone --local --bare {} .",
+            str(local_path),
+            error_if_not_exists=False,
+            reraise_error=True,
+        )
         self._is_git_repository = None
+        # `git clone --bare` creates no origin remote (pygit2 did); add it for
+        # parity so the caller's `remote set-url origin` succeeds
+        self.add_remote("origin", str(local_path))
         # Clear cache and reset so the caller's post-setup detection runs cleanly.
         _default_branch_cache.pop(str(self.path), None)
         self.default_branch = None

--- a/taf/git.py
+++ b/taf/git.py
@@ -201,13 +201,8 @@ class GitRepository:
         # This is used when instantiating a PyGitRepository repo, so do not use
         # self.pygit / self.pygit_repo here (would recurse via the pygit property).
         #
-        # Only a positive result is cached. A path that is not (yet) a repository
-        # can become one later - e.g. a GitRepository instance is created for a
-        # path before init_repo()/clone() runs, or before the updater (a
-        # different instance, or an external process) materializes it on disk.
-        # Caching the negative result would make this instance permanently report
-        # the path as a non-repository even after a valid .git appears, so we
-        # recompute until the answer is True.
+        # Only a positive result is cached: a path that is not (yet) a
+        # repository can become one later.
         if self._is_git_repository:
             return True
         # pygit2.discover_repository is a module-level function that searches
@@ -879,6 +874,15 @@ class GitRepository:
         branches=None,
         fetch_remote: bool = True,
     ) -> None:
+        """Clone this repository from a local path (hardlinking objects).
+
+        ``branches`` are the local branches whose upstream tracking should be
+        restored via ``set_upstream`` after the clone - ``remove_remote`` drops
+        the tracking relationship, so without this ``synced_with_remote()``
+        would report ``False``. ``fetch_remote=False`` populates
+        ``refs/remotes/origin/*`` from the local source instead of fetching the
+        network remote.
+        """
         if not PYGIT2_AVAILABLE:
             raise PygitError("pygit2 is not installed")
         self.path.mkdir(parents=True, exist_ok=True)
@@ -1364,18 +1368,34 @@ class GitRepository:
 
         repo.remotes.delete(temp_remote_name)
 
-    def mirror_local_heads_to_remote_tracking(self) -> None:
-        """Populate ``refs/remotes/origin/*`` from this repository's own
-        ``refs/heads/*`` via a local self-fetch (no network).
+    def fetch_heads_to_remote_tracking(self, source: str = ".") -> None:
+        """Populate this repo's ``refs/remotes/origin/*`` from the
+        ``refs/heads/*`` of ``source`` via a local fetch (no network);
+        ``source`` defaults to this repository itself.
 
-        A freshly ``clone(bare=True)``-d repository has only local heads,
-        whereas ``clone_from_disk`` produces remote-tracking refs as well.
-        Mirroring the heads here makes both flavors of temp repository expose
-        the same ``refs/remotes/origin/*`` namespace, so downstream code that
-        reads remote-tracking refs behaves identically regardless of how the
-        temp repository was created.
+        A freshly ``clone(bare=True)``-d repository exposes only local heads,
+        whereas ``clone_from_disk`` also produces remote-tracking refs, so
+        mirroring from ``.`` makes both temp-repo flavors expose the same
+        remote-tracking namespace. Passing another local repository as
+        ``source`` (e.g. the already-validated temp repo) brings its new
+        commits into this repo's remote-tracking refs without a second network
+        fetch.
         """
-        self._git("fetch . +refs/heads/*:refs/remotes/origin/*")
+        self._git("fetch {} +refs/heads/*:refs/remotes/origin/*", source)
+
+    def fetch_heads_from_remote(self, remote: str = "origin") -> None:
+        """Force-update local ``refs/heads/*`` from ``remote`` (network fetch).
+
+        Used after seeding a bare repo from a local copy: the seed carries the
+        user's possibly-stale heads, so this overwrites them with the remote's
+        current heads.
+        """
+        self._git(
+            "fetch {} +refs/heads/*:refs/heads/*",
+            remote,
+            log_error=True,
+            reraise_error=True,
+        )
 
     def find_first_branch_matching_pattern(
         self,
@@ -1914,6 +1934,15 @@ class GitRepository:
 
     def set_remote_url(self, new_url: str, remote: Optional[str] = "origin") -> None:
         self._git(f"remote set-url {remote} {new_url}")
+
+    def set_head_to_branch(self, branch_name: str) -> None:
+        """Point HEAD at the given local branch without checking it out."""
+        self._git(
+            "symbolic-ref HEAD refs/heads/{}",
+            branch_name,
+            log_error=True,
+            reraise_error=True,
+        )
 
     def set_upstream(self, branch_name: str) -> None:
         repo = self.pygit_repo

--- a/taf/git.py
+++ b/taf/git.py
@@ -1364,6 +1364,19 @@ class GitRepository:
 
         repo.remotes.delete(temp_remote_name)
 
+    def mirror_local_heads_to_remote_tracking(self) -> None:
+        """Populate ``refs/remotes/origin/*`` from this repository's own
+        ``refs/heads/*`` via a local self-fetch (no network).
+
+        A freshly ``clone(bare=True)``-d repository has only local heads,
+        whereas ``clone_from_disk`` produces remote-tracking refs as well.
+        Mirroring the heads here makes both flavors of temp repository expose
+        the same ``refs/remotes/origin/*`` namespace, so downstream code that
+        reads remote-tracking refs behaves identically regardless of how the
+        temp repository was created.
+        """
+        self._git("fetch . +refs/heads/*:refs/remotes/origin/*")
+
     def find_first_branch_matching_pattern(
         self,
         traverse_branch_name: str,

--- a/taf/git.py
+++ b/taf/git.py
@@ -205,11 +205,10 @@ class GitRepository:
         # repository can become one later.
         if self._is_git_repository:
             return True
-        # pygit2.discover_repository is a module-level function that searches
-        # upward for a repository, matching the semantics of the subprocess
-        # `rev-parse --is-inside-work-tree` / `--is-bare-repository` checks but
-        # without spawning a process (~150-400ms each on Windows).
-        if PYGIT2_AVAILABLE and not self.allow_unsafe:
+        # pygit2.discover_repository searches upward for a repository, matching
+        # the semantics of the `rev-parse --is-inside-work-tree` /
+        # `--is-bare-repository` checks without spawning a subprocess.
+        if not self.allow_unsafe:
             try:
                 if pygit2.discover_repository(str(self.path)) is not None:
                     self._is_git_repository = True
@@ -218,9 +217,8 @@ class GitRepository:
             except Exception:
                 # fall back to the subprocess check (e.g. ownership errors)
                 pass
-        # subprocess fallback: pygit2 unavailable, or allow_unsafe is set
-        # (libgit2 does not honor the `-c safe.directory` override the
-        # subprocess path uses)
+        # subprocess fallback for allow_unsafe: libgit2 does not honor the
+        # `-c safe.directory` override the subprocess path uses
         try:
             result = self._git("rev-parse --is-inside-work-tree", reraise_error=True)
             if result == "true":
@@ -344,10 +342,10 @@ class GitRepository:
 
         If the repository does not have a remote set, use `symbolic-ref` HEAD
 
-        The cheap symbolic-ref reads (steps 1 and 3) are done in-process via
-        pygit2 when possible to avoid spawning subprocesses (~150-400ms each on
-        Windows); each falls back to the subprocess equivalent on any failure,
-        so behavior is a strict superset of the previous implementation.
+        The symbolic-ref reads (steps 1 and 3) are done in-process via pygit2
+        when possible, each falling back to the subprocess equivalent on any
+        failure, so behavior is a strict superset of the previous
+        implementation.
         """
         # step 1: refs/remotes/origin/HEAD
         branch = self._symbolic_ref_branch_via_pygit("refs/remotes/origin/HEAD")
@@ -1967,12 +1965,11 @@ class GitRepository:
         # pygit2's status() includes untracked and modified files by default
         # (same set `git status --porcelain` reports), so an empty result means
         # the working tree is clean.
-        if PYGIT2_AVAILABLE:
-            try:
-                if not self.pygit_repo.status():
-                    return False
-            except Exception:
-                pass
+        try:
+            if not self.pygit_repo.status():
+                return False
+        except Exception:
+            pass
         return bool(self._git("status --porcelain"))
 
     def synced_with_remote(
@@ -2085,11 +2082,17 @@ class GitRepository:
         # detect the branch correctly instead of returning a stale None.
         return None
 
+    def clear_default_branch(self) -> None:
+        """Forget the detected default branch, both the attribute and the
+        path-keyed cache, so the next detection runs from scratch."""
+        _default_branch_cache.pop(str(self.path), None)
+        self.default_branch = None
+
     def clone_bare_from_local(self, local_path: Path) -> None:
         """Seed a bare repo from a local path (no network).
 
         Uses `git clone --local`, which hardlinks objects on the same volume
-        instead of copying them. Does NOT detect default_branch — the caller
+        instead of copying them. Does not detect default_branch — the caller
         must do that after updating origin to the real remote URL, otherwise
         remote show origin contacts local_path which may be in detached HEAD and
         returns a bogus branch name that then gets cached and blocks the correct
@@ -2106,9 +2109,8 @@ class GitRepository:
         # `git clone --bare` creates no origin remote (pygit2 did); add it for
         # parity so the caller's `remote set-url origin` succeeds
         self.add_remote("origin", str(local_path))
-        # Clear cache and reset so the caller's post-setup detection runs cleanly.
-        _default_branch_cache.pop(str(self.path), None)
-        self.default_branch = None
+        # reset so the caller's post-setup detection runs cleanly
+        self.clear_default_branch()
 
     def top_commit_of_remote_branch(
         self, branch, remote="origin"

--- a/taf/git.py
+++ b/taf/git.py
@@ -931,6 +931,13 @@ class GitRepository:
             else:
                 self.remove_remote("origin")
 
+        # seed the default-branch cache for this path from the source repo's
+        # entry to avoid re-detecting (a subprocess) the same logical repo at a
+        # new path during materialization
+        cached = _default_branch_cache.get(str(local_path))
+        if cached is not None:
+            _default_branch_cache.setdefault(str(self.path), cached)
+
         if self.default_branch is None:
             self.default_branch = self._determine_default_branch()
 

--- a/taf/git.py
+++ b/taf/git.py
@@ -46,6 +46,10 @@ except ImportError:
 
 EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
+# Per-process cache for default branch detection.
+# A repository's default branch never changes during a single run.
+_default_branch_cache: Dict[str, Optional[str]] = {}
+
 
 class GitRepository:
     def __init__(
@@ -789,6 +793,7 @@ class GitRepository:
         is_bare: bool = False,
         keep_remote=False,
         branches=None,
+        fetch_remote: bool = True,
     ) -> None:
         if not PYGIT2_AVAILABLE:
             raise PygitError("pygit2 is not installed")
@@ -801,10 +806,21 @@ class GitRepository:
         repo = self.pygit_repo
 
         if not keep_remote:
-            self.remove_remote("origin")
             if remote_url is not None:
+                self.remove_remote("origin")
                 self.add_remote("origin", remote_url)
-                self.fetch()
+                if fetch_remote:
+                    self.fetch()
+                else:
+                    # Populate refs/remotes/origin/* from the validated local clone instead
+                    # of re-fetching from the network. Bare sources expose all branches as
+                    # refs/heads/*; non-bare sources expose them as refs/remotes/origin/*.
+                    source_is_bare = pygit2.Repository(str(local_path)).is_bare
+                    if source_is_bare:
+                        refspec = "+refs/heads/*:refs/remotes/origin/*"
+                    else:
+                        refspec = "+refs/remotes/origin/*:refs/remotes/origin/*"
+                    self._git("fetch {} {}", str(local_path), refspec)
                 if repo is not None and branches:
                     local_branch_names = [
                         branch.split("/")[-1] for branch in repo.branches.local
@@ -812,6 +828,11 @@ class GitRepository:
                     for branch in branches:
                         if branch in local_branch_names:
                             self.set_upstream(str(branch))
+            else:
+                self.remove_remote("origin")
+
+        if self.default_branch is None:
+            self.default_branch = self._determine_default_branch()
 
     # TODO test this
     def clone_or_pull(
@@ -1869,10 +1890,16 @@ class GitRepository:
 
     def _determine_default_branch(self) -> Optional[str]:
         """Determine the default branch of the repository"""
+        cache_key = str(self.path)
+        if cache_key in _default_branch_cache:
+            return _default_branch_cache[cache_key]
+
         # try to get the default branch from the local repository
         errors = []
         try:
-            return self.get_default_branch()
+            result = self.get_default_branch()
+            _default_branch_cache[cache_key] = result
+            return result
         except GitError as e:
             errors.append(e)
             pass
@@ -1881,7 +1908,9 @@ class GitRepository:
         if self.urls:
             for url in self.urls:
                 try:
-                    return self.get_default_branch(url)
+                    result = self.get_default_branch(url)
+                    _default_branch_cache[cache_key] = result
+                    return result
                 except GitError as e:
                     errors.append(e)
                     pass
@@ -1889,7 +1918,26 @@ class GitRepository:
         self._log_debug(
             f"Cannot determine default branch with git -C at {self.path}: {errors}"
         )
+        # Do not cache None — the repo may not exist yet (e.g. temp path at
+        # instantiation time). The next call after the repo is created will
+        # detect the branch correctly instead of returning a stale None.
         return None
+
+    def clone_bare_from_local(self, local_path: Path) -> None:
+        """Seed a bare repo from a local path using pygit2 (no network).
+
+        Does NOT detect default_branch — the caller must do that after updating
+        origin to the real remote URL, otherwise remote show origin contacts
+        local_path which may be in detached HEAD and returns a bogus branch name
+        that then gets cached and blocks the correct subsequent detection.
+        """
+        if not PYGIT2_AVAILABLE:
+            raise PygitError("pygit2 is not installed")
+        self.path.mkdir(parents=True, exist_ok=True)
+        pygit2.clone_repository(str(local_path), str(self.path), bare=True)
+        # Clear cache and reset so the caller's post-setup detection runs cleanly.
+        _default_branch_cache.pop(str(self.path), None)
+        self.default_branch = None
 
     def top_commit_of_remote_branch(
         self, branch, remote="origin"

--- a/taf/pygit.py
+++ b/taf/pygit.py
@@ -1,7 +1,6 @@
 from typing import Dict
 import pygit2
 from collections import defaultdict
-from taf.log import taf_logger
 from taf.exceptions import GitError
 import os.path
 
@@ -53,14 +52,9 @@ class PyGitRepository:
         for the given commit object,
         get the blob at the given path
         """
-        taf_logger.debug(
-            f"Get blob at path {path}",
-        )
         working = self._get_object_at_path(obj, path)
         if working and isinstance(working, pygit2.Blob):
-            taf_logger.debug(f"Found blob at path {'/'.join(path)}")
             return working
-        taf_logger.debug(f"Blob not found at path {'/'.join(path)}")
         return None
 
     def cleanup(self):

--- a/taf/tests/test_git/test_git.py
+++ b/taf/tests/test_git/test_git.py
@@ -165,6 +165,22 @@ def test_is_git_repository_root_non_bare(repository: GitRepository):
     assert repository.is_git_repository_root
 
 
+def test_is_git_repository_not_cached_negative(tmp_path):
+    """is_git_repository must not permanently cache a negative result: an
+    instance created for a path before the repository exists (e.g. before the
+    updater or an external process materializes it) has to report True once a
+    valid repository appears on disk."""
+    repo_path = Path(tmp_path) / "repo"
+    repo = GitRepository(path=repo_path)
+    # path does not exist yet
+    assert repo.is_git_repository is False
+    # an external actor creates the repository at that path
+    repo_path.mkdir(parents=True, exist_ok=True)
+    GitRepository(path=repo_path).init_repo(bare=False)
+    # the original instance must now detect it instead of returning a stale False
+    assert repo.is_git_repository is True
+
+
 def test_all_commits_since_commit_when_repo_empty(empty_repository: GitRepository):
     all_commits_empty = empty_repository.all_commits_since_commit()
     assert isinstance(all_commits_empty, list)
@@ -663,3 +679,38 @@ def test_is_remote_branch(origin_repo: GitRepository, clone_repository: GitRepos
     assert not clone_repository.is_remote_branch(
         f"origin2/{clone_repository.default_branch}"
     )
+
+
+# --- pygit2-backed read-only checks ---
+
+
+def test_is_git_repository_in_subdirectory(repository: GitRepository):
+    # parity with `rev-parse --is-inside-work-tree`: a path inside a work tree
+    # is reported as a git repository (discover_repository searches upward)
+    subdir = repository.path / "nested"
+    subdir.mkdir()
+    repo = GitRepository(path=subdir, default_branch=repository.default_branch)
+    assert repo.is_git_repository
+
+
+def test_is_git_repository_non_repo():
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = GitRepository(path=tmp)
+        assert not repo.is_git_repository
+        assert not repo.is_git_repository_root
+
+
+def test_default_branch_from_origin_head(
+    origin_repo: GitRepository, clone_repository: GitRepository
+):
+    clone_repository.urls = [str(origin_repo.path)]
+    clone_repository.clone()
+    # cloned repos have refs/remotes/origin/HEAD; detection reads it in-process
+    assert (
+        clone_repository._get_default_branch_from_local() == origin_repo.default_branch
+    )
+
+
+def test_default_branch_from_head_no_remote(repository: GitRepository):
+    # no origin remote: falls back to local HEAD shorthand
+    assert repository._get_default_branch_from_local() == repository.default_branch

--- a/taf/tests/test_git/test_git.py
+++ b/taf/tests/test_git/test_git.py
@@ -183,6 +183,27 @@ def test_is_git_repository_not_cached_negative(tmp_path):
     assert repo.is_git_repository is True
 
 
+def test_set_head_to_branch(repository: GitRepository):
+    branch_name = "feature"
+    repository.create_branch(branch_name)
+    repository.set_head_to_branch(branch_name)
+    assert repository.get_current_branch() == branch_name
+
+
+def test_fetch_heads_to_remote_tracking(repository: GitRepository):
+    default_branch = repository.default_branch
+    assert default_branch is not None
+    # no remote-tracking ref before mirroring
+    assert not repository.branch_exists(
+        f"origin/{default_branch}", include_remotes=True
+    )
+    repository.fetch_heads_to_remote_tracking()
+    # refs/heads/* are now mirrored into refs/remotes/origin/*
+    assert repository.top_commit_of_remote_branch(default_branch) == (
+        repository.top_commit_of_branch(default_branch)
+    )
+
+
 def test_all_commits_since_commit_when_repo_empty(empty_repository: GitRepository):
     all_commits_empty = empty_repository.all_commits_since_commit()
     assert isinstance(all_commits_empty, list)

--- a/taf/tests/test_git/test_git.py
+++ b/taf/tests/test_git/test_git.py
@@ -704,9 +704,6 @@ def test_is_remote_branch(origin_repo: GitRepository, clone_repository: GitRepos
     )
 
 
-# --- pygit2-backed read-only checks ---
-
-
 def test_is_git_repository_in_subdirectory(repository: GitRepository):
     # parity with `rev-parse --is-inside-work-tree`: a path inside a work tree
     # is reported as a git repository (discover_repository searches upward)
@@ -737,9 +734,6 @@ def test_default_branch_from_origin_head(
 def test_default_branch_from_head_no_remote(repository: GitRepository):
     # no origin remote: falls back to local HEAD shorthand
     assert repository._get_default_branch_from_local() == repository.default_branch
-
-
-# --- git clone --local (hardlinked objects) ---
 
 
 def test_is_git_repository_cached_until_clone(repository, tmp_path):

--- a/taf/tests/test_git/test_git.py
+++ b/taf/tests/test_git/test_git.py
@@ -1,5 +1,7 @@
 import datetime
 import json
+import os
+from pathlib import Path
 from pygit2 import AlreadyExistsError
 from taf.models.types import Commitish
 import pytest
@@ -714,3 +716,69 @@ def test_default_branch_from_origin_head(
 def test_default_branch_from_head_no_remote(repository: GitRepository):
     # no origin remote: falls back to local HEAD shorthand
     assert repository._get_default_branch_from_local() == repository.default_branch
+
+
+# --- git clone --local (hardlinked objects) ---
+
+
+def test_is_git_repository_cached_until_clone(repository, tmp_path):
+    # before cloning the path is not a repo; the negative result must not be
+    # cached past the clone (cloning makes it a repo). tmp_path is outside any
+    # git checkout so the pre-clone state is genuinely "not a repository".
+    dest = GitRepository(path=tmp_path / "dest")
+    dest.path.mkdir()
+    assert not dest.is_git_repository
+    dest.clone_from_disk(repository.path)
+    assert dest.is_git_repository
+
+
+def test_clone_from_disk_bare_has_origin(repository: GitRepository, tmp_path):
+    # `git clone --bare` creates no origin; clone_from_disk must add it for parity
+    bare = GitRepository(path=tmp_path / "bare")
+    bare.clone_from_disk(
+        repository.path, "https://example.com/x.git", is_bare=True, fetch_remote=False
+    )
+    assert bare.is_bare_repository
+    assert bare.get_remote_url() == "https://example.com/x.git"
+
+
+def test_clone_from_disk_bare_source_populates_origin_refs(
+    origin_repo: GitRepository, tmp_path
+):
+    # materialization hot path: bare source, fetch_remote=False must populate
+    # refs/remotes/origin/* from the source's refs/heads/*
+    origin_repo.pygit_repo  # ensure instantiated
+    user = GitRepository(path=tmp_path / "user")
+    user.clone_from_disk(
+        origin_repo.path,
+        "https://example.com/x.git",
+        is_bare=False,
+        fetch_remote=False,
+    )
+    assert not user.is_bare_repository
+    default_branch = origin_repo.default_branch
+    assert default_branch
+    origin_refs = [
+        str(r) for r in user.pygit_repo.references if "refs/remotes/origin/" in str(r)
+    ]
+    assert any(default_branch in ref for ref in origin_refs), origin_refs
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "getuid"), reason="hardlink nlink check is POSIX-only"
+)
+def test_clone_from_disk_hardlinks_objects(repository: GitRepository, tmp_path):
+    # git clone --local hardlinks objects on the same volume
+    dest = GitRepository(path=tmp_path / "linked")
+    dest.clone_from_disk(repository.path, keep_remote=True)
+
+    def loose_objects(base):
+        objects = Path(base) / ".git" / "objects"
+        if not objects.exists():
+            objects = Path(base) / "objects"
+        return [f for d in objects.glob("??") for f in d.iterdir() if f.is_file()]
+
+    dest_objs = loose_objects(dest.path)
+    assert dest_objs, "expected loose objects in the clone"
+    # at least one object is hardlinked (st_nlink > 1) to the source copy
+    assert any(os.stat(obj).st_nlink > 1 for obj in dest_objs)

--- a/taf/tests/test_updater/test_handlers/conftest.py
+++ b/taf/tests/test_updater/test_handlers/conftest.py
@@ -1,6 +1,8 @@
 from taf.tests.conftest import TEST_DATA_PATH
 
 
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 from tuf.ngclient._internal import trusted_metadata_set
 from pytest import fixture
 
@@ -60,3 +62,17 @@ def update_handlers_invalid_inputs():
         input_path
         for input_path in UPDATE_HANDLERS_DATA_INVALID_INPUT_IDR.glob("*.json")
     ]
+
+
+@fixture
+def rsa_key_pair():
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_pem = (
+        private_key.public_key()
+        .public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("utf-8")
+    )
+    return private_key, public_pem

--- a/taf/tests/test_updater/test_handlers/test_in_memory_updater.py
+++ b/taf/tests/test_updater/test_handlers/test_in_memory_updater.py
@@ -1,8 +1,8 @@
 import inspect
 
 import pytest
-from cryptography.hazmat.primitives.asymmetric import padding, rsa
-from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives import hashes
 from securesystemslib.exceptions import UnverifiedSignatureError
 from securesystemslib.signer import SSlibKey, Signature
 from tuf.api.exceptions import DownloadLengthMismatchError
@@ -70,20 +70,6 @@ def test_download_bytes_enforces_max_length():
     fetcher = _FetcherStub(b"x" * 101)
     with pytest.raises(DownloadLengthMismatchError):
         fetcher.download_bytes("metadata/root.json", 100)
-
-
-@pytest.fixture
-def rsa_key_pair():
-    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    public_pem = (
-        private_key.public_key()
-        .public_bytes(
-            serialization.Encoding.PEM,
-            serialization.PublicFormat.SubjectPublicKeyInfo,
-        )
-        .decode("utf-8")
-    )
-    return private_key, public_pem
 
 
 def test_cached_key_verifies_and_rejects_signatures(rsa_key_pair):

--- a/taf/tests/test_updater/test_handlers/test_in_memory_updater.py
+++ b/taf/tests/test_updater/test_handlers/test_in_memory_updater.py
@@ -1,0 +1,118 @@
+import inspect
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.hazmat.primitives import hashes, serialization
+from securesystemslib.exceptions import UnverifiedSignatureError
+from securesystemslib.signer import SSlibKey, Signature
+from tuf.api.exceptions import DownloadLengthMismatchError
+from tuf.ngclient.updater import Updater
+
+from taf.tuf.key_cache import _load_pem_public_key_cached
+from taf.updater.handlers import GitUpdater
+from taf.updater.in_memory_updater import InMemoryUpdater
+
+
+def test_tuf_private_api_is_unchanged():
+    """InMemoryUpdater overrides these private python-tuf methods, so fail
+    loudly if a tuf upgrade changes their signatures."""
+    load_params = list(inspect.signature(Updater._load_local_metadata).parameters)
+    assert load_params == ["self", "rolename"]
+    persist_params = list(inspect.signature(Updater._persist_metadata).parameters)
+    assert persist_params == ["self", "rolename", "data"]
+
+
+def test_in_memory_updater_load_and_persist():
+    store = {}
+    # bypass __init__ - only the storage overrides are under test here
+    updater = InMemoryUpdater.__new__(InMemoryUpdater)
+    updater._metadata_store = store
+
+    updater._persist_metadata("targets", b"targets-data")
+    assert updater._load_local_metadata("targets") == b"targets-data"
+    # rolenames are quoted the same way tuf quotes local file names
+    updater._persist_metadata("role/with/separators", b"delegated-data")
+    assert store["role%2Fwith%2Fseparators"] == b"delegated-data"
+    assert updater._load_local_metadata("role/with/separators") == b"delegated-data"
+
+    # missing metadata must raise an OSError, like the file-based original
+    with pytest.raises(OSError):
+        updater._load_local_metadata("snapshot")
+
+
+def test_metadata_store_key():
+    assert GitUpdater._metadata_store_key("root.json") == "root"
+    assert GitUpdater._metadata_store_key("targets.json") == "targets"
+    # keys match what InMemoryUpdater computes from the rolename
+    updater = InMemoryUpdater.__new__(InMemoryUpdater)
+    updater._metadata_store = {GitUpdater._metadata_store_key("root.json"): b"data"}
+    assert updater._load_local_metadata("root") == b"data"
+
+
+class _FetcherStub:
+    """Minimal object exposing fetch() the way FetcherInterface does."""
+
+    def __init__(self, data):
+        self._data = data
+
+    def fetch(self, url):
+        return iter([self._data])
+
+    download_bytes = GitUpdater.download_bytes
+
+
+def test_download_bytes_returns_data():
+    fetcher = _FetcherStub(b"x" * 100)
+    assert fetcher.download_bytes("metadata/root.json", 100) == b"x" * 100
+
+
+def test_download_bytes_enforces_max_length():
+    fetcher = _FetcherStub(b"x" * 101)
+    with pytest.raises(DownloadLengthMismatchError):
+        fetcher.download_bytes("metadata/root.json", 100)
+
+
+@pytest.fixture
+def rsa_key_pair():
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_pem = (
+        private_key.public_key()
+        .public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("utf-8")
+    )
+    return private_key, public_pem
+
+
+def test_cached_key_verifies_and_rejects_signatures(rsa_key_pair):
+    """The PEM-parse cache must not change any verification outcome."""
+    private_key, public_pem = rsa_key_pair
+    sslib_key = SSlibKey(
+        "test-keyid",
+        "rsa",
+        "rsassa-pss-sha256",
+        {"public": public_pem},
+    )
+    data = b"signed payload"
+    signature_bytes = private_key.sign(
+        data,
+        padding.PSS(
+            mgf=padding.MGF1(hashes.SHA256()), salt_length=hashes.SHA256().digest_size
+        ),
+        hashes.SHA256(),
+    )
+    signature = Signature("test-keyid", signature_bytes.hex())
+
+    # verify twice so the second call exercises the cache hit
+    sslib_key.verify_signature(signature, data)
+    sslib_key.verify_signature(signature, data)
+
+    with pytest.raises(UnverifiedSignatureError):
+        sslib_key.verify_signature(signature, b"tampered payload")
+
+    # the cache returns the same parsed key object for the same PEM
+    assert _load_pem_public_key_cached(public_pem) is _load_pem_public_key_cached(
+        public_pem
+    )

--- a/taf/tests/test_updater/test_update/test_update_partial.py
+++ b/taf/tests/test_updater/test_update/test_update_partial.py
@@ -73,7 +73,9 @@ def test_update_partial_with_invalid_commits(origin_auth_repo, client_dir):
     ],
     indirect=True,
 )
-def test_update_ignores_commit_sha_stored_as_exclude_filter(origin_auth_repo, client_dir):
+def test_update_ignores_commit_sha_stored_as_exclude_filter(
+    origin_auth_repo, client_dir
+):
     clone_repositories(
         origin_auth_repo,
         client_dir,

--- a/taf/tests/test_updater/test_update/test_update_partial.py
+++ b/taf/tests/test_updater/test_update/test_update_partial.py
@@ -9,6 +9,7 @@ from taf.tests.test_updater.conftest import (
     add_unauthenticated_commit_to_target_repo,
     add_valid_target_commits,
     set_head_commit,
+    update_expiration_dates,
     update_target_repo_without_committing,
 )
 from taf.tests.test_updater.update_utils import (
@@ -61,6 +62,40 @@ def test_update_partial_with_invalid_commits(origin_auth_repo, client_dir):
         client_dir,
         force=True,
     )
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [{"name": "target1"}, {"name": "target2"}],
+        },
+    ],
+    indirect=True,
+)
+def test_update_ignores_commit_sha_stored_as_exclude_filter(origin_auth_repo, client_dir):
+    clone_repositories(
+        origin_auth_repo,
+        client_dir,
+    )
+
+    client_auth_repo = AuthenticationRepository(path=client_dir / origin_auth_repo.name)
+    lvc_data = client_auth_repo.last_validated_data
+    lvc_data["exclude_filter"] = client_auth_repo.head_commit().value
+    client_auth_repo.set_last_validated_data(lvc_data, set_last_validated_commit=False)
+
+    setup_manager = SetupManager(origin_auth_repo)
+    setup_manager.add_task(update_expiration_dates)
+    setup_manager.execute_tasks()
+
+    update_and_check_commit_shas(
+        OperationType.UPDATE,
+        origin_auth_repo,
+        client_dir,
+    )
+
+    client_auth_repo = AuthenticationRepository(path=client_dir / origin_auth_repo.name)
+    assert "exclude_filter" not in client_auth_repo.last_validated_data
 
 
 @pytest.mark.parametrize(

--- a/taf/tests/test_updater/test_update/test_update_valid.py
+++ b/taf/tests/test_updater/test_update/test_update_valid.py
@@ -194,9 +194,7 @@ def test_update_uses_configured_remote_over_local_origin(
         is_bare=True,
     )
 
-    client_auth_repo = AuthenticationRepository(
-        path=client_dir / origin_auth_repo.name
-    )
+    client_auth_repo = AuthenticationRepository(path=client_dir / origin_auth_repo.name)
     client_auth_repo.set_remote_url(str(stale_origin.path))
 
     setup_manager = SetupManager(origin_auth_repo)

--- a/taf/tests/test_updater/test_update/test_update_valid.py
+++ b/taf/tests/test_updater/test_update/test_update_valid.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import pytest
 from taf.auth_repo import AuthenticationRepository
+from taf.git import GitRepository
 from taf.tests.test_updater.conftest import (
     SetupManager,
     add_unauthenticated_commits_to_all_target_repos,
@@ -157,6 +158,46 @@ def test_update_valid_when_expiration_dates_updated(origin_auth_repo, client_dir
         origin_auth_repo,
         client_dir,
     )
+
+    setup_manager = SetupManager(origin_auth_repo)
+    setup_manager.add_task(update_expiration_dates)
+    setup_manager.execute_tasks()
+
+    update_and_check_commit_shas(
+        OperationType.UPDATE,
+        origin_auth_repo,
+        client_dir,
+    )
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [{"name": "target1"}, {"name": "target2"}],
+        },
+    ],
+    indirect=True,
+)
+def test_update_uses_configured_remote_over_local_origin(
+    origin_auth_repo, client_dir, tmp_path
+):
+    clone_repositories(
+        origin_auth_repo,
+        client_dir,
+    )
+
+    stale_origin = GitRepository(path=tmp_path / "stale-origin-auth")
+    stale_origin.clone_from_disk(
+        origin_auth_repo.path,
+        str(origin_auth_repo.path),
+        is_bare=True,
+    )
+
+    client_auth_repo = AuthenticationRepository(
+        path=client_dir / origin_auth_repo.name
+    )
+    client_auth_repo.set_remote_url(str(stale_origin.path))
 
     setup_manager = SetupManager(origin_auth_repo)
     setup_manager.add_task(update_expiration_dates)

--- a/taf/tests/test_utils.py
+++ b/taf/tests/test_utils.py
@@ -1,5 +1,15 @@
 import json
-from taf.utils import normalize_line_endings, safely_save_json_to_disk, safely_move_file
+import os
+import pytest
+from pathlib import Path
+
+from taf.utils import (
+    TempPartition,
+    _background_cleanup_threads,
+    normalize_line_endings,
+    safely_save_json_to_disk,
+    safely_move_file,
+)
 
 
 def test_normalize_line_ending_extra_lines():
@@ -40,6 +50,60 @@ def test_safely_save_json_to_disk_existing_file(output_path):
     saved_json = json.loads(saved_text)
     assert len(saved_json)
     assert saved_json == data
+
+
+def test_temp_partition_cleanup_async(output_path):
+    temp_partition = TempPartition(Path(output_path))
+    temp_dir = Path(temp_partition.temp_dir)
+    for index in range(3):
+        subdir = temp_dir / f"repo{index}" / "nested"
+        subdir.mkdir(parents=True)
+        (subdir / "file.txt").write_text("data")
+
+    temp_partition.cleanup_async()
+
+    # the temp dir is renamed away immediately, so a new TempPartition in the
+    # same location would not collide with it
+    assert not temp_dir.exists()
+    for thread in _background_cleanup_threads:
+        thread.join(timeout=30)
+    assert not list(temp_dir.parent.glob(f"*{TempPartition.TRASH_SUFFIX}"))
+
+
+def test_temp_partition_sweeps_stale_trash(output_path):
+    first = TempPartition(Path(output_path))
+    stale_trash = Path(f"{first.temp_dir}stale{TempPartition.TRASH_SUFFIX}")
+    (stale_trash / "leftover").mkdir(parents=True)
+
+    second = TempPartition(Path(output_path))
+
+    assert not stale_trash.exists()
+    first.cleanup()
+    second.cleanup()
+
+
+def test_temp_partition_sweep_skips_foreign_owned_trash(output_path, monkeypatch):
+    # the sweep must not delete trash dirs owned by a different user (shared
+    # /tmp on POSIX); simulate by making os.getuid return a uid that differs
+    # from the trash dir's owner
+    if not hasattr(os, "getuid"):
+        pytest.skip("ownership check is POSIX-only")
+
+    first = TempPartition(Path(output_path))
+    foreign_trash = Path(f"{first.temp_dir}foreign{TempPartition.TRASH_SUFFIX}")
+    (foreign_trash / "leftover").mkdir(parents=True)
+
+    real_uid = os.stat(foreign_trash).st_uid
+    monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
+
+    second = TempPartition(Path(output_path))
+
+    assert foreign_trash.exists()  # not ours -> left untouched
+    import shutil as _shutil
+
+    _shutil.rmtree(foreign_trash)
+    first.cleanup()
+    second.cleanup()
 
 
 def test_safely_move_file_same_filesystem(output_path):

--- a/taf/tools/repo/__init__.py
+++ b/taf/tools/repo/__init__.py
@@ -96,17 +96,44 @@ def _call_updater(config, format_output, result_file):
 
 def start_profiling():
     import cProfile
+    import pstats
     import atexit
+    import threading
 
     print("Profiling...")
-    pr = cProfile.Profile()
-    pr.enable()
+    main_pr = cProfile.Profile()
+    thread_profiles = []
+    lock = threading.Lock()
+
+    def _profile_thread(frame, event, arg):
+        # threading.setprofile only affects threads started AFTER this call,
+        # which is fine: profiling starts before the updater pipeline spawns
+        # any worker threads. cProfile is not safe to share across threads, so
+        # each worker gets its own Profile.
+        pr = cProfile.Profile()
+        with lock:
+            thread_profiles.append(pr)
+        pr.enable()
+
+    threading.setprofile(_profile_thread)
+    main_pr.enable()
 
     def exit_profiler():
-        pr.disable()
+        main_pr.disable()
+        threading.setprofile(None)
         print("Profiling completed")
+        stats = pstats.Stats(main_pr)
+        with lock:
+            for pr in thread_profiles:
+                try:
+                    # workers from context-managed executors are already joined;
+                    # skip the still-running daemon (background cleanup) threads
+                    pr.create_stats()
+                    stats.add(pr)
+                except Exception:
+                    pass
         filename = "updater.prof"  # You can change the filename if needed
-        pr.dump_stats(filename)
+        stats.dump_stats(filename)
 
     atexit.register(exit_profiler)
 

--- a/taf/tuf/key_cache.py
+++ b/taf/tuf/key_cache.py
@@ -27,10 +27,11 @@ def _cached_crypto_key(self):
 
 
 def enable_public_key_cache() -> None:
+    # Called once, at import time, so the warning below cannot be repeated.
     if hasattr(SSlibKey, "_crypto_key"):
         SSlibKey._crypto_key = _cached_crypto_key  # type: ignore
     else:
-        taf_logger.debug(
+        taf_logger.warning(
             "securesystemslib internals changed: SSlibKey._crypto_key not found, "
             "skipping public key cache"
         )

--- a/taf/tuf/key_cache.py
+++ b/taf/tuf/key_cache.py
@@ -1,0 +1,36 @@
+"""Cache PEM public key deserialization in securesystemslib.
+
+``SSlibKey._crypto_key`` re-parses the PEM-encoded public key on every
+signature verification. A TAF update verifies the same handful of keys
+thousands of times (once per metadata file per validated commit), so the
+parsing is memoized here. The cache key is the PEM string itself and the
+returned ``cryptography`` public key objects are immutable, so sharing them
+between SSlibKey instances cannot change any verification outcome.
+"""
+
+from functools import lru_cache
+
+from cryptography.hazmat.primitives.serialization import load_pem_public_key
+from securesystemslib.signer import SSlibKey
+
+from taf.log import taf_logger
+
+
+@lru_cache(maxsize=256)
+def _load_pem_public_key_cached(public_pem: str):
+    return load_pem_public_key(public_pem.encode("utf-8"))
+
+
+def _cached_crypto_key(self):
+    """Drop-in replacement for SSlibKey._crypto_key."""
+    return _load_pem_public_key_cached(self.keyval["public"])
+
+
+def enable_public_key_cache() -> None:
+    if hasattr(SSlibKey, "_crypto_key"):
+        SSlibKey._crypto_key = _cached_crypto_key  # type: ignore
+    else:
+        taf_logger.debug(
+            "securesystemslib internals changed: SSlibKey._crypto_key not found, "
+            "skipping public key cache"
+        )

--- a/taf/updater/handlers.py
+++ b/taf/updater/handlers.py
@@ -1,8 +1,9 @@
 import os
 import shutil
-import tempfile
 from functools import wraps
 from pathlib import Path
+from typing import Dict
+from urllib import parse
 
 from taf.models.types import Commitish
 from tuf.ngclient._internal import trusted_metadata_set
@@ -16,7 +17,7 @@ from taf.updater.git_trusted_metadata_set import GitTrustedMetadataSet
 from taf.tuf.key_cache import enable_public_key_cache
 
 from tuf.ngclient.fetcher import FetcherInterface
-from tuf.api.exceptions import DownloadHTTPError
+from tuf.api.exceptions import DownloadHTTPError, DownloadLengthMismatchError
 
 enable_public_key_cache()
 
@@ -53,7 +54,8 @@ class GitUpdater(FetcherInterface):
 
     Attributes:
         - repository_directory: the client's local repository's location
-        - metadata_dir_path: path of the metadata directory needed by the updater.
+        - metadata_store: in-memory store of the current metadata files needed
+        by the updater (replaces TUF's local metadata directory).
         - validation_auth_repo: a fresh clone of the metadata repository. It is
         a bare git repository. An instance of the `BareGitRepo` class.
         - commits: a list of commits, starting with the most recent commit in the
@@ -74,7 +76,9 @@ class GitUpdater(FetcherInterface):
 
     @property
     def metadata_dir(self) -> str:
-        return str(self.metadata_dir_path)
+        # the updater keeps metadata in memory (see metadata_store); this only
+        # satisfies the TUF Updater constructor, which stores but never uses it
+        return ""
 
     @property
     def targets_dir(self) -> str:
@@ -101,11 +105,9 @@ class GitUpdater(FetcherInterface):
 
         self.repository_directory = str(repository_directory)
 
-        tmp_dir = tempfile.mkdtemp()
-        metadata_path = Path(tmp_dir, "metadata")
-        metadata_path.mkdir(parents=True, exist_ok=True)
-
-        self.metadata_dir_path = metadata_path
+        # in-memory equivalent of the TUF updater's local metadata directory,
+        # keyed the same way as metadata file names (quoted rolename, no .json)
+        self.metadata_store: Dict[str, bytes] = {}
 
         try:
             self._init_metadata()
@@ -127,6 +129,18 @@ class GitUpdater(FetcherInterface):
                 f"Retrieval of data at current revision {self.current_commit} failed with error - {str(e)}"
             )
             raise e
+
+    def download_bytes(self, url: str, max_length: int) -> bytes:
+        # the default FetcherInterface implementation round-trips the data
+        # through a temporary file; the data is already in memory here, so
+        # only the max_length check is kept
+        data = b"".join(self.fetch(url))
+        if len(data) > max_length:
+            raise DownloadLengthMismatchError(
+                f"Downloaded {len(data)} bytes exceeding the maximum allowed "
+                f"length of {max_length}"
+            )
+        return data
 
     def _init_commits(self):
         """
@@ -152,24 +166,31 @@ class GitUpdater(FetcherInterface):
         self.commits = commits_since
         self.current_commit_index = 0
 
+    @staticmethod
+    def _metadata_store_key(filename: str) -> str:
+        """Key under which a metadata file is stored in metadata_store.
+        Mirrors how the TUF updater maps role names to local metadata file
+        names (quoted rolename without the .json extension)."""
+        rolename = filename[: -len(".json")] if filename.endswith(".json") else filename
+        return parse.quote(rolename, "")
+
     def _init_metadata(self):
         """
-        TUF updater expects the existence of a client
-        metadata directory. This directory stores
-        the current metadata files (which will get deleted after the update).
-        Directory must exist and contain at least root.json. Otherwise, update will
-        fail. We actually want to validate the remote authentication repository,
-        but will create a Temp directory in order to avoid modifying the updater.
+        TUF updater expects a client metadata store containing the current
+        metadata files - at least root.json, otherwise the update will fail.
+        We actually want to validate the remote authentication repository,
+        so the store is populated with the metadata at the current revision.
+        It is kept in memory (metadata_store) instead of on disk to avoid
+        per-revision file I/O (see InMemoryUpdater).
         """
         metadata_files = self.validation_auth_repo.list_files_at_revision(
             self.current_commit, "metadata"
         )
         for filename in metadata_files:
             metadata = self.validation_auth_repo.get_file(
-                self.current_commit, "metadata/" + filename
+                self.current_commit, "metadata/" + filename, raw=True
             )
-            current_filename = self.metadata_dir_path / filename
-            current_filename.write_text(metadata)
+            self.metadata_store[self._metadata_store_key(filename)] = metadata
 
     def _patch_tuf_metadata_set(self, cls):
         """
@@ -201,12 +222,10 @@ class GitUpdater(FetcherInterface):
 
     def cleanup(self):
         """
-        Removes the bare authentication repository and metadata
-        directory. This should be called after the update is finished,
-        either successfully or unsuccessfully.
+        Removes the bare authentication repository. This should be called
+        after the update is finished, either successfully or unsuccessfully.
         """
-        if self.metadata_dir_path.is_dir():
-            shutil.rmtree(self.metadata_dir_path)
+        self.metadata_store.clear()
         self.validation_auth_repo.cleanup()
         temp_dir = Path(self.validation_auth_repo.path, os.pardir).parent
         if temp_dir.is_dir():

--- a/taf/updater/handlers.py
+++ b/taf/updater/handlers.py
@@ -131,9 +131,17 @@ class GitUpdater(FetcherInterface):
             raise e
 
     def download_bytes(self, url: str, max_length: int) -> bytes:
-        # the default FetcherInterface implementation round-trips the data
-        # through a temporary file; the data is already in memory here, so
-        # only the max_length check is kept
+        """Return the metadata/target bytes for the current commit.
+
+        The only thing TUF's default implementation does beyond returning the
+        bytes is bound the size to ``max_length`` while streaming into a
+        temporary file. ``fetch`` already returns the bytes from git in memory,
+        so we drop the temp-file round-trip but keep the ``max_length`` guard.
+        That guard is the size bound TUF applies *before* the role's
+        signatures, hashes, version and expiry are verified later in
+        ``refresh()``; for roles whose trusted length isn't known yet (root,
+        timestamp) it is the only bound, so it must stay.
+        """
         data = b"".join(self.fetch(url))
         if len(data) > max_length:
             raise DownloadLengthMismatchError(

--- a/taf/updater/handlers.py
+++ b/taf/updater/handlers.py
@@ -13,9 +13,12 @@ from taf.auth_repo import AuthenticationRepository
 from taf.exceptions import UpdateFailedError
 from taf.utils import on_rm_error
 from taf.updater.git_trusted_metadata_set import GitTrustedMetadataSet
+from taf.tuf.key_cache import enable_public_key_cache
 
 from tuf.ngclient.fetcher import FetcherInterface
 from tuf.api.exceptions import DownloadHTTPError
+
+enable_public_key_cache()
 
 
 class GitUpdater(FetcherInterface):

--- a/taf/updater/in_memory_updater.py
+++ b/taf/updater/in_memory_updater.py
@@ -1,0 +1,41 @@
+from typing import Dict
+from urllib import parse
+
+from tuf.ngclient.updater import Updater
+
+from taf.exceptions import UpdateFailedError
+
+for _method in ("_load_local_metadata", "_persist_metadata"):
+    if not hasattr(Updater, _method):
+        raise UpdateFailedError(
+            f"python-tuf internals changed: Updater.{_method} no longer exists. "
+            "InMemoryUpdater must be updated to match the installed tuf version."
+        )
+
+
+class InMemoryUpdater(Updater):
+    """TUF Updater whose local metadata cache is an in-memory dict.
+
+    TAF runs one Updater per validated commit, so the "local metadata
+    directory" is written and re-read thousands of times per update. Keeping
+    that cache in a dict (shared between successive Updater instances via
+    GitUpdater.metadata_store) removes all of that disk I/O. Only the
+    load/persist methods are overridden - every verification step still runs
+    through unmodified python-tuf code.
+    """
+
+    def __init__(self, metadata_store: Dict[str, bytes], *args, **kwargs):
+        # must be set before super().__init__, which loads the trusted root
+        self._metadata_store = metadata_store
+        super().__init__(*args, **kwargs)
+
+    def _load_local_metadata(self, rolename: str) -> bytes:
+        try:
+            return self._metadata_store[parse.quote(rolename, "")]
+        except KeyError:
+            # an OSError subclass, matching the contract of the overridden
+            # method which raises it when the metadata file does not exist
+            raise FileNotFoundError(rolename)
+
+    def _persist_metadata(self, rolename: str, data: bytes) -> None:
+        self._metadata_store[parse.quote(rolename, "")] = data

--- a/taf/updater/in_memory_updater.py
+++ b/taf/updater/in_memory_updater.py
@@ -14,14 +14,32 @@ for _method in ("_load_local_metadata", "_persist_metadata"):
 
 
 class InMemoryUpdater(Updater):
-    """TUF Updater whose local metadata cache is an in-memory dict.
+    """TUF Updater whose local *trusted* metadata cache is an in-memory dict.
 
-    TAF runs one Updater per validated commit, so the "local metadata
-    directory" is written and re-read thousands of times per update. Keeping
-    that cache in a dict (shared between successive Updater instances via
-    GitUpdater.metadata_store) removes all of that disk I/O. Only the
-    load/persist methods are overridden - every verification step still runs
-    through unmodified python-tuf code.
+    python-tuf keeps a "local metadata directory" holding the trusted metadata
+    it has already verified (the trust anchor for the next run): on each
+    refresh it loads the trusted root from there, fetches new
+    timestamp/snapshot/targets from the remote, fully verifies them
+    (signatures, version/rollback, hashes, expiry) against that trusted state,
+    and persists the new trusted metadata back. It is *not* a cache of remote
+    files taken on faith - it is the output of verification.
+
+    TAF validates every commit, running one Updater per commit, so this
+    trusted store is written and re-read thousands of times per update. We
+    replace the on-disk directory with a dict (``GitUpdater.metadata_store``)
+    that is handed to each successive Updater, so the trusted state carries
+    forward exactly as it would on disk - only the storage medium changes, not
+    what is verified. Each commit's metadata is still fetched fresh (from git,
+    via ``GitUpdater``) and re-validated against the store on every refresh, so
+    the fact that metadata changes between commits is precisely what gets
+    checked.
+
+    Only the two private load/persist methods are overridden; all verification
+    runs through unmodified python-tuf. ``test_in_memory_updater`` covers the
+    store mechanics and the private-API guard, and the full ``test_updater``
+    suite exercises real clone/update validation through this path. In
+    ``--strict`` mode the store is additionally cross-checked against the
+    on-disk metadata at each commit (see ``_validate_metadata_on_disk``).
     """
 
     def __init__(self, metadata_store: Dict[str, bytes], *args, **kwargs):

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -12,6 +12,7 @@ from attr import attrs, define, field
 from taf.api.repository import reset_repository
 from taf.git import GitError
 from taf.git import GitRepository
+from taf.git import _default_branch_cache
 from taf.constants import INFO_JSON_PATH
 
 from taf.models.types import Commitish
@@ -939,6 +940,13 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                 self.state.validation_auth_repo.default_branch = (
                     self.state.validation_auth_repo.get_default_branch(remote_url)
                 )
+                # seed the cache with the authoritative remote value so later
+                # detections for this path don't shell out (clone_bare_from_local
+                # cleared it on purpose; this re-populates it correctly)
+                if self.state.validation_auth_repo.default_branch:
+                    _default_branch_cache[str(self.state.validation_auth_repo.path)] = (
+                        self.state.validation_auth_repo.default_branch
+                    )
                 if self.state.validation_auth_repo.default_branch:
                     self.state.validation_auth_repo._git(
                         "symbolic-ref HEAD refs/heads/{}",

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -1502,7 +1502,12 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                     )
                     self.state.repos_on_disk[users_repo.name] = users_repo
                 else:
-                    temp_repo.clone(bare=self.bare)
+                    # validation never needs a working tree in temp; a bare clone
+                    # avoids materializing (and later deleting) thousands of files
+                    temp_repo.clone(bare=True)
+                    # mirror the ref namespace clone_from_disk produces so both
+                    # temp-repo flavors expose refs/remotes/origin/*
+                    temp_repo._git("fetch . +refs/heads/*:refs/remotes/origin/*")
                     self.state.repos_not_on_disk[users_repo.name] = users_repo
 
             with ThreadPoolExecutor() as executor:

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -2122,8 +2122,10 @@ but commit not on branch {current_branch}"
                 return self.state.update_status
             if self.state.update_status == UpdateStatus.FAILED:
                 return self.state.update_status
-            for repository in self.state.users_target_repositories.values():
+
+            def _merge_repository_commits(repository):
                 # this will only include branches that were, at least partially, validated (up until a certain point)
+                events = []
                 last_branch = self.state.last_validated_data_per_repositories[
                     repository.name
                 ]["branch"]
@@ -2136,10 +2138,22 @@ but commit not on branch {current_branch}"
                     is_last_branch = branch == last_branch
                     last_validated_commit = validated_commits[-1]
                     commit_to_merge = last_validated_commit
-                    update_status = self._merge_commit(
-                        repository, branch, commit_to_merge, is_last_branch
+                    events.append(
+                        self._merge_commit(
+                            repository, branch, commit_to_merge, is_last_branch
+                        )
                     )
-                    events_list.append(update_status)
+                return events
+
+            # repositories are independent of each other, so they can be
+            # merged in parallel (branches within a repository stay sequential)
+            with ThreadPoolExecutor() as executor:
+                futures = [
+                    executor.submit(_merge_repository_commits, repository)
+                    for repository in self.state.users_target_repositories.values()
+                ]
+                for future in as_completed(futures):
+                    events_list.extend(future.result())
 
             if self.state.event == Event.UNCHANGED and Event.CHANGED in events_list:
                 # the auth repository was not updated, but one of the target repositories was
@@ -2196,6 +2210,33 @@ but commit not on branch {current_branch}"
             self.state.event = Event.FAILED
             return UpdateStatus.FAILED
 
+    def _is_already_merged(
+        self,
+        repository: AuthenticationRepository,
+        branch: str,
+        commit_to_merge: Commitish,
+        is_last_branch: bool,
+    ) -> bool:
+        """Check, before any worktree-touching work, if the branch already
+        points to the commit that would be merged and is checked out if it
+        needs to be - skipping the checkout in that case is a substantial
+        saving on Windows, where materializing a working tree is slow."""
+        try:
+            return (
+                repository.branch_exists(branch, include_remotes=False)
+                and repository.top_commit_of_branch(branch) == commit_to_merge
+                and (
+                    not is_last_branch
+                    or (
+                        not repository.is_detached_head
+                        and repository.get_current_branch() == branch
+                    )
+                )
+            )
+        except KeyError:
+            # an error will be raised if the repo is empty
+            return False
+
     def _merge_commit(
         self,
         repository: AuthenticationRepository,
@@ -2209,6 +2250,11 @@ but commit not on branch {current_branch}"
         if repository.is_bare_repository:
             repository.update_ref_for_bare_repository(branch, commit_to_merge)
             return
+
+        if not self.force and self._is_already_merged(
+            repository, branch, commit_to_merge, is_last_branch
+        ):
+            return Event.UNCHANGED
 
         # if the repo is in a deteched head state or if the updated branch exists,
         # but is not checked out, update the repo without automatically checking

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -1515,7 +1515,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                     temp_repo.clone(bare=True)
                     # mirror the ref namespace clone_from_disk produces so both
                     # temp-repo flavors expose refs/remotes/origin/*
-                    temp_repo._git("fetch . +refs/heads/*:refs/remotes/origin/*")
+                    temp_repo.mirror_local_heads_to_remote_tracking()
                     self.state.repos_not_on_disk[users_repo.name] = users_repo
 
             with ThreadPoolExecutor() as executor:

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -32,6 +32,7 @@ from tuf.ngclient.updater import Updater
 from taf.log import taf_logger
 
 EXPIRED_METADATA_ERROR = "ExpiredMetadataError"
+GIT_COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
 
 class UpdateStatus(Enum):
@@ -1384,9 +1385,18 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                 last_validated_data = self.state.users_auth_repo.last_validated_data
                 # exclude filter can be specified if running local validation
                 if not self.exclude_filter:
-                    self.exclude_filter = (
-                        last_validated_data.get("exclude_filter") or None
-                    )
+                    stored_exclude_filter = last_validated_data.get("exclude_filter")
+                    if stored_exclude_filter and GIT_COMMIT_SHA_RE.match(
+                        stored_exclude_filter
+                    ):
+                        taf_logger.warning(
+                            "{}: Ignoring invalid stored exclude_filter that looks like a commit SHA",
+                            self.state.users_auth_repo.name,
+                        )
+                        last_validated_data.pop("exclude_filter", None)
+                        self.state.last_validated_data.pop("exclude_filter", None)
+                        stored_exclude_filter = None
+                    self.exclude_filter = stored_exclude_filter or None
 
             if self.exclude_filter:
                 excluded_repo_names = repositoriesdb.get_repository_names_by_expression(

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -899,8 +899,55 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
             self.state.validation_auth_repo = AuthenticationRepository(
                 path=path, urls=self.urls, alias="Validation repository"
             )
-            self.state.validation_auth_repo.clone(bare=True)
-            self.state.validation_auth_repo.fetch(fetch_all=True)
+            if self.state.existing_repo and self.state.users_auth_repo:
+                # Seed the temp validation repo from the user's on-disk copy (fast,
+                # no network), then fetch only the delta from the real remote.
+                # The refspec +refs/heads/*:refs/heads/* force-updates local heads so
+                # the validation pipeline sees the current remote commits, not the
+                # user's stale ones.
+                remote_url = (
+                    self.urls[0]
+                    if self.urls
+                    else self.state.users_auth_repo.get_remote_url()
+                )
+                if not remote_url:
+                    raise UpdateFailedError(
+                        "URL cannot be determined. Please specify it"
+                    )
+                self.state.validation_auth_repo.clone_bare_from_local(
+                    self.state.users_auth_repo.path
+                )
+                self.state.validation_auth_repo._git(
+                    "remote set-url origin {}",
+                    remote_url,
+                    log_error=True,
+                    reraise_error=True,
+                )
+                self.state.validation_auth_repo._git(
+                    "fetch origin +refs/heads/*:refs/heads/*",
+                    log_error=True,
+                    reraise_error=True,
+                )
+                # Determine default_branch from the real remote, not from the
+                # seeded local repo. clone_bare_from_local leaves HEAD pointing at
+                # the user's checked-out branch (often a speculative/publication
+                # branch after a build), and _determine_default_branch() prefers
+                # local detection, which would fall back to that stale HEAD and
+                # make validation walk the wrong lineage. The remote's HEAD is the
+                # authoritative default branch (matches the clean-clone path).
+                self.state.validation_auth_repo.default_branch = (
+                    self.state.validation_auth_repo.get_default_branch(remote_url)
+                )
+                if self.state.validation_auth_repo.default_branch:
+                    self.state.validation_auth_repo._git(
+                        "symbolic-ref HEAD refs/heads/{}",
+                        self.state.validation_auth_repo.default_branch,
+                        log_error=True,
+                        reraise_error=True,
+                    )
+            else:
+                self.state.validation_auth_repo.clone(bare=True)
+                self.state.validation_auth_repo.fetch(fetch_all=True)
 
             settings.validation_repo_path[self.state.validation_auth_repo.name] = (
                 self.state.validation_auth_repo.path
@@ -962,6 +1009,13 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                 users_head_commit = self.state.users_auth_repo.top_commit_of_branch(
                     default_branch
                 )
+                if users_head_commit is None:
+                    raise UpdateFailedError(
+                        f"Could not find branch '{default_branch}' in local repository "
+                        f"{self.state.users_auth_repo.name}. "
+                        "This can happen if the repository's default branch was changed after cloning. "
+                        "Please re-clone the repository using 'taf repo clone'."
+                    )
                 if not _check_if_commit_on_branch(
                     self.state.validation_auth_repo, users_head_commit, default_branch
                 ):
@@ -1240,10 +1294,38 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
             f"{self.state.auth_repo_name}: Cloning or updating user's authentication repository..."
         )
         try:
+            temp_path = self.state.validation_auth_repo.path
             if self.state.existing_repo:
-                self.state.users_auth_repo.fetch(fetch_all=True)
+                # Fetch new commits from the already-fetched temp validation repo
+                # (local, no network) instead of re-fetching from the real remote.
+                self.state.users_auth_repo._git(
+                    "fetch {} +refs/heads/*:refs/remotes/origin/*",
+                    str(temp_path),
+                    log_error=True,
+                    reraise_error=True,
+                )
             else:
-                self.state.users_auth_repo.clone(bare=self.bare)
+                # Materialize the user's auth repo from the validated temp rather
+                # than cloning from the network a second time.
+                remote_url = (
+                    self.state.users_auth_repo.urls[0]
+                    if self.state.users_auth_repo.urls
+                    else None
+                )
+                # Pass the default branch so clone_from_disk calls set_upstream,
+                # restoring the tracking relationship that remove_remote destroys.
+                # Without it, synced_with_remote() returns False immediately.
+                default_branch = self.state.validation_auth_repo.default_branch
+                branches = (
+                    [default_branch] if default_branch and not self.bare else None
+                )
+                self.state.users_auth_repo.clone_from_disk(
+                    temp_path,
+                    remote_url,
+                    is_bare=self.bare,
+                    fetch_remote=False,
+                    branches=branches,
+                )
         except Exception as e:
             self.state.errors.append(e)
             self.state.event = Event.FAILED
@@ -1619,8 +1701,8 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                         msg = f"{repository.name} does not contain a branch named {branch} and cannot be validated. Please update the repositories."
                         taf_logger.error(msg)
                         raise UpdateFailedError(msg)
-                else:
-                    repository.fetch(branch=branch)
+                # else: clone_target_repositories_to_temp already fetched from
+                # origin, so refs/remotes/origin/* are current — skip re-fetch.
 
             if old_head is not None:
                 if not self.only_validate:
@@ -1945,7 +2027,8 @@ but commit not on branch {current_branch}"
         if self.state.update_status == UpdateStatus.FAILED:
             return self.state.update_status
         try:
-            for repository_name in self.state.repos_not_on_disk:
+
+            def _materialize_not_on_disk(repository_name):
                 branches = [
                     branch
                     for branch in self.state.validated_commits_per_target_repos_branches[
@@ -1961,8 +2044,10 @@ but commit not on branch {current_branch}"
                     temp_target_repo.get_remote_url(),
                     is_bare=self.bare,
                     branches=branches,
+                    fetch_remote=False,
                 )
-            for repository_name in self.state.repos_on_disk:
+
+            def _materialize_on_disk(repository_name):
                 users_target_repo = self.state.users_target_repositories[
                     repository_name
                 ]
@@ -1973,6 +2058,17 @@ but commit not on branch {current_branch}"
                 for branch in branches:
                     temp_target_repo.update_local_branch(branch=branch)
                 users_target_repo.fetch_from_disk(temp_target_repo.path, branches)
+
+            with ThreadPoolExecutor() as executor:
+                futures = [
+                    executor.submit(_materialize_not_on_disk, name)
+                    for name in self.state.repos_not_on_disk
+                ] + [
+                    executor.submit(_materialize_on_disk, name)
+                    for name in self.state.repos_on_disk
+                ]
+                for future in as_completed(futures):
+                    future.result()
 
             return self.state.update_status
         except Exception as e:

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -2097,10 +2097,12 @@ but commit not on branch {current_branch}"
         if not self.state.temp_root:
             return self.state.update_status
         try:
+            # close all repositories first - open pygit2 handles would prevent
+            # renaming/removing the temp directory on Windows
             for repo in self.state.temp_target_repositories.values():
                 repo.cleanup()
-            self.state.temp_root.cleanup()
             self.state.update_handler.cleanup()
+            self.state.temp_root.cleanup_async()
         except Exception:
             taf_logger.warning(
                 f"WARNING: Could not remove clean up temp folder: {self.state.temp_root}. Please remove it manually."

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -901,62 +901,11 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
             self.state.validation_auth_repo = AuthenticationRepository(
                 path=path, urls=self.urls, alias="Validation repository"
             )
-            if self.state.existing_repo and self.state.users_auth_repo:
-                # Seed the temp validation repo from the user's on-disk copy (fast,
-                # no network), then fetch only the delta from the real remote.
-                # The refspec +refs/heads/*:refs/heads/* force-updates local heads so
-                # the validation pipeline sees the current remote commits, not the
-                # user's stale ones.
-                remote_url = (
-                    self.urls[0]
-                    if self.urls
-                    else self.state.users_auth_repo.get_remote_url()
-                )
-                if not remote_url:
-                    raise UpdateFailedError(
-                        "URL cannot be determined. Please specify it"
-                    )
-                self.state.validation_auth_repo.clone_bare_from_local(
-                    self.state.users_auth_repo.path
-                )
-                self.state.validation_auth_repo._git(
-                    "remote set-url origin {}",
-                    remote_url,
-                    log_error=True,
-                    reraise_error=True,
-                )
-                self.state.validation_auth_repo._git(
-                    "fetch origin +refs/heads/*:refs/heads/*",
-                    log_error=True,
-                    reraise_error=True,
-                )
-                # Determine default_branch from the real remote, not from the
-                # seeded local repo. clone_bare_from_local leaves HEAD pointing at
-                # the user's checked-out branch (often a speculative/publication
-                # branch after a build), and _determine_default_branch() prefers
-                # local detection, which would fall back to that stale HEAD and
-                # make validation walk the wrong lineage. The remote's HEAD is the
-                # authoritative default branch (matches the clean-clone path).
-                self.state.validation_auth_repo.default_branch = (
-                    self.state.validation_auth_repo.get_default_branch(remote_url)
-                )
-                # seed the cache with the authoritative remote value so later
-                # detections for this path don't shell out (clone_bare_from_local
-                # cleared it on purpose; this re-populates it correctly)
-                if self.state.validation_auth_repo.default_branch:
-                    _default_branch_cache[str(self.state.validation_auth_repo.path)] = (
-                        self.state.validation_auth_repo.default_branch
-                    )
-                if self.state.validation_auth_repo.default_branch:
-                    self.state.validation_auth_repo._git(
-                        "symbolic-ref HEAD refs/heads/{}",
-                        self.state.validation_auth_repo.default_branch,
-                        log_error=True,
-                        reraise_error=True,
-                    )
-            else:
-                self.state.validation_auth_repo.clone(bare=True)
-                self.state.validation_auth_repo.fetch(fetch_all=True)
+            _populate_validation_auth_repo(
+                self.state.validation_auth_repo,
+                self.state.users_auth_repo if self.state.existing_repo else None,
+                self.urls,
+            )
 
             settings.validation_repo_path[self.state.validation_auth_repo.name] = (
                 self.state.validation_auth_repo.path
@@ -1305,13 +1254,8 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
         try:
             temp_path = self.state.validation_auth_repo.path
             if self.state.existing_repo:
-                # Fetch new commits from the already-fetched temp validation repo
-                # (local, no network) instead of re-fetching from the real remote.
-                self.state.users_auth_repo._git(
-                    "fetch {} +refs/heads/*:refs/remotes/origin/*",
-                    str(temp_path),
-                    log_error=True,
-                    reraise_error=True,
+                self.state.users_auth_repo.fetch_heads_to_remote_tracking(
+                    str(temp_path)
                 )
             else:
                 # Materialize the user's auth repo from the validated temp rather
@@ -1321,9 +1265,6 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                     if self.state.users_auth_repo.urls
                     else None
                 )
-                # Pass the default branch so clone_from_disk calls set_upstream,
-                # restoring the tracking relationship that remove_remote destroys.
-                # Without it, synced_with_remote() returns False immediately.
                 default_branch = self.state.validation_auth_repo.default_branch
                 branches = (
                     [default_branch] if default_branch and not self.bare else None
@@ -1513,9 +1454,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                     # validation never needs a working tree in temp; a bare clone
                     # avoids materializing (and later deleting) thousands of files
                     temp_repo.clone(bare=True)
-                    # mirror the ref namespace clone_from_disk produces so both
-                    # temp-repo flavors expose refs/remotes/origin/*
-                    temp_repo.mirror_local_heads_to_remote_tracking()
+                    temp_repo.fetch_heads_to_remote_tracking()
                     self.state.repos_not_on_disk[users_repo.name] = users_repo
 
             with ThreadPoolExecutor() as executor:
@@ -2503,6 +2442,43 @@ def _get_repository_name_from_info_json(auth_repo, commit_sha):
         raise MissingInfoJsonError(
             "Error during info.json parse. If the authentication repository's path is not specified, info.json metadata is expected to be in targets/protected"
         )
+
+
+def _populate_validation_auth_repo(validation_auth_repo, users_auth_repo, urls):
+    """Fill the temp validation auth repo with the commits to validate.
+
+    When the user already has a local auth repo, seed the validation repo from
+    it (``git clone --local`` hardlinks objects, no network), then point origin
+    at the real remote and force-update heads from it so validation sees the
+    current remote commits rather than the user's possibly-stale ones.
+    Otherwise clone the remote directly.
+
+    The default branch is resolved from the remote: ``clone_bare_from_local``
+    leaves HEAD on whatever branch the user had checked out (often a
+    speculative branch after a build), so the remote's HEAD is the
+    authoritative default branch (matches the clean-clone path). It is cached
+    and HEAD is repointed to it.
+    """
+    if users_auth_repo is None:
+        validation_auth_repo.clone(bare=True)
+        validation_auth_repo.fetch(fetch_all=True)
+        return
+
+    remote_url = urls[0] if urls else users_auth_repo.get_remote_url()
+    if not remote_url:
+        raise UpdateFailedError("URL cannot be determined. Please specify it")
+
+    validation_auth_repo.clone_bare_from_local(users_auth_repo.path)
+    validation_auth_repo.set_remote_url(remote_url)
+    validation_auth_repo.fetch_heads_from_remote()
+    validation_auth_repo.default_branch = validation_auth_repo.get_default_branch(
+        remote_url
+    )
+    if validation_auth_repo.default_branch:
+        _default_branch_cache[str(validation_auth_repo.path)] = (
+            validation_auth_repo.default_branch
+        )
+        validation_auth_repo.set_head_to_branch(validation_auth_repo.default_branch)
 
 
 def _is_unauthenticated_allowed(repository):

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -28,7 +28,7 @@ from taf.updater.handlers import GitUpdater
 from taf.updater.lifecycle_handlers import Event
 from taf.updater.types.update import OperationType, UpdateType
 from taf.utils import TempPartition, on_rm_error, ensure_pre_push_hook
-from tuf.ngclient.updater import Updater
+from taf.updater.in_memory_updater import InMemoryUpdater
 from taf.log import taf_logger
 
 EXPIRED_METADATA_ERROR = "ExpiredMetadataError"
@@ -2465,7 +2465,8 @@ def _run_tuf_updater(git_fetcher, auth_repo_name):
 
     def _init_updater():
         try:
-            return Updater(
+            return InMemoryUpdater(
+                git_fetcher.metadata_store,
                 git_fetcher.metadata_dir,
                 "metadata/",
                 git_fetcher.targets_dir,
@@ -2572,8 +2573,10 @@ def _validate_metadata_on_disk(git_fetcher):
         if re.search(consistent_snaphost_pattern, metadata_file_name):
             continue
 
-        current_tuf_metadata_file = Path(git_fetcher.metadata_dir, metadata_file_name)
-        if not current_tuf_metadata_file.is_file():
+        tuf_metadata_content = git_fetcher.metadata_store.get(
+            git_fetcher._metadata_store_key(metadata_file_name)
+        )
+        if tuf_metadata_content is None:
             # this validation causes an issue with one of the first
             # commits of our production repositories and it should
             # not be enabled until we specify a later commit of those
@@ -2584,8 +2587,9 @@ def _validate_metadata_on_disk(git_fetcher):
             #     f"Invalid metadata file {metadata_file_name}"
             # )
             continue
-        metadata_content = git_fetcher.get_current_metadata_data(metadata_file_name)
-        tuf_metadata_content = current_tuf_metadata_file.read_text()
+        metadata_content = git_fetcher.get_current_metadata_data(
+            metadata_file_name, raw=True
+        )
         if metadata_content != tuf_metadata_content:
             raise UpdateFailedError(f"Invalid metadata file {metadata_file_name}")
 

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -2464,9 +2464,9 @@ def _populate_validation_auth_repo(validation_auth_repo, users_auth_repo, urls):
         validation_auth_repo.fetch(fetch_all=True)
         return
 
+    # the remote URL is already validated by clone_repository/update_repository
+    # before the pipeline runs
     remote_url = urls[0] if urls else users_auth_repo.get_remote_url()
-    if not remote_url:
-        raise UpdateFailedError("URL cannot be determined. Please specify it")
 
     validation_auth_repo.clone_bare_from_local(users_auth_repo.path)
     validation_auth_repo.set_remote_url(remote_url)

--- a/taf/utils.py
+++ b/taf/utils.py
@@ -1,3 +1,4 @@
+import atexit
 import platform
 import click
 import errno
@@ -9,8 +10,11 @@ import stat
 import subprocess
 import tempfile
 import shutil
+import threading
 import uuid
 import sys
+
+from concurrent.futures import ThreadPoolExecutor
 
 from io import BytesIO
 from getpass import getpass
@@ -520,7 +524,38 @@ class timed_run:
         return wrapper_func
 
 
+_background_cleanup_threads: List[threading.Thread] = []
+
+
+def _join_background_cleanup_threads():
+    for thread in _background_cleanup_threads:
+        thread.join(timeout=10)
+
+
+atexit.register(_join_background_cleanup_threads)
+
+
+def _remove_trash_dir(trash_dir):
+    # deletion on Windows is latency-bound, so removing the immediate
+    # subdirectories in parallel gives a substantial speedup
+    trash_dir = Path(trash_dir)
+    try:
+        subdirs = [path for path in trash_dir.iterdir() if path.is_dir()]
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            for _ in executor.map(
+                lambda path: shutil.rmtree(path, onerror=on_rm_error), subdirs
+            ):
+                pass
+        shutil.rmtree(trash_dir, onerror=on_rm_error)
+    except Exception as e:
+        taf_logger.warning(
+            f"Could not remove temp folder {trash_dir}: {e}. Please remove it manually."
+        )
+
+
 class TempPartition:
+    TRASH_SUFFIX = ".taf-trash"
+
     def __init__(self, ref_path):
         self.ref_partition = self.get_partition_root(ref_path)
         temp_dir_partition = self.get_partition_root(Path(tempfile.gettempdir()))
@@ -531,6 +566,30 @@ class TempPartition:
             taf_dir = self.ref_partition / ".taf"
             taf_dir.mkdir(exist_ok=True)
             self.temp_dir = tempfile.mkdtemp(dir=str(taf_dir))
+        self._sweep_stale_trash()
+
+    def _sweep_stale_trash(self):
+        # Remove leftovers of cleanups that did not finish (crash, timeout).
+        # In the same-partition case the parent is the shared system temp dir
+        # (e.g. /tmp on POSIX), where another user could have created a
+        # directory matching the trash pattern - so only delete trash we own
+        # and never follow symlinks.
+        try:
+            own_uid = os.getuid()  # POSIX only; per-user temp dirs on Windows
+        except AttributeError:
+            own_uid = None
+        try:
+            for trash in Path(self.temp_dir).parent.glob(f"*{self.TRASH_SUFFIX}"):
+                try:
+                    if trash.is_symlink():
+                        continue
+                    if own_uid is not None and os.lstat(trash).st_uid != own_uid:
+                        continue
+                    shutil.rmtree(trash, onerror=on_rm_error)
+                except Exception:
+                    pass
+        except Exception:
+            pass
 
     def get_partition_root(self, path):
         # Get the root directory of the partition containing the specified path
@@ -542,6 +601,27 @@ class TempPartition:
         # Remove the temporary directory and the ".taf" directory
         if Path(self.temp_dir).is_dir():
             shutil.rmtree(self.temp_dir, onerror=on_rm_error)
+
+    def cleanup_async(self):
+        """Move the temporary directory out of the way immediately and delete
+        it in the background, keeping the deletion (which can take tens of
+        seconds on Windows) off the update's critical path. All repositories
+        inside the temp directory must be closed before calling this."""
+        if not Path(self.temp_dir).is_dir():
+            return
+        trash_path = f"{self.temp_dir}{uuid.uuid4().hex[:8]}{self.TRASH_SUFFIX}"
+        try:
+            os.rename(self.temp_dir, trash_path)
+        except OSError:
+            # something still holds the temp dir (e.g. open repo handles) -
+            # fall back to synchronous removal
+            self.cleanup()
+            return
+        thread = threading.Thread(
+            target=_remove_trash_dir, args=(trash_path,), daemon=True
+        )
+        _background_cleanup_threads.append(thread)
+        thread.start()
 
     def __enter__(self):
         return self.temp_dir, self.partition


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Passthrough on performance benefits by cutting down network time. 

- taf repo clone is 50% faster. We skip the redundant network fetch when materializing fresh target repos. Validated objects are already in the temp clone, so origin is never re-fetched; materialization is also parallelized.
- taf repo update is 70% faster: build the temp validation auth repo from the user's on-disk copy + a delta fetch, and refresh the user's auth repo from the temp clone. This is cutting two full network pulls of auth history down to one incremental one.
- Target repo network fetch de-duplicated on update: clone_target_repositories_to_temp and get_target_repositories_commits previously each hit origin independently; they now share a single fetch.
- Hot-path debug logging removed: ~125k eager f-string debug() calls inside _get_blob_at_path (invoked ~63k per clone) are gone, saving ~4–5s of pure logging overhead.


Closes #709

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
