### PR TITLE
Fix commits on branch and not other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Fix commits on branch and not other when there is no local merge branch ([744])
 - Fix false out-of-band authentication failures on update and clone ([740])
 
+[744]: https://github.com/openlawlibrary/taf/pull/744
 [740]: https://github.com/openlawlibrary/taf/pull/740
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][keepachangelog],
 and this project adheres to [Semantic Versioning][semver].
 
-
 ## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+
+## [0.38.4]
 
 ### Added
 
@@ -1833,7 +1841,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 [keepachangelog]: https://keepachangelog.com/en/1.0.0/
 [semver]: https://semver.org/spec/v2.0.0.html
-[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.38.3...HEAD
+[unreleased]: https://github.com/openlawlibrary/taf/compare/v0.38.4...HEAD
+[0.38.4]: https://github.com/openlawlibrary/taf/compare/v0.38.3...v0.38.4
 [0.38.3]: https://github.com/openlawlibrary/taf/compare/v0.38.2...v0.38.3
 [0.38.2]: https://github.com/openlawlibrary/taf/compare/v0.38.1...v0.38.2
 [0.38.1]: https://github.com/openlawlibrary/taf/compare/v0.38.0...v0.38.1

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 PACKAGE_NAME = "taf"
-VERSION = "0.38.3"
+VERSION = "0.38.4"
 AUTHOR = "Open Law Library"
 AUTHOR_EMAIL = "info@openlawlib.org"
 DESCRIPTION = "Implementation of archival authentication"

--- a/taf/git.py
+++ b/taf/git.py
@@ -1020,6 +1020,16 @@ class GitRepository:
         a commit from another branch. For example, to find only commits
         on a speculative branch and not on the main branch.
         """
+        if not self.branch_exists(branch2, include_remotes=False):
+            remote_tracking = self.find_remote_tracking_branch(branch2)
+            if remote_tracking is not None:
+                branch2 = remote_tracking
+            else:
+                raise GitError(
+                    self,
+                    message=f"Branch {branch2} does not exist locally or on any remote",
+                )
+
         merge_base = self.get_merge_base(branch1, branch2)
         commits = self.all_commits_since_commit(merge_base, branch1, reverse=False)
 
@@ -1359,6 +1369,18 @@ class GitRepository:
             return tracking_branch
         except GitError:
             return None
+
+    def find_remote_tracking_branch(self, branch_name: str) -> Optional[str]:
+        """Returns the first remote tracking ref matching branch_name across all remotes
+        (e.g. 'origin/main' for 'main'), or None if no remote has a tracking branch for it.
+        Useful when a branch no longer exists locally but its remote tracking ref is still present.
+        """
+        repo = self.pygit_repo
+        for remote in self.remotes:
+            remote_tracking = f"{remote}/{branch_name}"
+            if repo.branches.remote.get(remote_tracking) is not None:
+                return remote_tracking
+        return None
 
     def set_tracking_branch(
         self,

--- a/taf/git.py
+++ b/taf/git.py
@@ -1020,15 +1020,8 @@ class GitRepository:
         a commit from another branch. For example, to find only commits
         on a speculative branch and not on the main branch.
         """
-        if not self.branch_exists(branch2, include_remotes=False):
-            remote_tracking = self.find_remote_tracking_branch(branch2)
-            if remote_tracking is not None:
-                branch2 = remote_tracking
-            else:
-                raise GitError(
-                    self,
-                    message=f"Branch {branch2} does not exist locally or on any remote",
-                )
+        branch1 = self.get_branch_reference(branch1)
+        branch2 = self.get_branch_reference(branch2)
 
         merge_base = self.get_merge_base(branch1, branch2)
         commits = self.all_commits_since_commit(merge_base, branch1, reverse=False)
@@ -1322,6 +1315,20 @@ class GitRepository:
         if full_name:
             return branch.name
         return branch.shorthand
+
+    def get_branch_reference(self, branch_name: str) -> str:
+        """Return a local branch name or matching remote-tracking branch reference."""
+        if self.branch_exists(branch_name, include_remotes=False):
+            return branch_name
+
+        remote_tracking = self.find_remote_tracking_branch(branch_name)
+        if remote_tracking is not None:
+            return remote_tracking
+
+        raise GitError(
+            self,
+            message=f"Branch {branch_name} does not exist locally or on any remote",
+        )
 
     def get_last_remote_commit(
         self, url: Optional[str] = None, branch: Optional[str] = None

--- a/taf/tests/test_git/test_commits_on_branch_and_not_other.py
+++ b/taf/tests/test_git/test_commits_on_branch_and_not_other.py
@@ -1,0 +1,51 @@
+from taf.git import GitRepository
+
+
+def test_commits_on_branch_and_not_other(repository: GitRepository):
+    branch_name = "new-branch"
+    repository.create_and_checkout_branch(branch_name)
+    commit1 = repository.commit_empty("test commit1")
+    commit2 = repository.commit_empty("test commit2")
+    commit3 = repository.commit_empty("test commit3")
+    assert repository.default_branch
+    all_commits = repository.commits_on_branch_and_not_other(
+        branch_name, repository.default_branch
+    )
+    assert len(all_commits) == 3
+    for commit in (commit1, commit2, commit3):
+        assert commit in all_commits
+
+
+def test_commits_on_branch_and_not_other_when_base_branch_exists_only_on_remote(
+    origin_repo: GitRepository,
+    clone_repository: GitRepository,
+    repository: GitRepository,
+):
+    # Push a feature branch (created from main) to origin
+    default_branch = repository.default_branch
+    repository.add_remote("origin", str(origin_repo.path))
+    feature_branch = "feature"
+    repository.create_and_checkout_branch(feature_branch)
+    commit1 = repository.commit_empty("feature commit1")
+    commit2 = repository.commit_empty("feature commit2")
+    repository.push(branch=feature_branch, set_upstream=True)
+
+    # Clone origin - main is checked out locally, feature is remote-only
+    clone_repository.urls = [str(origin_repo.path)]
+    clone_repository.clone()
+    clone_repository.fetch(branch=feature_branch)
+
+    # Simulate the default branch being changed on the remote: delete local main
+    # so it only exists as origin/main (remote tracking)
+    clone_repository.checkout_branch(feature_branch)
+    clone_repository.delete_branch(default_branch)
+
+    assert not clone_repository.branch_exists(default_branch, include_remotes=False)
+    assert clone_repository.branch_exists(default_branch)
+
+    # Should return only the 2 feature commits, not all commits on the branch
+    commits = clone_repository.commits_on_branch_and_not_other(
+        feature_branch, default_branch
+    )
+    assert len(commits) == 2
+    assert set(commits) == {commit1, commit2}

--- a/taf/tests/test_git/test_commits_on_branch_and_not_other.py
+++ b/taf/tests/test_git/test_commits_on_branch_and_not_other.py
@@ -25,6 +25,7 @@ def test_commits_on_branch_and_not_other_when_base_branch_exists_only_on_remote(
 ):
     # Push a feature branch (created from main) to origin
     default_branch = repository.default_branch
+    assert default_branch
     repository.add_remote("origin", str(origin_repo.path))
     feature_branch = "feature"
     repository.create_and_checkout_branch(feature_branch)

--- a/taf/tests/test_git/test_commits_on_branch_and_not_other.py
+++ b/taf/tests/test_git/test_commits_on_branch_and_not_other.py
@@ -1,3 +1,5 @@
+import pytest
+from taf.exceptions import GitError
 from taf.git import GitRepository
 
 
@@ -49,3 +51,13 @@ def test_commits_on_branch_and_not_other_when_base_branch_exists_only_on_remote(
     )
     assert len(commits) == 2
     assert set(commits) == {commit1, commit2}
+
+
+def test_commits_on_branch_and_not_other_raises_when_branch_does_not_exist(
+    repository: GitRepository,
+):
+    branch_name = "new-branch"
+    repository.create_and_checkout_branch(branch_name)
+    repository.commit_empty("test commit1")
+    with pytest.raises(GitError, match="does not exist"):
+        repository.commits_on_branch_and_not_other(branch_name, "nonexistent-branch")

--- a/taf/tests/test_git/test_commits_on_branch_and_not_other.py
+++ b/taf/tests/test_git/test_commits_on_branch_and_not_other.py
@@ -54,6 +54,36 @@ def test_commits_on_branch_and_not_other_when_base_branch_exists_only_on_remote(
     assert set(commits) == {commit1, commit2}
 
 
+def test_commits_on_branch_and_not_other_when_source_branch_exists_only_on_remote(
+    origin_repo: GitRepository,
+    clone_repository: GitRepository,
+    repository: GitRepository,
+):
+    default_branch = repository.default_branch
+    assert default_branch
+    repository.add_remote("origin", str(origin_repo.path))
+    feature_branch = "feature"
+    repository.create_and_checkout_branch(feature_branch)
+    commit1 = repository.commit_empty("feature commit1")
+    commit2 = repository.commit_empty("feature commit2")
+    repository.push(branch=feature_branch, set_upstream=True)
+
+    clone_repository.urls = [str(origin_repo.path)]
+    clone_repository.clone()
+    clone_repository.fetch(branch=feature_branch)
+    clone_repository.checkout_branch(default_branch)
+    clone_repository.delete_branch(feature_branch)
+
+    assert not clone_repository.branch_exists(feature_branch, include_remotes=False)
+    assert clone_repository.branch_exists(feature_branch)
+
+    commits = clone_repository.commits_on_branch_and_not_other(
+        feature_branch, default_branch
+    )
+    assert len(commits) == 2
+    assert set(commits) == {commit1, commit2}
+
+
 def test_commits_on_branch_and_not_other_raises_when_branch_does_not_exist(
     repository: GitRepository,
 ):

--- a/taf/tests/test_git/test_git.py
+++ b/taf/tests/test_git/test_git.py
@@ -299,7 +299,6 @@ def test_commit_exists(repository: GitRepository):
     assert not repository.commit_exists(Commitish.from_hash("123456"))
 
 
-
 def test_commit_before_commit(repository: GitRepository):
     commit1 = repository.commit_empty("test commit1")
     commit2 = repository.commit_empty("test commit2")

--- a/taf/tests/test_git/test_git.py
+++ b/taf/tests/test_git/test_git.py
@@ -299,20 +299,6 @@ def test_commit_exists(repository: GitRepository):
     assert not repository.commit_exists(Commitish.from_hash("123456"))
 
 
-def test_commit_on_branch_an_not_other(repository: GitRepository):
-    branch_name = "new-branch"
-    repository.create_and_checkout_branch(branch_name)
-    commit1 = repository.commit_empty("test commit1")
-    commit2 = repository.commit_empty("test commit2")
-    commit3 = repository.commit_empty("test commit3")
-    assert repository.default_branch
-    all_commits = repository.commits_on_branch_and_not_other(
-        branch_name, repository.default_branch
-    )
-    assert len(all_commits) == 3
-    for commit in (commit1, commit2, commit3):
-        assert commit in all_commits
-
 
 def test_commit_before_commit(repository: GitRepository):
     commit1 = repository.commit_empty("test commit1")


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Commits on one branch and not the other was returning all commits on the branch in case when there was no merge branch. Then there was no local source branch, it was returning an empty list. Added failing tests and update the code to get that passing.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
