### PR TITLE
fix: raise clear error when target repo is missing a referenced branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Raise clear error when a target repository is missing a branch referenced by the authentication repository's target metadata ([751])
+
+[751]: https://github.com/openlawlibrary/taf/pull/751
+
 
 ## [0.38.4]
 

--- a/taf/tests/test_updater/conftest.py
+++ b/taf/tests/test_updater/conftest.py
@@ -84,6 +84,7 @@ UNCOMMITTED_CHANGES_RESET_PATTERN = r"There are uncommited changes in ([A-Za-z0-
 DETACHED_HEAD_RESET_PATTERN = r"(\w+\/\w+) is in detached head state. Fix the state manually or run reset with force flag."
 OLD_LVC_FORMAT_ERROR_PATTERN = r"Failure to set excluded targets for repo (\w+\/\w+) - last_validated_commit file is in old format which is not supported anymore. Please delete the file and re-run the command."
 DEFAULT_BRANCH_NOT_FOUND_PATTERN = r"Update of ([\w/]+) failed due to error: Could not find branch '[\w-]+' in local repository ([\w/]+)\. This can happen if the repository's default branch was changed after cloning\. Please re-clone the repository using 'taf repo clone'\."
+TARGET_MISSING_BRANCH_PATTERN = r"Update of (\w+\/\w+) failed due to error: Target repository '([\w/-]+)' does not contain branch '[^']+', which is referenced by authentication repository '([\w/-]+)'.*All branches referenced by the authentication repository's target metadata must be present in the target repositories\."
 
 
 # Disable console logging for all tests
@@ -661,6 +662,21 @@ def switch_target_branch_and_sign(
     sign_target_repositories(
         TEST_DATA_ORIGIN_PATH, auth_repo.name, KEYSTORE_PATH, pin_manager
     )
+
+
+def delete_target_branch(
+    target_repos: list,
+    target_name: str,
+    branch_name: str,
+):
+    """Delete a branch from the named target repository, checking out the
+    default branch first. This simulates a target repository that is missing
+    a branch which the authentication repository's target metadata references."""
+    for repo in target_repos:
+        if target_name in repo.name:
+            repo.checkout_branch(repo.default_branch)
+            repo.delete_local_branch(branch_name)
+            break
 
 
 def create_index_lock(auth_repo: AuthenticationRepository, client_dir: Path):

--- a/taf/tests/test_updater/test_update/test_update_invalid.py
+++ b/taf/tests/test_updater/test_update/test_update_invalid.py
@@ -5,6 +5,7 @@ from taf.tests.test_updater.conftest import (
     DEFAULT_BRANCH_NOT_FOUND_PATTERN,
     INVALID_KEYS_PATTERN,
     LVC_NOT_IN_REMOTE_PATTERN,
+    TARGET_MISSING_BRANCH_PATTERN,
     TARGET_MISSMATCH_PATTERN,
     UNCOMMITTED_CHANGES,
     OLD_LVC_FORMAT_ERROR_PATTERN,
@@ -12,7 +13,9 @@ from taf.tests.test_updater.conftest import (
     add_unauthenticated_commits_to_all_target_repos,
     add_valid_target_commits,
     create_file_without_committing,
+    delete_target_branch,
     set_last_validated_commit_of_auth_repo,
+    switch_target_branch_and_sign,
     update_expiration_dates,
     update_timestamp_metadata_invalid_signature,
     replace_with_old_last_validated_commit_format,
@@ -180,6 +183,48 @@ def test_update_when_old_last_validated_commit(origin_auth_repo, client_dir):
         origin_auth_repo,
         client_dir,
         OLD_LVC_FORMAT_ERROR_PATTERN,
+        True,
+    )
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [{"name": "target1"}, {"name": "target2"}],
+        },
+    ],
+    indirect=True,
+)
+def test_update_fails_when_target_repo_missing_referenced_branch(
+    origin_auth_repo, client_dir
+):
+    """The auth repo's target metadata pins target1 at a commit on a branch that
+    is not present in the target repository. The updater must fail with a clear
+    error naming the target repo and the missing branch, not an IndexError/KeyError."""
+    clone_repositories(origin_auth_repo, client_dir)
+
+    missing_branch = "missing-branch"
+
+    setup_manager = SetupManager(origin_auth_repo)
+    # record a commit on `missing_branch` of target1 in the auth metadata
+    setup_manager.add_task(
+        switch_target_branch_and_sign,
+        kwargs={"target_name": "target1", "branch_name": missing_branch},
+    )
+    # then remove that branch from the target repo so the auth repo references
+    # a branch the target repo no longer contains
+    setup_manager.add_task(
+        delete_target_branch,
+        kwargs={"target_name": "target1", "branch_name": missing_branch},
+    )
+    setup_manager.execute_tasks()
+
+    update_invalid_repos_and_check_if_repos_exist(
+        OperationType.UPDATE,
+        origin_auth_repo,
+        client_dir,
+        TARGET_MISSING_BRANCH_PATTERN,
         True,
     )
 

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -1663,6 +1663,13 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                         msg = f"{repository.name} does not contain a branch named {branch} and cannot be validated. Please update the repositories."
                         taf_logger.error(msg)
                         raise UpdateFailedError(msg)
+                elif not branch_exists:
+                    raise UpdateFailedError(
+                        f"Target repository '{repository.name}' does not contain branch '{branch}', "
+                        f"which is referenced by authentication repository '{self.state.auth_repo_name}'. "
+                        "All branches referenced by the authentication repository's target metadata "
+                        "must be present in the target repositories."
+                    )
                 # else: clone_target_repositories_to_temp already fetched from
                 # origin, so refs/remotes/origin/* are current — skip re-fetch.
 


### PR DESCRIPTION
## What

When the authentication repository's target metadata references a branch that a target repository does not actually contain, the updater now raises a clear `UpdateFailedError` naming the target repo, the missing branch, and the auth repo.

## Why

Previously this situation surfaced as an opaque `IndexError`/`KeyError` deep in the update pipeline, giving no indication of the real cause.

## Changes

- `taf/updater/updater_pipeline.py`: in `get_target_repositories_commits`, raise a descriptive `UpdateFailedError` when a referenced branch is missing from a target repo on disk (non-validate path).
- `taf/tests/test_updater/conftest.py`: add `delete_target_branch` helper and `TARGET_MISSING_BRANCH_PATTERN`.
- `taf/tests/test_updater/test_update/test_update_invalid.py`: add regression test `test_update_fails_when_target_repo_missing_referenced_branch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ha9oVdZM5uqXJSurqWNtu7