### PR TITLE
fix: use set_last_validated_of_repo in dev-mode reset path

### DIFF
--- a/taf/tests/test_updater/test_update/test_update_partial.py
+++ b/taf/tests/test_updater/test_update/test_update_partial.py
@@ -9,7 +9,6 @@ from taf.tests.test_updater.conftest import (
     add_unauthenticated_commit_to_target_repo,
     add_valid_target_commits,
     set_head_commit,
-    update_expiration_dates,
     update_target_repo_without_committing,
 )
 from taf.tests.test_updater.update_utils import (
@@ -62,42 +61,6 @@ def test_update_partial_with_invalid_commits(origin_auth_repo, client_dir):
         client_dir,
         force=True,
     )
-
-
-@pytest.mark.parametrize(
-    "origin_auth_repo",
-    [
-        {
-            "targets_config": [{"name": "target1"}, {"name": "target2"}],
-        },
-    ],
-    indirect=True,
-)
-def test_update_ignores_commit_sha_stored_as_exclude_filter(
-    origin_auth_repo, client_dir
-):
-    clone_repositories(
-        origin_auth_repo,
-        client_dir,
-    )
-
-    client_auth_repo = AuthenticationRepository(path=client_dir / origin_auth_repo.name)
-    lvc_data = client_auth_repo.last_validated_data
-    lvc_data["exclude_filter"] = client_auth_repo.head_commit().value
-    client_auth_repo.set_last_validated_data(lvc_data, set_last_validated_commit=False)
-
-    setup_manager = SetupManager(origin_auth_repo)
-    setup_manager.add_task(update_expiration_dates)
-    setup_manager.execute_tasks()
-
-    update_and_check_commit_shas(
-        OperationType.UPDATE,
-        origin_auth_repo,
-        client_dir,
-    )
-
-    client_auth_repo = AuthenticationRepository(path=client_dir / origin_auth_repo.name)
-    assert "exclude_filter" not in client_auth_repo.last_validated_data
 
 
 @pytest.mark.parametrize(

--- a/taf/updater/updater.py
+++ b/taf/updater/updater.py
@@ -127,7 +127,7 @@ def _reset_to_commits_before_pull(auth_repo, commits_data, targets_data):
 
     auth_repo.checkout_branch(auth_repo.default_branch)
     _reset_repository(auth_repo, commits_data)
-    auth_repo.set_last_validated_commit(commits_data.before_pull)
+    auth_repo.set_last_validated_of_repo(auth_repo.name, commits_data.before_pull)
 
     for repo_name, repo_data in targets_data.items():
         repo = repositoriesdb.get_repository(auth_repo, repo_name)

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -33,7 +33,6 @@ from taf.updater.in_memory_updater import InMemoryUpdater
 from taf.log import taf_logger
 
 EXPIRED_METADATA_ERROR = "ExpiredMetadataError"
-GIT_COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
 
 class UpdateStatus(Enum):
@@ -1334,18 +1333,9 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
                 last_validated_data = self.state.users_auth_repo.last_validated_data
                 # exclude filter can be specified if running local validation
                 if not self.exclude_filter:
-                    stored_exclude_filter = last_validated_data.get("exclude_filter")
-                    if stored_exclude_filter and GIT_COMMIT_SHA_RE.match(
-                        stored_exclude_filter
-                    ):
-                        taf_logger.warning(
-                            "{}: Ignoring invalid stored exclude_filter that looks like a commit SHA",
-                            self.state.users_auth_repo.name,
-                        )
-                        last_validated_data.pop("exclude_filter", None)
-                        self.state.last_validated_data.pop("exclude_filter", None)
-                        stored_exclude_filter = None
-                    self.exclude_filter = stored_exclude_filter or None
+                    self.exclude_filter = (
+                        last_validated_data.get("exclude_filter") or None
+                    )
 
             if self.exclude_filter:
                 excluded_repo_names = repositoriesdb.get_repository_names_by_expression(


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

_reset_to_commits_before_pull called set_last_validated_commit, which was removed in an earlier refactor, causing an AttributeError instead of resetting last-validated state on script handler failure. Also drop the exclude_filter-looks-like-a-SHA workaround (and its test).

Closes #749 


## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
