### PR TITLE
fix: disable_file_logging must remove all file handlers, not just "log"

### DIFF
--- a/taf/log.py
+++ b/taf/log.py
@@ -53,11 +53,12 @@ def disable_console_logging():
 
 
 def disable_file_logging():
-    try:
-        taf_logger.remove(file_loggers["log"])
-    except (KeyError, ValueError):
-        # will be raised if this is called twice
-        pass
+    for handler_id in file_loggers:
+        try:
+            taf_logger.remove(file_loggers[handler_id])
+        except (KeyError, ValueError):
+            # will be raised if this is called twice
+            pass
 
 
 def _get_log_location():


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Only the "log" handler was removed, leaving the "error" and "debug" handlers active even after disable_file_logging() was called.

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
