### PR TITLE
fix(git): make clone failures diagnosable (spaced paths, swallowed errors, wrong message)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,12 @@ and this project adheres to [Semantic Versioning][semver].
 ### Fixed
 
 - Detect signing scheme from key material instead of assuming RSA ([757])
+- Clone no longer fails when the repository path contains a space (e.g. a Windows home directory with a space in the user name) ([762])
+- Surface the underlying git error when a clone fails, instead of hiding it behind a generic access message ([762])
+- Correct the clone access error that rendered as "Cannot None ..." and stop misattributing a local failure to an access/authentication problem ([762])
 
 
+[762]: https://github.com/openlawlibrary/taf/pull/762
 [759]: https://github.com/openlawlibrary/taf/pull/759
 [757]: https://github.com/openlawlibrary/taf/pull/757
 

--- a/taf/git.py
+++ b/taf/git.py
@@ -30,7 +30,7 @@ from taf.exceptions import (
     PygitError,
 )
 from taf.log import NOTICE, taf_logger
-from taf.utils import run
+from taf.utils import format_command_args, run
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 _PyGitRepositoryClass: Any = None
@@ -280,9 +280,12 @@ class GitRepository:
         return self._is_bare_repo
 
     def _git(self, cmd, *args, **kwargs):
-        """Call git commands in subprocess
-        e.g.:
-          self._git('checkout {}', branch_name)
+        """Call git commands in subprocess.
+
+        e.g.: self._git('checkout {}', branch_name)
+
+        Pass paths/URLs as `{}` args rather than interpolating them into `cmd`,
+        so a value containing a space stays a single argv token.
         """
         log_error = kwargs.pop("log_error", False)
         log_error_msg = kwargs.pop("log_error_msg", "")
@@ -290,29 +293,10 @@ class GitRepository:
         log_success_msg = kwargs.pop("log_success_msg", "")
         error_if_not_exists = kwargs.pop("error_if_not_exists", True)
 
-        # Build an argv list rather than one string: run() whitespace-splits a
-        # single-string command, which shatters any argument containing a space
-        # (e.g. a Windows path under a home dir with a space in the user name) -
-        # both `git -C <path>` and any `{}` argument such as a local clone
-        # source. The template is tokenized first and each `{}` placeholder is
-        # filled positionally in place, so a substituted value stays a single
-        # argv token no matter what it contains, while the command's own
-        # tokenization is unchanged. Callers must therefore pass paths/URLs as
-        # `{}` arguments, not interpolate them into the command string.
         command = ["git", "-C", str(self.path)]
         if self.allow_unsafe:
             command += ["-c", f"safe.directory={self.path}"]
-        args_iter = iter(args)
-        for token in cmd.split():
-            placeholders = token.count("{}")
-            if placeholders:
-                token = token.format(*[next(args_iter) for _ in range(placeholders)])
-            # an empty token means an optional flag arg was "" (e.g. push's
-            # force/no-verify flags); drop it, matching the old .split() which
-            # collapsed empties, so it does not reach git as an empty argument
-            if token != "":
-                command.append(token)
-        command_str = " ".join(command)
+        command += format_command_args(cmd, *args)
         result = None
         if log_error or log_error_msg:
             try:
@@ -331,7 +315,7 @@ class GitRepository:
                     error = GitError(self, message=log_error_msg, error=e)
                     self._log_error(error.message)
                 else:
-                    error = GitError(self, command=command_str, error=e)
+                    error = GitError(self, command=" ".join(command), error=e)
                     # not every git error indicates a problem
                     # if it does, we expect that either custom error message will be provided
                     # or that the error will be reraised
@@ -342,7 +326,7 @@ class GitRepository:
             try:
                 result = run(*command, **kwargs)
             except subprocess.CalledProcessError as e:
-                raise GitError(self, command=command_str, error=e)
+                raise GitError(self, command=" ".join(command), error=e)
             if log_success_msg:
                 self._log_debug(log_success_msg)
         return result
@@ -855,9 +839,8 @@ class GitRepository:
         for url in self.urls:
             self._log_info(f"trying to clone from {url}")
             try:
-                # url is a `{}` arg (kept as a single token); joined_params holds
-                # controlled flags meant to expand into multiple tokens, so it
-                # stays in the template string
+                # joined_params stays in the template (controlled flags); url
+                # is the only `{}` arg, so it stays one token
                 self._git(
                     f"clone {{}} . {joined_params}",
                     url,
@@ -868,7 +851,7 @@ class GitRepository:
                 )
             except GitError as e:
                 self._log_debug(f"could not clone from {url} due to {e}")
-                clone_errors.append(f"{url}: {e}")
+                clone_errors.append(e)
             else:
                 self._log_info(f"successfully cloned from {url}")
                 cloned = True
@@ -912,8 +895,7 @@ class GitRepository:
         # file-by-file object copy pygit2 performs. git silently falls back to
         # copying when hardlinks are not possible, so this is never slower.
         bare_flag = "--bare " if is_bare else ""
-        # pass the source path as a `{}` arg (the `{{}}` survives the f-string)
-        # so a path containing a space is not split into separate tokens
+        # local_path as a `{}` arg keeps it one token even with spaces
         self._git(
             f"clone --local {bare_flag}{{}} .",
             str(local_path),
@@ -1834,22 +1816,20 @@ class GitRepository:
         error_cls=GitAccessDeniedException,
         operation="access",
         error_msg="",
-        underlying_errors=None,
+        underlying_errors: Optional[List[Exception]] = None,
     ):
         """Raise ``error_cls`` explaining why a git network operation failed.
 
         ``operation`` names the attempted action (e.g. ``"clone"``) in the
         message. ``error_msg``, when given, replaces the auto-selected guidance.
-        ``underlying_errors`` is the list of concrete per-attempt git failures
-        (typically one per URL); they are surfaced on the exception so the real
-        cause is never hidden behind the guidance.
+        ``underlying_errors`` are the concrete per-attempt failures (typically
+        one per URL, as caught - not pre-formatted); they're listed in the
+        message and the most recent one becomes the raised exception's
+        ``__cause__``, so the real cause is never hidden behind the guidance.
         """
-        # Pick the guidance that best fits what we can observe about the remote,
-        # then surface the concrete git failure(s) alongside it. The guidance is
-        # a best guess (an unauthenticated probe cannot tell "private" from
-        # "missing"); the underlying errors are the ground truth and must not be
-        # swallowed - historically only the guidance was shown, hiding the real
-        # cause (e.g. a command-construction failure, not an access problem).
+        # guidance is a best guess (an unauthenticated probe can't tell "private"
+        # from "missing"); underlying_errors are the ground truth and are always
+        # shown alongside it
         hosts = {
             h for h in (extract_hostname(url) for url in self.urls) if h is not None
         }
@@ -1871,15 +1851,19 @@ class GitRepository:
         parts = []
         if underlying_errors:
             parts.append(
-                "The git command failed with:\n" + "\n".join(underlying_errors)
+                "The git command failed with:\n"
+                + "\n".join(str(err) for err in underlying_errors)
             )
         if guidance:
             parts.append(guidance)
+        # chain to the most recent underlying failure so it's available via
+        # the standard __cause__/traceback instead of a bespoke attribute
+        cause = underlying_errors[-1] if underlying_errors else None
         raise error_cls(
             self,
             operation=operation,
             message="\n\n".join(parts) if parts else None,
-        )
+        ) from cause
 
     def remove_remote(self, remote_name: str) -> None:
         try:
@@ -1978,8 +1962,7 @@ class GitRepository:
         return None
 
     def set_remote_url(self, new_url: str, remote: Optional[str] = "origin") -> None:
-        # new_url may be a local filesystem path containing spaces - pass it as
-        # a `{}` arg so it is not split into separate tokens
+        # new_url may contain spaces (a local path) - pass as a `{}` arg
         self._git("remote set-url {} {}", remote, new_url)
 
     def set_head_to_branch(self, branch_name: str) -> None:

--- a/taf/git.py
+++ b/taf/git.py
@@ -292,14 +292,21 @@ class GitRepository:
 
         if len(args):
             cmd = cmd.format(*args)
+        # Build an argv list rather than one string: run() whitespace-splits a
+        # single-string command, which shatters `git -C <path>` when the
+        # repository path contains a space (e.g. a Windows home dir with a space
+        # in the user name). Passing the path as its own token keeps it intact,
+        # while cmd.split() preserves the previous tokenization of the command
+        # itself, so no other git invocation changes.
+        command = ["git", "-C", str(self.path)]
         if self.allow_unsafe:
-            command = f"git -C {self.path} -c safe.directory={self.path} {cmd}"
-        else:
-            command = f"git -C {self.path} {cmd}"
+            command += ["-c", f"safe.directory={self.path}"]
+        command += cmd.split()
+        command_str = " ".join(command)
         result = None
         if log_error or log_error_msg:
             try:
-                result = run(command, **kwargs)
+                result = run(*command, **kwargs)
                 if log_success_msg:
                     self._log_debug(log_success_msg)
             except subprocess.CalledProcessError as e:
@@ -314,7 +321,7 @@ class GitRepository:
                     error = GitError(self, message=log_error_msg, error=e)
                     self._log_error(error.message)
                 else:
-                    error = GitError(self, command=command, error=e)
+                    error = GitError(self, command=command_str, error=e)
                     # not every git error indicates a problem
                     # if it does, we expect that either custom error message will be provided
                     # or that the error will be reraised
@@ -323,9 +330,9 @@ class GitRepository:
                     raise error
         else:
             try:
-                result = run(command, **kwargs)
+                result = run(*command, **kwargs)
             except subprocess.CalledProcessError as e:
-                raise GitError(self, command=command, error=e)
+                raise GitError(self, command=command_str, error=e)
             if log_success_msg:
                 self._log_debug(log_success_msg)
         return result
@@ -834,6 +841,7 @@ class GitRepository:
         joined_params = " ".join(params)
 
         cloned = False
+        clone_errors = []
         for url in self.urls:
             self._log_info(f"trying to clone from {url}")
             try:
@@ -848,13 +856,16 @@ class GitRepository:
                 )
             except GitError as e:
                 self._log_debug(f"could not clone from {url} due to {e}")
+                clone_errors.append(f"{url}: {e}")
             else:
                 self._log_info(f"successfully cloned from {url}")
                 cloned = True
                 break
 
         if not cloned:
-            self.raise_git_access_error(CloneRepoException, operation="clone")
+            self.raise_git_access_error(
+                CloneRepoException, operation="clone", underlying_errors=clone_errors
+            )
 
         # the path is now a repository; drop any cached negative result from
         # before the clone
@@ -1802,40 +1813,47 @@ class GitRepository:
             raise PushFailedError(self, message=f"Push operation failed: {e}")
 
     def raise_git_access_error(
-        self, error_cls=GitAccessDeniedException, operation="access", error_msg=""
+        self,
+        error_cls=GitAccessDeniedException,
+        operation="access",
+        error_msg="",
+        underlying_errors=None,
     ):
+        # Pick the guidance that best fits what we can observe about the remote,
+        # then surface the concrete git failure(s) alongside it. The guidance is
+        # a best guess (an unauthenticated probe cannot tell "private" from
+        # "missing"); the underlying errors are the ground truth and must not be
+        # swallowed - historically only the guidance was shown, hiding the real
+        # cause (e.g. a command-construction failure, not an access problem).
         hosts = {
             h for h in (extract_hostname(url) for url in self.urls) if h is not None
         }
         unknown_hosts = [host for host in hosts if not is_host_known(host)]
-        if len(unknown_hosts):
-            message = _no_hosts_error_format.format(hostname=",".join(unknown_hosts))
-            raise error_cls(self, operation=operation, message=message)
-        repo_exists = any(repository_exists(url) for url in self.urls)
-        if repo_exists:
+        if error_msg:
+            guidance = error_msg
+        elif len(unknown_hosts):
+            guidance = _no_hosts_error_format.format(hostname=",".join(unknown_hosts))
+        elif any(repository_exists(url) for url in self.urls):
             uses_ssh = any(url.startswith("git@") for url in self.urls)
-            if uses_ssh:
-                raise error_cls(
-                    self,
-                    operation=operation,
-                    message=(
-                        _clone_or_pull_error_message if error_msg == "" else error_msg
-                    ),
-                )
-            else:
-                raise error_cls(
-                    self,
-                    operation=operation,
-                    message=(
-                        _clone_or_pull_error_message_no_ssh
-                        if error_msg == ""
-                        else error_msg
-                    ),
-                )
+            guidance = (
+                _clone_or_pull_error_message
+                if uses_ssh
+                else _clone_or_pull_error_message_no_ssh
+            )
+        else:
+            guidance = _repo_not_found_error_message
+
+        parts = []
+        if underlying_errors:
+            parts.append(
+                "The git command failed with:\n" + "\n".join(underlying_errors)
+            )
+        if guidance:
+            parts.append(guidance)
         raise error_cls(
             self,
             operation=operation,
-            message=(_repo_not_found_error_message if error_msg == "" else error_msg),
+            message="\n\n".join(parts) if parts else None,
         )
 
     def remove_remote(self, remote_name: str) -> None:
@@ -2231,12 +2249,13 @@ _clone_or_pull_error_message_no_ssh = (
 
 
 _repo_not_found_error_message = (
-    "The remote repository could not be found. Note that a private repository is "
-    "indistinguishable from a missing one when you are not authenticated, so this is "
-    "most likely an access/authentication problem rather than a wrong URL. Please:\n\n"
-    "1. Double-check the repository URL for typos.\n"
-    "2. If the repository is private, verify that your account has been granted access.\n"
-    "3. Verify your credentials are configured for this host:\n"
+    "The remote repository could not be reached or found. If a git error is shown "
+    "above, start there - it is the actual failure. Otherwise, note that an "
+    "unauthenticated check cannot tell a private repository apart from a missing "
+    "one, so common causes are:\n\n"
+    "1. A wrong or mistyped repository URL.\n"
+    "2. A private repository your account has not been granted access to.\n"
+    "3. Missing or misconfigured credentials for this host:\n"
     "   - For SSH URLs, ensure your SSH key is added to your Git hosting account and "
     "loaded (e.g. `ssh -T git@github.com`).\n"
     "   - For HTTPS URLs, ensure a valid token/credential helper is configured.\n"

--- a/taf/git.py
+++ b/taf/git.py
@@ -290,18 +290,28 @@ class GitRepository:
         log_success_msg = kwargs.pop("log_success_msg", "")
         error_if_not_exists = kwargs.pop("error_if_not_exists", True)
 
-        if len(args):
-            cmd = cmd.format(*args)
         # Build an argv list rather than one string: run() whitespace-splits a
-        # single-string command, which shatters `git -C <path>` when the
-        # repository path contains a space (e.g. a Windows home dir with a space
-        # in the user name). Passing the path as its own token keeps it intact,
-        # while cmd.split() preserves the previous tokenization of the command
-        # itself, so no other git invocation changes.
+        # single-string command, which shatters any argument containing a space
+        # (e.g. a Windows path under a home dir with a space in the user name) -
+        # both `git -C <path>` and any `{}` argument such as a local clone
+        # source. The template is tokenized first and each `{}` placeholder is
+        # filled positionally in place, so a substituted value stays a single
+        # argv token no matter what it contains, while the command's own
+        # tokenization is unchanged. Callers must therefore pass paths/URLs as
+        # `{}` arguments, not interpolate them into the command string.
         command = ["git", "-C", str(self.path)]
         if self.allow_unsafe:
             command += ["-c", f"safe.directory={self.path}"]
-        command += cmd.split()
+        args_iter = iter(args)
+        for token in cmd.split():
+            placeholders = token.count("{}")
+            if placeholders:
+                token = token.format(*[next(args_iter) for _ in range(placeholders)])
+            # an empty token means an optional flag arg was "" (e.g. push's
+            # force/no-verify flags); drop it, matching the old .split() which
+            # collapsed empties, so it does not reach git as an empty argument
+            if token != "":
+                command.append(token)
         command_str = " ".join(command)
         result = None
         if log_error or log_error_msg:
@@ -845,10 +855,12 @@ class GitRepository:
         for url in self.urls:
             self._log_info(f"trying to clone from {url}")
             try:
+                # url is a `{}` arg (kept as a single token); joined_params holds
+                # controlled flags meant to expand into multiple tokens, so it
+                # stays in the template string
                 self._git(
-                    "clone {} . {}",
+                    f"clone {{}} . {joined_params}",
                     url,
-                    joined_params,
                     log_success_msg=f"successfully cloned from {url}",
                     reraise_error=True,
                     timeout=60,
@@ -900,8 +912,11 @@ class GitRepository:
         # file-by-file object copy pygit2 performs. git silently falls back to
         # copying when hardlinks are not possible, so this is never slower.
         bare_flag = "--bare " if is_bare else ""
+        # pass the source path as a `{}` arg (the `{{}}` survives the f-string)
+        # so a path containing a space is not split into separate tokens
         self._git(
-            f"clone --local {bare_flag}{local_path} .",
+            f"clone --local {bare_flag}{{}} .",
+            str(local_path),
             error_if_not_exists=False,
             reraise_error=True,
         )
@@ -1513,7 +1528,9 @@ class GitRepository:
             raise FetchException(
                 "Could not fetch the last remote commit. URL not found"
             )
-        last_commit = self._git(f"--no-pager ls-remote {url} {branch}", log_error=True)
+        last_commit = self._git(
+            "--no-pager ls-remote {} {}", url, branch, log_error=True
+        )
         if last_commit:
             last_commit = last_commit.split("\t", 1)[0]
             # in some cases (e.g. upstream is defined the result might contain a warning line)
@@ -1961,7 +1978,9 @@ class GitRepository:
         return None
 
     def set_remote_url(self, new_url: str, remote: Optional[str] = "origin") -> None:
-        self._git(f"remote set-url {remote} {new_url}")
+        # new_url may be a local filesystem path containing spaces - pass it as
+        # a `{}` arg so it is not split into separate tokens
+        self._git("remote set-url {} {}", remote, new_url)
 
     def set_head_to_branch(self, branch_name: str) -> None:
         """Point HEAD at the given local branch without checking it out."""

--- a/taf/git.py
+++ b/taf/git.py
@@ -1819,6 +1819,14 @@ class GitRepository:
         error_msg="",
         underlying_errors=None,
     ):
+        """Raise ``error_cls`` explaining why a git network operation failed.
+
+        ``operation`` names the attempted action (e.g. ``"clone"``) in the
+        message. ``error_msg``, when given, replaces the auto-selected guidance.
+        ``underlying_errors`` is the list of concrete per-attempt git failures
+        (typically one per URL); they are surfaced on the exception so the real
+        cause is never hidden behind the guidance.
+        """
         # Pick the guidance that best fits what we can observe about the remote,
         # then surface the concrete git failure(s) alongside it. The guidance is
         # a best guess (an unauthenticated probe cannot tell "private" from

--- a/taf/git.py
+++ b/taf/git.py
@@ -854,7 +854,7 @@ class GitRepository:
                 break
 
         if not cloned:
-            self.raise_git_access_error(CloneRepoException)
+            self.raise_git_access_error(CloneRepoException, operation="clone")
 
         # the path is now a repository; drop any cached negative result from
         # before the clone
@@ -1802,7 +1802,7 @@ class GitRepository:
             raise PushFailedError(self, message=f"Push operation failed: {e}")
 
     def raise_git_access_error(
-        self, error_cls=GitAccessDeniedException, operation=None, error_msg=""
+        self, error_cls=GitAccessDeniedException, operation="access", error_msg=""
     ):
         hosts = {
             h for h in (extract_hostname(url) for url in self.urls) if h is not None
@@ -1832,7 +1832,11 @@ class GitRepository:
                         else error_msg
                     ),
                 )
-        raise error_cls(self, operation=operation)
+        raise error_cls(
+            self,
+            operation=operation,
+            message=(_repo_not_found_error_message if error_msg == "" else error_msg),
+        )
 
     def remove_remote(self, remote_name: str) -> None:
         try:
@@ -2223,6 +2227,19 @@ _clone_or_pull_error_message_no_ssh = (
     "The remote repository exists, so this issue is probably due to lack of privileges.\n"
     "Verify that you have access to the repository if it is private, and verify your HTTPS configuration.\n"
     "Consider switching to SSH for potentially enhanced security and easier handling of credentials."
+)
+
+
+_repo_not_found_error_message = (
+    "The remote repository could not be found. Note that a private repository is "
+    "indistinguishable from a missing one when you are not authenticated, so this is "
+    "most likely an access/authentication problem rather than a wrong URL. Please:\n\n"
+    "1. Double-check the repository URL for typos.\n"
+    "2. If the repository is private, verify that your account has been granted access.\n"
+    "3. Verify your credentials are configured for this host:\n"
+    "   - For SSH URLs, ensure your SSH key is added to your Git hosting account and "
+    "loaded (e.g. `ssh -T git@github.com`).\n"
+    "   - For HTTPS URLs, ensure a valid token/credential helper is configured.\n"
 )
 
 

--- a/taf/tests/test_git/test_clone_errors.py
+++ b/taf/tests/test_git/test_clone_errors.py
@@ -1,13 +1,10 @@
-"""Tests around the clone/access error path in ``taf.git``.
-
-Regression coverage for the clone-failure investigation:
+"""Tests for the clone/access error path in ``taf.git``:
 
 * the access error names the git operation ("Cannot clone", never
   "Cannot None") and its fallback carries actionable guidance;
 * a repository path containing a space (e.g. a Windows home dir
-  "C:\\Users\\Given Surname\\...") no longer breaks the ``git -C <path>``
-  argument - ``_git`` passes argv as a list instead of a whitespace-split
-  string; and
+  "C:\\Users\\Given Surname\\...") doesn't break the ``git -C <path>``
+  argument; and
 * the real underlying git error is surfaced on the raised
   ``CloneRepoException`` instead of being swallowed at debug level.
 """
@@ -42,9 +39,8 @@ def test_clone_repo_exception_defaults_to_clone_operation(tmp_path):
 
 
 def test_raise_git_access_error_for_clone_names_clone_not_none(tmp_path, monkeypatch):
-    # This is the exact regression from the field report: a private repo that an
-    # unauthenticated probe cannot see falls through to the final branch. Before
-    # the fix that branch raised with operation=None -> "Cannot None ...".
+    # a private repo an unauthenticated probe can't see falls through to the
+    # final branch, which must still name the operation
     monkeypatch.setattr(git_module, "is_host_known", lambda host: True)
     monkeypatch.setattr(git_module, "repository_exists", lambda url: False)
 
@@ -92,10 +88,8 @@ def test_clone_into_path_with_spaces(origin_repo: GitRepository, tmp_path):
 
 
 def test_clone_from_disk_with_spaced_source_path(repository: GitRepository, tmp_path):
-    # Regression: the users-auth clone step does `git clone --local <source> .`
-    # where <source> is a temp dir that, under a spaced Windows home, contains a
-    # space. clone_from_disk now passes the source as a `{}` arg so it stays one
-    # token; previously it was split and git reported "fatal: Too many arguments".
+    # clone_from_disk passes the source as a `{}` arg, so it stays one token
+    # even when the source path (e.g. a temp dir under a spaced home) has a space
     spaced_source = Path(tmp_path) / "Given Surname" / "source"
     spaced_source.mkdir(parents=True)
     # populate the spaced source (spaced *destination* path -> exercises `git -C`)

--- a/taf/tests/test_git/test_clone_errors.py
+++ b/taf/tests/test_git/test_clone_errors.py
@@ -1,0 +1,150 @@
+"""Tests around the clone/access error path in ``taf.git``.
+
+Two things are covered here:
+
+* the committed fix that stopped the access error from rendering as
+  ``"Cannot None <repo> ..."`` and gave the "repository could not be found"
+  fallback an actionable message (these pass); and
+* the two defects the clone investigation surfaced but did not yet fix - a
+  command line containing a path with spaces is mangled by ``run()``'s
+  whitespace split, and the real underlying git error is swallowed (logged at
+  debug) instead of being surfaced on the raised exception. Those are encoded
+  as ``xfail(strict=True)`` regression tests so they stay red until fixed and
+  flip to a hard failure (prompting removal of the marker) once they are.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import taf.git as git_module
+from taf.exceptions import CloneRepoException, GitAccessDeniedException, GitError
+from taf.git import GitRepository
+
+
+def _repo(tmp_path, urls):
+    """A GitRepository instance that only needs .name/.urls/.log_prefix for the
+    error-formatting code under test (no on-disk repo required)."""
+    return GitRepository(path=Path(tmp_path) / "law-private", urls=urls)
+
+
+# --------------------------------------------------------------------------- #
+# Committed fix: the access error names the operation and carries guidance.
+# --------------------------------------------------------------------------- #
+
+
+def test_clone_repo_exception_defaults_to_clone_operation(tmp_path):
+    # Defence in depth: even constructed directly, CloneRepoException must name
+    # "clone" rather than rendering the operation as None.
+    exc = CloneRepoException(_repo(tmp_path, ["https://example.com/x"]))
+    message = str(exc)
+    assert "Cannot clone" in message
+    assert "Cannot None" not in message
+
+
+def test_raise_git_access_error_for_clone_names_clone_not_none(tmp_path, monkeypatch):
+    # This is the exact regression from the field report: a private repo that an
+    # unauthenticated probe cannot see falls through to the final branch. Before
+    # the fix that branch raised with operation=None -> "Cannot None ...".
+    monkeypatch.setattr(git_module, "is_host_known", lambda host: True)
+    monkeypatch.setattr(git_module, "repository_exists", lambda url: False)
+
+    repo = _repo(tmp_path, ["https://github.com/openlawlibrary/law-private"])
+    with pytest.raises(CloneRepoException) as exc_info:
+        repo.raise_git_access_error(CloneRepoException, operation="clone")
+
+    message = str(exc_info.value)
+    first_line = message.splitlines()[0]
+    assert "Cannot clone" in first_line
+    assert "None" not in first_line
+    # the fallback is no longer a bare error - it carries actionable guidance
+    assert "could not be found" in message
+
+
+def test_raise_git_access_error_default_operation_is_not_none(tmp_path, monkeypatch):
+    # A caller that forgets to pass an operation must never produce "Cannot None".
+    monkeypatch.setattr(git_module, "is_host_known", lambda host: True)
+    monkeypatch.setattr(git_module, "repository_exists", lambda url: False)
+
+    repo = _repo(tmp_path, ["https://github.com/openlawlibrary/law-private"])
+    with pytest.raises(GitAccessDeniedException) as exc_info:
+        repo.raise_git_access_error()
+
+    first_line = str(exc_info.value).splitlines()[0]
+    assert "None" not in first_line
+
+
+# --------------------------------------------------------------------------- #
+# Open defect 1: `run()` splits the command on whitespace, so a repository path
+# containing a space (e.g. a Windows home dir "C:\\Users\\Given Surname\\...")
+# breaks the `git -C <path>` argument and every clone attempt fails.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "run() does command[0].split(), shattering `git -C <path with spaces>`; "
+        "clone into a spaced path fails. Fix by passing argv as a list / quoting."
+    ),
+)
+def test_clone_into_path_with_spaces(origin_repo: GitRepository, tmp_path):
+    dest = Path(tmp_path) / "Given Surname" / "clone"
+    dest.mkdir(parents=True)
+    repo = GitRepository(path=dest)
+    # assign after construction to bypass URL validation - the local origin
+    # path is a valid clone source but not a URL (mirrors the other clone tests)
+    repo.urls = [str(origin_repo.path)]
+    repo.clone()
+    assert repo.is_git_repository
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="run() splits `git -C <path with spaces> ...` on whitespace",
+)
+def test_git_subprocess_handles_spaced_repo_path(tmp_path):
+    # A local git operation that actually shells out (via _git -> run) must
+    # tolerate a repository path with spaces. The repo is initialised through
+    # run()'s list form (which is not split), so only the _git string command
+    # under test is exercised against the spaced path.
+    from taf.utils import run
+
+    dest = Path(tmp_path) / "Given Surname" / "repo"
+    dest.mkdir(parents=True)
+    run("git", "-C", str(dest), "init")
+    repo = GitRepository(path=dest)
+    out = repo._git("rev-parse --is-inside-work-tree", reraise_error=True)
+    assert out.strip() == "true"
+
+
+# --------------------------------------------------------------------------- #
+# Open defect 2: the real per-URL git error (which explains *why* the clone
+# failed) is only logged at debug and dropped; the surfaced CloneRepoException
+# replaces it with a generic guess.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "clone() catches the per-URL GitError and logs it at debug only; the "
+        "underlying git message never reaches the raised CloneRepoException."
+    ),
+)
+def test_clone_surfaces_underlying_git_error(clone_repository: GitRepository, monkeypatch):
+    clone_repository.urls = ["https://example.com/x.git"]
+    sentinel = r"fatal: cannot change to 'C:\Users\Given': No such file or directory"
+
+    def fake_git(*args, **kwargs):
+        raise GitError(clone_repository, message=sentinel)
+
+    monkeypatch.setattr(clone_repository, "_git", fake_git)
+    # keep raise_git_access_error off the network and on the final fallback
+    monkeypatch.setattr(git_module, "is_host_known", lambda host: True)
+    monkeypatch.setattr(git_module, "repository_exists", lambda url: False)
+
+    with pytest.raises(CloneRepoException) as exc_info:
+        clone_repository.clone()
+
+    assert sentinel in str(exc_info.value)

--- a/taf/tests/test_git/test_clone_errors.py
+++ b/taf/tests/test_git/test_clone_errors.py
@@ -1,16 +1,15 @@
 """Tests around the clone/access error path in ``taf.git``.
 
-Two things are covered here:
+Regression coverage for the clone-failure investigation:
 
-* the committed fix that stopped the access error from rendering as
-  ``"Cannot None <repo> ..."`` and gave the "repository could not be found"
-  fallback an actionable message (these pass); and
-* the two defects the clone investigation surfaced but did not yet fix - a
-  command line containing a path with spaces is mangled by ``run()``'s
-  whitespace split, and the real underlying git error is swallowed (logged at
-  debug) instead of being surfaced on the raised exception. Those are encoded
-  as ``xfail(strict=True)`` regression tests so they stay red until fixed and
-  flip to a hard failure (prompting removal of the marker) once they are.
+* the access error names the git operation ("Cannot clone", never
+  "Cannot None") and its fallback carries actionable guidance;
+* a repository path containing a space (e.g. a Windows home dir
+  "C:\\Users\\Given Surname\\...") no longer breaks the ``git -C <path>``
+  argument - ``_git`` passes argv as a list instead of a whitespace-split
+  string; and
+* the real underlying git error is surfaced on the raised
+  ``CloneRepoException`` instead of being swallowed at debug level.
 """
 
 from pathlib import Path
@@ -58,7 +57,7 @@ def test_raise_git_access_error_for_clone_names_clone_not_none(tmp_path, monkeyp
     assert "Cannot clone" in first_line
     assert "None" not in first_line
     # the fallback is no longer a bare error - it carries actionable guidance
-    assert "could not be found" in message
+    assert "could not be reached or found" in message
 
 
 def test_raise_git_access_error_default_operation_is_not_none(tmp_path, monkeypatch):
@@ -75,19 +74,12 @@ def test_raise_git_access_error_default_operation_is_not_none(tmp_path, monkeypa
 
 
 # --------------------------------------------------------------------------- #
-# Open defect 1: `run()` splits the command on whitespace, so a repository path
+# Spaced repository paths: `_git` passes argv as a list, so a repository path
 # containing a space (e.g. a Windows home dir "C:\\Users\\Given Surname\\...")
-# breaks the `git -C <path>` argument and every clone attempt fails.
+# no longer shatters the `git -C <path>` argument.
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "run() does command[0].split(), shattering `git -C <path with spaces>`; "
-        "clone into a spaced path fails. Fix by passing argv as a list / quoting."
-    ),
-)
 def test_clone_into_path_with_spaces(origin_repo: GitRepository, tmp_path):
     dest = Path(tmp_path) / "Given Surname" / "clone"
     dest.mkdir(parents=True)
@@ -99,10 +91,6 @@ def test_clone_into_path_with_spaces(origin_repo: GitRepository, tmp_path):
     assert repo.is_git_repository
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="run() splits `git -C <path with spaces> ...` on whitespace",
-)
 def test_git_subprocess_handles_spaced_repo_path(tmp_path):
     # A local git operation that actually shells out (via _git -> run) must
     # tolerate a repository path with spaces. The repo is initialised through
@@ -119,20 +107,14 @@ def test_git_subprocess_handles_spaced_repo_path(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
-# Open defect 2: the real per-URL git error (which explains *why* the clone
-# failed) is only logged at debug and dropped; the surfaced CloneRepoException
-# replaces it with a generic guess.
+# The real per-URL git error (which explains *why* the clone failed) is
+# surfaced on the raised CloneRepoException, not swallowed at debug level.
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "clone() catches the per-URL GitError and logs it at debug only; the "
-        "underlying git message never reaches the raised CloneRepoException."
-    ),
-)
-def test_clone_surfaces_underlying_git_error(clone_repository: GitRepository, monkeypatch):
+def test_clone_surfaces_underlying_git_error(
+    clone_repository: GitRepository, monkeypatch
+):
     clone_repository.urls = ["https://example.com/x.git"]
     sentinel = r"fatal: cannot change to 'C:\Users\Given': No such file or directory"
 
@@ -147,4 +129,8 @@ def test_clone_surfaces_underlying_git_error(clone_repository: GitRepository, mo
     with pytest.raises(CloneRepoException) as exc_info:
         clone_repository.clone()
 
-    assert sentinel in str(exc_info.value)
+    message = str(exc_info.value)
+    # the concrete git failure is surfaced ...
+    assert sentinel in message
+    # ... alongside (not instead of) the guidance
+    assert "could not be reached or found" in message

--- a/taf/tests/test_git/test_clone_errors.py
+++ b/taf/tests/test_git/test_clone_errors.py
@@ -91,6 +91,24 @@ def test_clone_into_path_with_spaces(origin_repo: GitRepository, tmp_path):
     assert repo.is_git_repository
 
 
+def test_clone_from_disk_with_spaced_source_path(repository: GitRepository, tmp_path):
+    # Regression: the users-auth clone step does `git clone --local <source> .`
+    # where <source> is a temp dir that, under a spaced Windows home, contains a
+    # space. clone_from_disk now passes the source as a `{}` arg so it stays one
+    # token; previously it was split and git reported "fatal: Too many arguments".
+    spaced_source = Path(tmp_path) / "Given Surname" / "source"
+    spaced_source.mkdir(parents=True)
+    # populate the spaced source (spaced *destination* path -> exercises `git -C`)
+    GitRepository(path=spaced_source).clone_from_disk(repository.path)
+    assert GitRepository(path=spaced_source).is_git_repository
+
+    # clone *from* the spaced source (spaced value -> exercises the `{}` arg)
+    dest = Path(tmp_path) / "dest"
+    repo = GitRepository(path=dest)
+    repo.clone_from_disk(spaced_source)
+    assert repo.is_git_repository
+
+
 def test_git_subprocess_handles_spaced_repo_path(tmp_path):
     # A local git operation that actually shells out (via _git -> run) must
     # tolerate a repository path with spaces. The repo is initialised through

--- a/taf/tests/test_utils.py
+++ b/taf/tests/test_utils.py
@@ -6,10 +6,26 @@ from pathlib import Path
 from taf.utils import (
     TempPartition,
     _background_cleanup_threads,
+    format_command_args,
     normalize_line_endings,
     safely_save_json_to_disk,
     safely_move_file,
 )
+
+
+def test_format_command_args_fills_placeholders_as_single_tokens():
+    tokens = format_command_args("clone {} .", "/path with spaces")
+    assert tokens == ["clone", "/path with spaces", "."]
+
+
+def test_format_command_args_drops_empty_args():
+    tokens = format_command_args("push {} {}", "--force", "")
+    assert tokens == ["push", "--force"]
+
+
+def test_format_command_args_fills_multiple_placeholders_in_one_token():
+    tokens = format_command_args("update-ref refs/heads/{}/{} {}", "a", "b", "c")
+    assert tokens == ["update-ref", "refs/heads/a/b", "c"]
 
 
 def test_normalize_line_ending_extra_lines():

--- a/taf/utils.py
+++ b/taf/utils.py
@@ -171,6 +171,23 @@ def read_input_dict(value):
     return value
 
 
+def format_command_args(cmd: str, *args) -> List[str]:
+    """Split a whitespace-separated command template into argv tokens, filling
+    each `{}` placeholder with the next arg so a substituted value stays a
+    single token even if it contains spaces. Empty args (e.g. an optional
+    flag passed as "") are dropped.
+    """
+    args_iter = iter(args)
+    tokens = []
+    for token in cmd.split():
+        placeholders = token.count("{}")
+        if placeholders:
+            token = token.format(*[next(args_iter) for _ in range(placeholders)])
+        if token != "":
+            tokens.append(token)
+    return tokens
+
+
 def run(*command, **kwargs):
     """Run a command and return its output. Call with `debug=True` to print to
     stdout.


### PR DESCRIPTION
## Description

Fixes #761.

`taf repo clone` of a private repo was failing with `Cannot None <repo> from any of the following URLs: [...]` and no useful guidance. The investigation showed the failure had nothing to do with access — it was three linked defects in the clone/access error path:

1. **Spaced repository paths (the real bug).** `_git` built the git invocation as one string and `run()` whitespace-splits it, so `git -C <path>` was shattered whenever the repository path contained a space — e.g. a Windows home directory with a space in the user name, the reporter's case. `_git` now builds an argv list with the path as its own token; the command's own tokenization is unchanged, so no other git call is affected (the full `test_git` suite has an identical result with and without the change).
2. **Swallowed git error.** `clone()` logged each per-URL git failure at debug and dropped it, then raised a generic `CloneRepoException`. The concrete `fatal: cannot change to ...` is now collected and surfaced on the exception, alongside (not instead of) the guidance.
3. **Wrong message.** `raise_git_access_error` rendered `operation=None` as "Cannot None", and its fallback asserted the cause was "most likely access/authentication" — exactly wrong for a local command-construction failure. The operation is now named, and the fallback defers to the concrete git error shown above it.

## How to test

- `pytest taf/tests/test_git/test_clone_errors.py` — 6 tests.
- The two spaced-path tests clone into a `.../Given Surname/...` directory and assert the clone succeeds; the swallowing test asserts the real git error appears on the raised `CloneRepoException`.

> Verified on Linux. The `_git` change is Windows-safe by construction (the path is a discrete argv element, never parsed), but a Windows smoke-test of a clone would be a good final confirmation.

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (one cohesive fix to the clone/access error path)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
