### PR TITLE
Support signing keys in any PIV slot 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,16 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
+- Sign and discover keys across all YubiKey PIV slots, not just SIGNATURE ([767])
 - Support choosing a YubiKey PIV slot when setting up signing keys ([759])
 
 ### Changed
 
 - Remove unused `scheme` parameters ([757])
+
+### Removed
+
+- `--reset`/`--force` from `taf yubikey setup-signing-key`/`setup-test-key` - an occupied PIV slot is refused instead of being overwritten ([767])
 
 ### Fixed
 
@@ -23,6 +28,7 @@ and this project adheres to [Semantic Versioning][semver].
 - Correct the clone access error that rendered as "Cannot None ..." and stop misattributing a local failure to an access/authentication problem ([762])
 
 
+[767]: https://github.com/openlawlibrary/taf/pull/767
 [762]: https://github.com/openlawlibrary/taf/pull/762
 [759]: https://github.com/openlawlibrary/taf/pull/759
 [757]: https://github.com/openlawlibrary/taf/pull/757

--- a/taf/api/yubikey.py
+++ b/taf/api/yubikey.py
@@ -328,7 +328,7 @@ def setup_signing_yubikey(
         )
         if not yubikeys:
             raise YubikeyError("Could not generate a new key")
-        _, serial_num, _ = yubikeys[0]
+        _, serial_num, _, _ = yubikeys[0]
     else:
         # not resetting, so the PIN itself is untouched - it's only needed
         # here to unlock the card's stored management key

--- a/taf/api/yubikey.py
+++ b/taf/api/yubikey.py
@@ -24,8 +24,8 @@ def _ensure_slot_free(serial: str, piv_slot: SLOT) -> None:
     if yk.is_slot_occupied(serial, piv_slot):
         raise YubikeyError(
             f"The {piv_slot.name} slot on YubiKey {serial} already has a key. "
-            "taf will not overwrite or reset it - reset the YubiKey's PIV "
-            "application outside of taf and try again."
+            "taf will not overwrite or reset it. Use another slot with --slot "
+            "or reset the YubiKey's PIV application outside of taf and try again."
         )
     print(f"Setting up a new key in the {piv_slot.name} slot.")
 

--- a/taf/api/yubikey.py
+++ b/taf/api/yubikey.py
@@ -1,19 +1,17 @@
 from logging import DEBUG, ERROR
 from typing import Dict, Optional, Tuple
-import click
 
 from pathlib import Path
 from cryptography import x509
 from logdecorator import log_on_end, log_on_error, log_on_start
 from taf.auth_repo import AuthenticationRepository
 from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
-from taf.exceptions import TAFError, YubikeyError
+from taf.exceptions import KeystoreError, TAFError, YubikeyError
 
 # from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
 from taf.log import taf_logger
 from taf.tuf.keys import get_sslib_key_from_value
 from taf.tuf.repository import MAIN_ROLES
-from taf.utils import get_pin_for
 import taf.yubikey.yubikey as yk
 from taf.yubikey.yubikey_manager import PinManager
 from yubikit.piv import SLOT
@@ -22,44 +20,41 @@ from yubikit.piv import SLOT
 SETUP_SLOTS = {SLOT.SIGNATURE, SLOT.AUTHENTICATION, SLOT.KEY_MANAGEMENT, SLOT.CARD_AUTH}
 
 
-def _check_if_slot_overwrite_allowed(serial: str, piv_slot: SLOT, force: bool) -> bool:
-    """Check whether the target slot is already occupied and, if so, confirm
-    before overwriting it. Returns whether to proceed."""
-    occupied = yk.is_slot_occupied(serial, piv_slot)
-    if occupied and not force:
-        if not click.confirm(
-            f"WARNING - the {piv_slot.name} slot already has a key. "
-            "This will overwrite it. Proceed?"
-        ):
-            return False
-    elif occupied:
-        print(f"Overwriting the existing key in the {piv_slot.name} slot.")
-    else:
-        print(f"Setting up a new key in the {piv_slot.name} slot.")
-    return True
+def _ensure_slot_free(serial: str, piv_slot: SLOT) -> None:
+    """Raise a clear error if the target slot is already occupied. taf never
+    overwrites or resets a YubiKey - if the slot isn't free, the user has to
+    reset the card's PIV application themselves and try again."""
+    if yk.is_slot_occupied(serial, piv_slot):
+        raise YubikeyError(
+            f"The {piv_slot.name} slot on YubiKey {serial} already has a key. "
+            "taf will not overwrite or reset it - reset the YubiKey's PIV "
+            "application outside of taf and try again."
+        )
+    print(f"Setting up a new key in the {piv_slot.name} slot.")
 
 
-def _prepare_non_reset_setup(
+def _prepare_setup(
     pin_manager: PinManager,
     piv_slot: SLOT,
-    force: bool,
     serial: Optional[str] = None,
     insert_prompt: Optional[str] = None,
-) -> Tuple[bool, str, str]:
-    """Resolve which YubiKey to use, get its PIN, and confirm before
-    touching an occupied slot."""
+) -> Tuple[str, str]:
+    """Resolve which YubiKey to use, confirm the target slot is free, and get
+    its PIN. Occupancy is checked first since it needs no PIN - no point
+    prompting for one only to fail on an occupied slot."""
     if serial is None:
         serial = _resolve_single_serial(insert_prompt)
+
+    _ensure_slot_free(serial, piv_slot)
 
     # needed to unlock the card's stored, PIN-protected management key
     pin = pin_manager.get_pin(serial)
     if pin is None:
         name = f"YubiKey {serial}" if len(yk.get_serial_nums()) > 1 else "YubiKey"
-        pin = get_pin_for(name, confirm=False, repeat=False)
+        pin = yk.get_and_validate_pin(name, serial=serial)
         pin_manager.add_pin(serial, pin)
 
-    proceed = _check_if_slot_overwrite_allowed(serial, piv_slot, force)
-    return proceed, serial, pin
+    return serial, pin
 
 
 def _resolve_single_serial(prompt: Optional[str] = None) -> str:
@@ -287,8 +282,6 @@ def setup_signing_yubikey(
     certs_dir: Optional[str] = None,
     key_size: int = 2048,
     slot: str = "SIGNATURE",
-    force: bool = False,
-    reset: bool = False,
 ) -> None:
     """
     Generate a new key and copy it to the given PIV slot of the inserted YubiKey.
@@ -298,11 +291,6 @@ def setup_signing_yubikey(
         certs_dir (optional): Path to a directory where the exported certificate should be stored.
         slot (optional): Name of the PIV slot to set the key up in ("SIGNATURE",
             "AUTHENTICATION", "KEY_MANAGEMENT", or "CARD_AUTH"). Defaults to "SIGNATURE".
-        force (optional): Whether to overwrite the target slot if it already
-            has a key in it. Has no effect when reset is True, since resetting
-            always leaves every slot empty first, so there's nothing to
-            overwrite in that case.
-        reset (optional): Whether to factory-reset the card first. Defaults to False.
 
     Side Effects:
        None
@@ -312,45 +300,19 @@ def setup_signing_yubikey(
     """
     piv_slot = _resolve_slot(slot)
 
-    if reset:
-        if not click.confirm(
-            "WARNING - this will delete everything from the inserted key. Proceed?"
-        ):
-            return
-        # resetting wipes the PIN too, so a new one is chosen here
-        yubikeys = yk.yubikey_prompt(
-            ["new Yubikey"],
-            pin_manager=pin_manager,
-            creating_new_key=True,
-            pin_confirm=True,
-            pin_repeat=True,
-            prompt_message="Please insert the new Yubikey and press ENTER",
-        )
-        if not yubikeys:
-            raise YubikeyError("Could not generate a new key")
-        _, serial_num, _, _ = yubikeys[0]
-    else:
-        # not resetting, so the PIN itself is untouched - it's only needed
-        # here to unlock the card's stored management key
-        proceed, serial_num, _ = _prepare_non_reset_setup(
-            pin_manager,
-            piv_slot,
-            force,
-            insert_prompt="Insert the YubiKey you want to set up and press ENTER",
-        )
-        if not proceed:
-            return
-        # proceed=True means any occupied-slot warning was already
-        # confirmed, so overwriting is now always allowed
-        force = True
+    # the PIN itself is untouched by this - it's only needed here to unlock
+    # the card's stored management key
+    serial_num, _ = _prepare_setup(
+        pin_manager,
+        piv_slot,
+        insert_prompt="Insert the YubiKey you want to set up and press ENTER",
+    )
 
     key = yk.setup_new_yubikey(
         pin_manager,
         serial_num,
         key_size=key_size,
         slot=piv_slot,
-        force=force,
-        reset=reset,
     )
     yk.export_yk_certificate(certs_dir, key, serial_num)
 
@@ -369,8 +331,6 @@ def setup_test_yubikey(
     key_size: Optional[int] = 2048,
     serial: Optional[str] = None,
     slot: str = "SIGNATURE",
-    force: bool = False,
-    reset: bool = False,
 ) -> None:
     """
     Copy the specified key to the inserted YubiKey's given PIV slot.
@@ -379,9 +339,6 @@ def setup_test_yubikey(
         key_path: Path to a key which should be copied to a YubiKey.
         slot (optional): Name of the PIV slot to copy the key into ("SIGNATURE",
             "AUTHENTICATION", "KEY_MANAGEMENT", or "CARD_AUTH"). Defaults to "SIGNATURE".
-        force (optional): Whether to overwrite the target slot if it already
-            has a key in it. Has no effect when reset is True.
-        reset (optional): Whether to factory-reset the card first. Defaults to False.
 
     Side Effects:
        None
@@ -389,32 +346,15 @@ def setup_test_yubikey(
     Returns:
         None
     """
-    piv_slot = _resolve_slot(slot)
-
-    if reset:
-        if serial is None:
-            serial = _resolve_single_serial()
-        if not click.confirm("WARNING - this will reset the inserted key. Proceed?"):
-            return
-    else:
-        proceed, serial, pin = _prepare_non_reset_setup(
-            pin_manager, piv_slot, force, serial=serial
-        )
-        if not proceed:
-            return
-        # proceed=True means any occupied-slot warning was already
-        # confirmed, so overwriting is now always allowed
-        force = True
-
     key_pem_path = Path(key_path)
+    if not key_pem_path.is_file():
+        raise KeystoreError(f"{key_pem_path} does not exist")
     key_pem = key_pem_path.read_bytes()
 
-    print(f"Importing RSA private key from {key_path} to Yubikey...")
-    if reset:
-        # resetting wipes the PIN too, so it's reset to the default here
-        pin = yk.DEFAULT_PIN
-        pin_manager.add_pin(serial, pin)
+    piv_slot = _resolve_slot(slot)
+    serial, pin = _prepare_setup(pin_manager, piv_slot, serial=serial)
 
+    print(f"Importing RSA private key from {key_path} to Yubikey...")
     pub_key = yk.setup(
         pin,
         serial,
@@ -422,10 +362,6 @@ def setup_test_yubikey(
         private_key_pem=key_pem,
         key_size=key_size,
         slot=piv_slot,
-        force=force,
-        reset=reset,
     )
     print("\nPrivate key successfully imported.\n")
     print("\nPublic key (PEM): \n{}".format(pub_key.decode("utf-8")))
-    if reset:
-        print("Pin: {}\n".format(pin))

--- a/taf/api/yubikey.py
+++ b/taf/api/yubikey.py
@@ -13,11 +13,9 @@ from taf.log import taf_logger
 from taf.tuf.keys import get_sslib_key_from_value
 from taf.tuf.repository import MAIN_ROLES
 import taf.yubikey.yubikey as yk
+from taf.yubikey.yubikey import SETUP_SLOTS
 from taf.yubikey.yubikey_manager import PinManager
 from yubikit.piv import SLOT
-
-# Retired slots (RETIRED1-RETIRED20) are reserved for key history/decryption, not signing.
-SETUP_SLOTS = {SLOT.SIGNATURE, SLOT.AUTHENTICATION, SLOT.KEY_MANAGEMENT, SLOT.CARD_AUTH}
 
 
 def _ensure_slot_free(serial: str, piv_slot: SLOT) -> None:

--- a/taf/api/yubikey.py
+++ b/taf/api/yubikey.py
@@ -311,7 +311,7 @@ def setup_signing_yubikey(
         key_size=key_size,
         slot=piv_slot,
     )
-    yk.export_yk_certificate(certs_dir, key, serial_num)
+    yk.export_yk_certificate(certs_dir, key, serial_num, slot=piv_slot)
 
 
 @log_on_start(DEBUG, "Setting up a new test YubiKey", logger=taf_logger)

--- a/taf/api/yubikey.py
+++ b/taf/api/yubikey.py
@@ -4,6 +4,7 @@ from typing import Dict, Optional, Tuple
 from pathlib import Path
 from cryptography import x509
 from logdecorator import log_on_end, log_on_error, log_on_start
+from taf.api.utils._conf import find_taf_directory
 from taf.auth_repo import AuthenticationRepository
 from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME
 from taf.exceptions import KeystoreError, TAFError, YubikeyError
@@ -43,14 +44,16 @@ def _prepare_setup(
     # an unauthenticated PIV read, so check it before ever asking for a PIN
     _ensure_slot_free(serial, piv_slot)
 
-    # needed to unlock the card's stored, PIN-protected management key
-    pin = pin_manager.get_pin(serial)
-    if pin is None:
-        name = f"YubiKey {serial}" if len(yk.get_serial_nums()) > 1 else "YubiKey"
-        pin = yk.get_and_validate_pin(name, serial=serial)
-        pin_manager.add_pin(serial, pin)
+    # needed to unlock the card's stored, PIN-protected management key -
+    # reuse the same resolve-from-env-then-validate flow used everywhere
+    # else a PIN is entered, instead of a partial reimplementation
+    name = f"YubiKey {serial}" if len(yk.get_serial_nums()) > 1 else "YubiKey"
+    taf_dir = find_taf_directory(Path.cwd())
+    yk._resolve_and_cache_pin(
+        pin_manager, serial, None, taf_dir, name, True, True, None
+    )
 
-    return serial, pin
+    return serial, pin_manager.get_pin(serial)
 
 
 def _resolve_single_serial(prompt: Optional[str] = None) -> str:
@@ -296,8 +299,6 @@ def setup_signing_yubikey(
     """
     piv_slot = _resolve_slot(slot)
 
-    # the PIN itself is untouched by this - it's only needed here to unlock
-    # the card's stored management key
     serial_num, _ = _prepare_setup(
         pin_manager,
         piv_slot,

--- a/taf/api/yubikey.py
+++ b/taf/api/yubikey.py
@@ -21,9 +21,7 @@ SETUP_SLOTS = {SLOT.SIGNATURE, SLOT.AUTHENTICATION, SLOT.KEY_MANAGEMENT, SLOT.CA
 
 
 def _ensure_slot_free(serial: str, piv_slot: SLOT) -> None:
-    """Raise a clear error if the target slot is already occupied. taf never
-    overwrites or resets a YubiKey - if the slot isn't free, the user has to
-    reset the card's PIV application themselves and try again."""
+    """Raise a clear error if the target slot is already occupied."""
     if yk.is_slot_occupied(serial, piv_slot):
         raise YubikeyError(
             f"The {piv_slot.name} slot on YubiKey {serial} already has a key. "
@@ -40,11 +38,11 @@ def _prepare_setup(
     insert_prompt: Optional[str] = None,
 ) -> Tuple[str, str]:
     """Resolve which YubiKey to use, confirm the target slot is free, and get
-    its PIN. Occupancy is checked first since it needs no PIN - no point
-    prompting for one only to fail on an occupied slot."""
+    its PIN."""
     if serial is None:
         serial = _resolve_single_serial(insert_prompt)
 
+    # an unauthenticated PIV read, so check it before ever asking for a PIN
     _ensure_slot_free(serial, piv_slot)
 
     # needed to unlock the card's stored, PIN-protected management key

--- a/taf/keys.py
+++ b/taf/keys.py
@@ -659,17 +659,16 @@ def _setup_yubikey(
         if yubikeys is not None:
             key, serial_num, key_name, _ = yubikeys[0]
             if not use_existing:
-                # TODO: always resetting is temporary - once signing supports
-                # slots other than SIGNATURE, let the user pick which slot to
-                # use here (default SIGNATURE), and only overwrite it (force,
-                # non-destructive to the rest of the card) instead of ever
-                # doing a full reset
+                # TODO: always uses SLOT.SIGNATURE - let the user pick which
+                # slot to generate the new key in. taf never resets or
+                # overwrites a card, so this fails outright if SIGNATURE is
+                # already occupied; the user has to reset the YubiKey's PIV
+                # application themselves and try again.
                 key = yk.setup_new_yubikey(
                     auth_repo.pin_manager,
                     serial_num,
                     scheme,
                     key_size=key_size,
-                    reset=True,
                 )
 
             if certs_dir is not None:

--- a/taf/keys.py
+++ b/taf/keys.py
@@ -25,7 +25,6 @@ from taf.constants import DEFAULT_RSA_SIGNATURE_SCHEME, RoleSetupParams
 from taf.exceptions import (
     KeystoreError,
     SigningError,
-    YubikeyError,
 )
 from taf.keystore import (
     get_keystore_keys_of_role,
@@ -641,13 +640,6 @@ def _setup_yubikey(
             f"User chose to {'reuse' if use_existing else 'generate a new'} YubiKey for '{key_name}'."
         )
 
-        if not use_existing:
-            if not click.confirm(
-                "WARNING - this will delete everything from the inserted key. Proceed?"
-            ):
-                if click.confirm("Cancel?"):
-                    raise YubikeyError("Yubikey setup canceled")
-                continue
         yubikeys = yk.yubikey_prompt(
             [key_name],
             pin_manager=auth_repo.pin_manager,
@@ -662,10 +654,6 @@ def _setup_yubikey(
         if yubikeys is not None:
             key, serial_num, key_name, slot = yubikeys[0]
             if not use_existing:
-                occupied = yk.get_piv_public_keys_tuf(serial=serial_num).get(
-                    serial_num, {}
-                )
-                slot = yk._prompt_for_new_key_slot(serial_num, occupied.keys())
                 key = yk.setup_new_yubikey(
                     auth_repo.pin_manager,
                     serial_num,
@@ -673,12 +661,20 @@ def _setup_yubikey(
                     key_size=key_size,
                     slot=slot,
                 )
+                # the key didn't exist yet when yubikey_prompt recorded this
+                # entry, so it was stored with public_key=None - refresh it
+                # now that the key has actually been generated
+                auth_repo.yubikey_store.add_key_data(
+                    key_name, serial_num, key, role_name, slot=slot
+                )
 
             if certs_dir is not None:
                 # check if already exported
                 if len(auth_repo.yubikey_store.get_roles_of_key(serial_num, key)) == 1:
                     # this is the first time that this key is being used (can only be used once per role)
-                    yk.export_yk_certificate(certs_dir, key, serial=serial_num)
+                    yk.export_yk_certificate(
+                        certs_dir, key, serial=serial_num, slot=slot
+                    )
             return key, serial_num, slot
 
 

--- a/taf/keys.py
+++ b/taf/keys.py
@@ -44,7 +44,7 @@ except ImportError:
     yk = YubikeyMissingLibrary()  # type: ignore
 
 
-def _create_signer(auth_repo, public_key, serial_num, key_name):
+def _create_signer(auth_repo, public_key, serial_num, key_name, slot=None):
     return YkSigner(
         public_key,
         serial_num,
@@ -54,6 +54,7 @@ def _create_signer(auth_repo, public_key, serial_num, key_name):
             serial_num=serial_num,
         ),
         key_name=key_name,
+        slot=slot,
     )
 
 
@@ -242,10 +243,10 @@ def _load_yubikeys(
     taf_logger.debug(f"Currently loaded keyids for {role}: {loaded_keyids}")
 
     loaded_key_names = []
-    for public_key, serial_num, key_name in yubikeys:
+    for public_key, serial_num, key_name, slot in yubikeys:
         if public_key is not None and public_key.keyid not in loaded_keyids:
             taf_logger.debug(
-                f"Found YubiKey: Serial={serial_num}, key_name='{key_name}', keyid={public_key.keyid}"
+                f"Found YubiKey: Serial={serial_num}, key_name='{key_name}', keyid={public_key.keyid}, slot={slot}"
             )
             signer = YkSigner(
                 public_key,
@@ -256,6 +257,7 @@ def _load_yubikeys(
                     serial_num=serial_num,
                 ),
                 key_name=key_name,
+                slot=slot,
             )
             signers_yubikeys.append(signer)
             loaded_keyids.append(public_key.keyid)
@@ -463,14 +465,16 @@ def _setup_yubikey_roles_keys(
         for key_name in list(yubikey_ids):
             key_data = auth_repo.yubikey_store.get_key_data(key_name)
             if key_data is not None:
-                public_key, serial_num = key_data
+                public_key, serial_num, slot = key_data
                 auth_repo.yubikey_store.add_key_data(
-                    key_name, serial_num, public_key, role.name
+                    key_name, serial_num, public_key, role.name, slot=slot
                 )
                 yubikey_ids.remove(key_name)
                 yubikey_keys.append(public_key)
                 loaded_keys_num += 1
-                signer = _create_signer(auth_repo, public_key, serial_num, key_name)
+                signer = _create_signer(
+                    auth_repo, public_key, serial_num, key_name, slot=slot
+                )
                 signers.append(signer)
 
         # if key already loaded while setting up a different role, skip it
@@ -494,9 +498,9 @@ def _setup_yubikey_roles_keys(
             if not auth_repo.yubikey_store.is_key_name_loaded(key_name):
                 yk_with_public_key[key_name] = public_key
             else:
-                serial_num = auth_repo.yubikey_store.get_key_data["serial"]
+                _, serial_num, slot = auth_repo.yubikey_store.get_key_data(key_name)
                 auth_repo.yubikey_store.add_key_data(
-                    key_name, serial_num, public_key, role.name
+                    key_name, serial_num, public_key, role.name, slot=slot
                 )
                 loaded_keys_num += 1
             yubikey_keys.append(public_key)
@@ -653,7 +657,7 @@ def _setup_yubikey(
             yubikeys_to_skip=yubikeys_to_skip,
         )
         if yubikeys is not None:
-            key, serial_num, key_name = yubikeys[0]
+            key, serial_num, key_name, _ = yubikeys[0]
             if not use_existing:
                 # TODO: always resetting is temporary - once signing supports
                 # slots other than SIGNATURE, let the user pick which slot to
@@ -697,16 +701,19 @@ def _load_remaining_keys_of_role(
     while loaded_keys_num < role.threshold:
         loaded_keys = []
         for key_name, public_key in yk_with_public_key.items():
-            serial_num = _load_and_verify_yubikey(
+            result = _load_and_verify_yubikey(
                 role.name,
                 key_name,
                 public_key,
                 taf_repo=auth_repo,
             )
-            if serial_num:
+            if result:
+                serial_num, slot = result
                 loaded_keys_num += 1
                 loaded_keys.append(key_name)
-                signer = _create_signer(auth_repo, public_key, serial_num, key_name)
+                signer = _create_signer(
+                    auth_repo, public_key, serial_num, key_name, slot=slot
+                )
                 signers.append(signer)
                 yubikey_keys.remove(signer.public_key)
 
@@ -724,7 +731,7 @@ def _load_and_verify_yubikey(
     key_name: str,
     public_key,
     taf_repo: AuthenticationRepository,
-) -> Optional[str]:
+) -> Optional[Tuple[str, object]]:
     if not click.confirm(f"Sign using {key_name} Yubikey?"):
         return None
     while True:
@@ -740,11 +747,12 @@ def _load_and_verify_yubikey(
         )
         if yubikeys:
             yubikey = yubikeys[0]
-            yk_pub_key_id = yubikey[0].keyid
+            yk_pub_key_id = yubikey[0].keyid if yubikey[0] is not None else None
             if yk_pub_key_id != public_key.keyid:
                 print(
                     "Public key of the inserted key is not equal to the specified one."
                 )
                 if not click.confirm("Try again?"):
                     return None
-            return yubikey[1]
+                continue
+            return yubikey[1], yubikey[3]

--- a/taf/keys.py
+++ b/taf/keys.py
@@ -744,8 +744,8 @@ def _load_and_verify_yubikey(
             pin_repeat=True,
         )
         if yubikeys:
-            yubikey = yubikeys[0]
-            yk_pub_key_id = yubikey[0].keyid if yubikey[0] is not None else None
+            yk_public_key, serial_num, _, slot = yubikeys[0]
+            yk_pub_key_id = yk_public_key.keyid if yk_public_key is not None else None
             if yk_pub_key_id != public_key.keyid:
                 print(
                     "Public key of the inserted key is not equal to the specified one."
@@ -753,4 +753,4 @@ def _load_and_verify_yubikey(
                 if not click.confirm("Try again?"):
                     return None
                 continue
-            return yubikey[1], yubikey[3]
+            return serial_num, slot

--- a/taf/keys.py
+++ b/taf/keys.py
@@ -33,6 +33,7 @@ from taf.keystore import (
     load_signer_from_private_keystore,
 )
 from taf import YubikeyMissingLibrary
+from securesystemslib.signer import SSlibKey
 from securesystemslib.signer._crypto_signer import CryptoSigner
 
 try:
@@ -512,7 +513,7 @@ def _setup_yubikey_roles_keys(
             taf_logger.debug(
                 f"Preparing to set up YubiKey for role '{role.name}', key_name='{key_name}'."
             )
-            public_key, serial_num = _setup_yubikey(
+            public_key, serial_num, slot = _setup_yubikey(
                 auth_repo,
                 role.name,
                 key_name,
@@ -522,7 +523,9 @@ def _setup_yubikey_roles_keys(
                 yubikes_to_skip,
             )
             loaded_keys_num += 1
-            signer = _create_signer(auth_repo, public_key, serial_num, key_name)
+            signer = _create_signer(
+                auth_repo, public_key, serial_num, key_name, slot=slot
+            )
             signers.append(signer)
 
         key_id = _get_legacy_keyid(public_key)
@@ -627,7 +630,7 @@ def _setup_yubikey(
     certs_dir: Optional[Union[Path, str]] = None,
     key_size: int = 2048,
     yubikeys_to_skip: Optional[List] = None,
-) -> Tuple[Dict, str]:
+) -> Tuple[SSlibKey, str, object]:
     print(f"Registering keys for {key_name}")
     taf_logger.debug(
         f"Starting YubiKey setup for role '{role_name}', key '{key_name}'. Checking if user wants to reuse an existing key."
@@ -657,26 +660,26 @@ def _setup_yubikey(
             yubikeys_to_skip=yubikeys_to_skip,
         )
         if yubikeys is not None:
-            key, serial_num, key_name, _ = yubikeys[0]
+            key, serial_num, key_name, slot = yubikeys[0]
             if not use_existing:
-                # TODO: always uses SLOT.SIGNATURE - let the user pick which
-                # slot to generate the new key in. taf never resets or
-                # overwrites a card, so this fails outright if SIGNATURE is
-                # already occupied; the user has to reset the YubiKey's PIV
-                # application themselves and try again.
+                occupied = yk.get_piv_public_keys_tuf(serial=serial_num).get(
+                    serial_num, {}
+                )
+                slot = yk._prompt_for_new_key_slot(serial_num, occupied.keys())
                 key = yk.setup_new_yubikey(
                     auth_repo.pin_manager,
                     serial_num,
                     scheme,
                     key_size=key_size,
+                    slot=slot,
                 )
 
             if certs_dir is not None:
                 # check if already exported
-                if len(auth_repo.yubikey_store.get_roles_of_key(serial_num)) == 1:
+                if len(auth_repo.yubikey_store.get_roles_of_key(serial_num, key)) == 1:
                     # this is the first time that this key is being used (can only be used once per role)
                     yk.export_yk_certificate(certs_dir, key, serial=serial_num)
-            return key, serial_num
+            return key, serial_num, slot
 
 
 def _load_remaining_keys_of_role(

--- a/taf/tests/conftest.py
+++ b/taf/tests/conftest.py
@@ -4,7 +4,10 @@ import json
 import re
 import shutil
 from pathlib import Path
+from typing import Optional
 
+from taf.api.repository import create_repository
+from taf.auth_repo import AuthenticationRepository
 from taf.tuf.keys import load_signer_from_file
 
 # from taf.tests import TEST_WITH_REAL_YK
@@ -23,6 +26,9 @@ HANDLERS_DATA_INPUT_DIR = TEST_DATA_PATH / "handler_inputs"
 TEST_INIT_DATA_PATH = Path(__file__).parent / "init_data"
 REPOSITORY_DESCRIPTION_INPUT_DIR = TEST_DATA_PATH / "repository_description_inputs"
 NO_YUBIKEYS_INPUT = REPOSITORY_DESCRIPTION_INPUT_DIR / "no_yubikeys.json"
+KEYSTORE_NO_YUBIKEYS_INPUT = (
+    REPOSITORY_DESCRIPTION_INPUT_DIR / "keystore_no_yubikeys.json"
+)
 WITH_DELEGATIONS_NO_YUBIKEY = (
     REPOSITORY_DESCRIPTION_INPUT_DIR / "with_delegations_no_yubikeys.json"
 )
@@ -60,6 +66,11 @@ def mirrors_json_path():
 @pytest.fixture(scope="session")
 def no_yubikeys_input():
     return json.loads(NO_YUBIKEYS_INPUT.read_text())
+
+
+@pytest.fixture(scope="session")
+def keystore_no_yubikeys_path():
+    return str(KEYSTORE_NO_YUBIKEYS_INPUT)
 
 
 @pytest.fixture(scope="session")
@@ -143,6 +154,26 @@ def output_path():
 @pytest.fixture(scope="session")
 def pin_manager():
     return PinManager()
+
+
+def create_authentication_repository(
+    library_dir: Path,
+    pin_manager: PinManager,
+    repo_name: str,
+    keys_description: str,
+    is_test_repo: bool = False,
+    keystore: Optional[Path] = None,
+) -> AuthenticationRepository:
+    repo_path = Path(library_dir, repo_name)
+    create_repository(
+        str(repo_path),
+        pin_manager,
+        str(keystore) if keystore is not None else str(KEYSTORE_PATH),
+        keys_description,
+        commit=True,
+        test=is_test_repo,
+    )
+    return AuthenticationRepository(library_dir, repo_name, pin_manager=pin_manager)
 
 
 @pytest.fixture(scope="session")

--- a/taf/tests/data/repository_description_inputs/keystore_no_yubikeys.json
+++ b/taf/tests/data/repository_description_inputs/keystore_no_yubikeys.json
@@ -1,0 +1,16 @@
+{
+  "roles": {
+    "root": {
+      "number": 2,
+      "threshold": 1
+    },
+    "targets": {
+      "number": 1,
+      "threshold": 1
+    },
+    "snapshot": {
+    },
+    "timestamp": {
+    }
+  }
+}

--- a/taf/tests/test_updater/conftest.py
+++ b/taf/tests/test_updater/conftest.py
@@ -26,7 +26,6 @@ from taf.exceptions import GitError
 from taf.utils import on_rm_error
 from taf.log import disable_console_logging
 from taf.tests.test_updater.update_utils import load_target_repositories
-from taf.api.repository import create_repository
 from taf.api.targets import (
     register_target_files,
     update_target_repos_from_repositories_json,
@@ -41,6 +40,7 @@ from taf.tests.conftest import (
     TEST_DATA_ORIGIN_PATH,
     KEYSTORE_PATH,
     TEST_INIT_DATA_PATH,
+    create_authentication_repository,
 )
 from taf.yubikey.yubikey_manager import PinManager
 
@@ -314,24 +314,6 @@ def create_mirrors_json(library_dir: Path, repo_name: str):
     mirrors = {"mirrors": [f"{library_dir}/{{org_name}}/{{repo_name}}"]}
     mirrors_path = targets_dir_path / MIRRORS_JSON_NAME
     mirrors_path.write_text(json.dumps(mirrors))
-
-
-def create_authentication_repository(
-    library_dir: Path,
-    pin_manager: PinManager,
-    repo_name: str,
-    keys_description: str,
-    is_test_repo: bool = False,
-):
-    repo_path = Path(library_dir, repo_name)
-    create_repository(
-        str(repo_path),
-        pin_manager,
-        str(KEYSTORE_PATH),
-        keys_description,
-        commit=True,
-        test=is_test_repo,
-    )
 
 
 def sign_target_files(library_dir, repo_name, keystore, pin_manager):

--- a/taf/tests/tuf/test_keys/conftest.py
+++ b/taf/tests/tuf/test_keys/conftest.py
@@ -2,11 +2,13 @@ import pytest
 import shutil
 
 import taf.yubikey.yubikey as yk
+from taf.tests.conftest import create_authentication_repository
 from taf.tools.yubikey.yubikey_utils import FakeYubiKey, _yk_piv_ctrl_mock
 from taf.utils import on_rm_error
 from taf.models.converter import from_dict
 from taf.models.types import RolesKeysData
 from taf.tuf.repository import MetadataRepository
+from taf.yubikey.yubikey_manager import PinManager
 
 
 @pytest.fixture
@@ -64,6 +66,27 @@ def make_fake_yubikey(monkeypatch, keystore):
 
     for device in created:
         device.remove()
+
+
+@pytest.fixture
+def create_auth_repo(repo_path, keystore, keystore_no_yubikeys_path):
+    """Factory wrapping create_authentication_repository: root is signed
+    with root1+root2, both already present in the shared keystore fixture,
+    so it can be pointed at directly - nothing needs generating or writing.
+    Built under the test's own repo_path, cleaned up with it.
+    """
+
+    def _create(pin_manager=None):
+        return create_authentication_repository(
+            repo_path,
+            pin_manager if pin_manager is not None else PinManager(),
+            "test/auth",
+            keystore_no_yubikeys_path,
+            is_test_repo=True,
+            keystore=keystore,
+        )
+
+    return _create
 
 
 @pytest.fixture(autouse=False)

--- a/taf/tests/tuf/test_keys/conftest.py
+++ b/taf/tests/tuf/test_keys/conftest.py
@@ -28,6 +28,44 @@ def fake_yubikey(monkeypatch, keystore):
     key.remove()
 
 
+@pytest.fixture
+def make_fake_yubikey(monkeypatch, keystore):
+    """Factory for fake inserted YubiKeys, each backed by a given keystore
+    key (occupying SIGNATURE) and optionally pre-provisioned with more keys
+    in other slots. Each call creates one independent device; all are
+    removed automatically at teardown.
+
+    Usage:
+        device = make_fake_yubikey("targets")
+        device = make_fake_yubikey(
+            "snapshot", extra_slots={SLOT.AUTHENTICATION: "timestamp"}
+        )
+    """
+    monkeypatch.setattr(yk, "_yk_piv_ctrl", _yk_piv_ctrl_mock)
+    created = []
+
+    def _make(key_name, extra_slots=None):
+        device = FakeYubiKey(
+            keystore / key_name, keystore / f"{key_name}.pub", scheme=None
+        )
+        device.insert()
+        for slot, other_key_name in (extra_slots or {}).items():
+            yk.setup(
+                pin=device.pin,
+                serial=device.serial,
+                cert_cn=f"{other_key_name} key",
+                private_key_pem=(keystore / other_key_name).read_bytes(),
+                slot=slot,
+            )
+        created.append(device)
+        return device
+
+    yield _make
+
+    for device in created:
+        device.remove()
+
+
 @pytest.fixture(autouse=False)
 def tuf_repo(
     tuf_repo_path, signers_with_delegations, with_delegations_no_yubikeys_input

--- a/taf/tests/tuf/test_keys/test_yubikey_repo_signing.py
+++ b/taf/tests/tuf/test_keys/test_yubikey_repo_signing.py
@@ -1,0 +1,186 @@
+"""Integration test: a real authentication repository, created and updated
+through the real CLI-level API (taf.api.repository.create_repository,
+taf.api.targets.register_target_files), signed with fake YubiKeys standing
+in for real hardware - one device for targets, a second device holding two
+different keys (one per PIV slot) for snapshot and timestamp.
+
+Unlike taf/tests/tuf/test_keys/test_yubikey_slots.py (which exercises the
+low-level discovery/signing functions directly), this drives the same
+interactive setup flow a real user would go through, mocking only the
+genuine I/O boundaries (PIN/confirm/prompt input) - never taf's own
+collaborator logic.
+"""
+
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from tuf.api.metadata import Metadata
+from yubikit.piv import SLOT
+
+import taf.keys as taf_keys
+import taf.yubikey.yubikey as yk
+from taf.api.repository import create_repository
+from taf.api.targets import register_target_files
+from taf.auth_repo import AuthenticationRepository
+from taf.tools.yubikey.yubikey_utils import FakeYubiKey, _yk_piv_ctrl_mock
+from taf.yubikey.yubikey_manager import PinManager
+
+
+@pytest.fixture
+def two_fake_yubikeys(monkeypatch, keystore):
+    """Two fake devices: device_b (targets' key, SIGNATURE only) and
+    device_a, pre-provisioned with two *different* keys in two different
+    slots - snapshot's in SIGNATURE, timestamp's in AUTHENTICATION - the
+    same way a real device would be set up ahead of time with
+    `taf yubikey setup-test-key` before being reused during repo creation.
+    """
+    monkeypatch.setattr(yk, "_yk_piv_ctrl", _yk_piv_ctrl_mock)
+
+    device_b = FakeYubiKey(keystore / "targets", keystore / "targets.pub", scheme=None)
+    device_a = FakeYubiKey(
+        keystore / "snapshot", keystore / "snapshot.pub", scheme=None
+    )
+    device_b.insert()
+    device_a.insert()
+    yk.setup(
+        pin=device_a.pin,
+        serial=device_a.serial,
+        cert_cn="Timestamp key",
+        private_key_pem=(keystore / "timestamp").read_bytes(),
+        slot=SLOT.AUTHENTICATION,
+    )
+    # only device_b should be inserted when repo creation starts - the
+    # confirm-mock below inserts device_a once targets' setup is done
+    device_a.remove()
+
+    yield device_a, device_b
+
+    device_a.remove()
+    device_b.remove()
+
+
+def _make_confirm_side_effect(device_a, device_b):
+    """Sequences taf's interactive "reuse already set up Yubikey?" prompt -
+    every role reuses an already-set-up key (device_b's default SIGNATURE
+    key for targets, then device_a's two slots for snapshot/timestamp), so
+    the answer is always "yes"; this only needs to swap which device is
+    "inserted" between targets and snapshot. Every other confirm() in the
+    flow (generate/write keystore keys, etc.) is also answered "yes" to
+    just proceed.
+    """
+    reuse_calls = {"count": 0}
+
+    def _side_effect(message, *args, **kwargs):
+        if message == "Do you want to reuse already set up Yubikey?":
+            reuse_calls["count"] += 1
+            if reuse_calls["count"] == 2:
+                device_b.remove()
+                device_a.insert()
+        return True
+
+    return _side_effect
+
+
+def test_create_repo_and_sign_target_update_across_devices_and_slots(
+    two_fake_yubikeys, keystore, tmp_path
+):
+    device_a, device_b = two_fake_yubikeys
+    pin_manager = PinManager()
+    pin_manager.add_pin(device_a.serial, device_a.pin)
+    pin_manager.add_pin(device_b.serial, device_b.pin)
+
+    repo_path = tmp_path / "auth"
+    scratch_keystore = tmp_path / "keystore"
+    scratch_keystore.mkdir()
+
+    roles_key_infos_path = tmp_path / "keys-description.json"
+    roles_key_infos_path.write_text(
+        json.dumps(
+            {
+                "roles": {
+                    "root": {"number": 1, "threshold": 1},
+                    "targets": {"number": 1, "threshold": 1, "yubikey": True},
+                    "snapshot": {"number": 1, "threshold": 1, "yubikey": True},
+                    "timestamp": {"yubikey": True},
+                }
+            }
+        )
+    )
+
+    def _input_side_effect(prompt="", *args, **kwargs):
+        # keeping this blank avoids encrypting the generated keystore key
+        # with a password load_signer_from_pem is never given back
+        if "password" in prompt.lower():
+            return ""
+        return "Test key holder"
+
+    # role setup needs devices inserted one at a time (taf refuses to guess
+    # which of several not-yet-loaded devices a role means), but the actual
+    # metadata signing that follows happens as one batch across all roles,
+    # needing every device that was used present at once - so device_b is
+    # brought back once timestamp (the last role) finishes its own setup,
+    # before any signing happens.
+    real_setup_yubikey = taf_keys._setup_yubikey
+
+    def _setup_yubikey_wrapper(auth_repo, role_name, key_name, *args, **kwargs):
+        result = real_setup_yubikey(auth_repo, role_name, key_name, *args, **kwargs)
+        if role_name == "timestamp":
+            device_b.insert()
+        return result
+
+    with mock.patch(
+        "click.confirm", side_effect=_make_confirm_side_effect(device_a, device_b)
+    ), mock.patch("click.prompt", side_effect=[2, 1]), mock.patch(
+        "builtins.input", side_effect=_input_side_effect
+    ), mock.patch(
+        "taf.keys._setup_yubikey", side_effect=_setup_yubikey_wrapper
+    ):
+        create_repository(
+            str(repo_path),
+            pin_manager,
+            keystore=str(scratch_keystore),
+            roles_key_infos=str(roles_key_infos_path),
+            commit=True,
+            test=True,
+        )
+
+    metadata_path = repo_path / "metadata"
+    root_md = Metadata.from_file(str(metadata_path / "root.json"))
+    versions_before = {}
+    for role in ("targets", "snapshot", "timestamp"):
+        role_md = Metadata.from_file(str(metadata_path / f"{role}.json"))
+        root_md.verify_delegate(role, role_md)
+        versions_before[role] = role_md.signed.version
+
+    # add a target file and sign the update - both devices stay inserted;
+    # this goes through _read_and_check_yubikeys (role-validity-based
+    # discovery), not the interactive setup flow, so no confirm/prompt
+    # mocking is needed here
+    auth_repo = AuthenticationRepository(path=str(repo_path), pin_manager=pin_manager)
+    target_file = auth_repo.targets_path / "a-new-target.txt"
+    target_file.write_text("hello")
+
+    register_target_files(
+        str(repo_path),
+        pin_manager,
+        keystore=str(scratch_keystore),
+        update_snapshot_and_timestamp=True,
+        push=False,
+    )
+
+    assert "a-new-target.txt" in auth_repo.get_signed_target_files()
+
+    root_md = Metadata.from_file(str(metadata_path / "root.json"))
+    updated_targets_md = Metadata.from_file(str(metadata_path / "targets.json"))
+    updated_snapshot_md = Metadata.from_file(str(metadata_path / "snapshot.json"))
+    updated_timestamp_md = Metadata.from_file(str(metadata_path / "timestamp.json"))
+    root_md.verify_delegate("targets", updated_targets_md)
+    root_md.verify_delegate("snapshot", updated_snapshot_md)
+    root_md.verify_delegate("timestamp", updated_timestamp_md)
+
+    # re-signing must have actually happened, not a no-op
+    assert updated_targets_md.signed.version > versions_before["targets"]
+    assert updated_snapshot_md.signed.version > versions_before["snapshot"]
+    assert updated_timestamp_md.signed.version > versions_before["timestamp"]

--- a/taf/tests/tuf/test_keys/test_yubikey_repo_signing.py
+++ b/taf/tests/tuf/test_keys/test_yubikey_repo_signing.py
@@ -1,150 +1,66 @@
-"""Integration test: a real authentication repository, created and updated
-through the real CLI-level API (taf.api.repository.create_repository,
-taf.api.targets.register_target_files), signed with fake YubiKeys standing
-in for real hardware - one device for targets, a second device holding two
-different keys (one per PIV slot) for snapshot and timestamp.
-
-Unlike taf/tests/tuf/test_keys/test_yubikey_slots.py (which exercises the
-low-level discovery/signing functions directly), this drives the same
-interactive setup flow a real user would go through, mocking only the
-genuine I/O boundaries (PIN/confirm/prompt input) - never taf's own
-collaborator logic.
-"""
-
 import json
-from pathlib import Path
-from unittest import mock
+import shutil
 
-import pytest
 from tuf.api.metadata import Metadata
 from yubikit.piv import SLOT
 
-import taf.keys as taf_keys
-import taf.yubikey.yubikey as yk
 from taf.api.repository import create_repository
 from taf.api.targets import register_target_files
 from taf.auth_repo import AuthenticationRepository
-from taf.tools.yubikey.yubikey_utils import FakeYubiKey, _yk_piv_ctrl_mock
 from taf.yubikey.yubikey_manager import PinManager
 
 
-@pytest.fixture
-def two_fake_yubikeys(monkeypatch, keystore):
-    """Two fake devices: device_b (targets' key, SIGNATURE only) and
-    device_a, pre-provisioned with two *different* keys in two different
-    slots - snapshot's in SIGNATURE, timestamp's in AUTHENTICATION - the
-    same way a real device would be set up ahead of time with
-    `taf yubikey setup-test-key` before being reused during repo creation.
-    """
-    monkeypatch.setattr(yk, "_yk_piv_ctrl", _yk_piv_ctrl_mock)
-
-    device_b = FakeYubiKey(keystore / "targets", keystore / "targets.pub", scheme=None)
-    device_a = FakeYubiKey(
-        keystore / "snapshot", keystore / "snapshot.pub", scheme=None
-    )
-    device_b.insert()
-    device_a.insert()
-    yk.setup(
-        pin=device_a.pin,
-        serial=device_a.serial,
-        cert_cn="Timestamp key",
-        private_key_pem=(keystore / "timestamp").read_bytes(),
-        slot=SLOT.AUTHENTICATION,
-    )
-    # only device_b should be inserted when repo creation starts - the
-    # confirm-mock below inserts device_a once targets' setup is done
-    device_a.remove()
-
-    yield device_a, device_b
-
-    device_a.remove()
-    device_b.remove()
-
-
-def _make_confirm_side_effect(device_a, device_b):
-    """Sequences taf's interactive "reuse already set up Yubikey?" prompt -
-    every role reuses an already-set-up key (device_b's default SIGNATURE
-    key for targets, then device_a's two slots for snapshot/timestamp), so
-    the answer is always "yes"; this only needs to swap which device is
-    "inserted" between targets and snapshot. Every other confirm() in the
-    flow (generate/write keystore keys, etc.) is also answered "yes" to
-    just proceed.
-    """
-    reuse_calls = {"count": 0}
-
-    def _side_effect(message, *args, **kwargs):
-        if message == "Do you want to reuse already set up Yubikey?":
-            reuse_calls["count"] += 1
-            if reuse_calls["count"] == 2:
-                device_b.remove()
-                device_a.insert()
-        return True
-
-    return _side_effect
-
-
 def test_create_repo_and_sign_target_update_across_devices_and_slots(
-    two_fake_yubikeys, keystore, tmp_path
+    make_fake_yubikey, keystore, tmp_path
 ):
-    device_a, device_b = two_fake_yubikeys
+    # root/targets/snapshot/timestamp are plain keystore roles for repo
+    # creation - pre-populating their key files means every load succeeds
+    # on the first try, so no interactive prompting is needed. The same
+    # key material is then flashed onto the fake YubiKeys below, so the
+    # roles can be re-signed via YubiKey afterwards.
+    creation_keystore = tmp_path / "creation_keystore"
+    creation_keystore.mkdir()
+    for src_name, dst_name in [
+        ("root1", "root"),
+        ("targets", "targets"),
+        ("snapshot", "snapshot"),
+        ("timestamp", "timestamp"),
+    ]:
+        shutil.copy(keystore / src_name, creation_keystore / dst_name)
+        shutil.copy(keystore / f"{src_name}.pub", creation_keystore / f"{dst_name}.pub")
+
+    device_b = make_fake_yubikey("targets")
+    device_a = make_fake_yubikey(
+        "snapshot", extra_slots={SLOT.AUTHENTICATION: "timestamp"}
+    )
+
     pin_manager = PinManager()
     pin_manager.add_pin(device_a.serial, device_a.pin)
     pin_manager.add_pin(device_b.serial, device_b.pin)
 
     repo_path = tmp_path / "auth"
-    scratch_keystore = tmp_path / "keystore"
-    scratch_keystore.mkdir()
-
     roles_key_infos_path = tmp_path / "keys-description.json"
     roles_key_infos_path.write_text(
         json.dumps(
             {
                 "roles": {
                     "root": {"number": 1, "threshold": 1},
-                    "targets": {"number": 1, "threshold": 1, "yubikey": True},
-                    "snapshot": {"number": 1, "threshold": 1, "yubikey": True},
-                    "timestamp": {"yubikey": True},
+                    "targets": {"number": 1, "threshold": 1},
+                    "snapshot": {"number": 1, "threshold": 1},
+                    "timestamp": {},
                 }
             }
         )
     )
 
-    def _input_side_effect(prompt="", *args, **kwargs):
-        # keeping this blank avoids encrypting the generated keystore key
-        # with a password load_signer_from_pem is never given back
-        if "password" in prompt.lower():
-            return ""
-        return "Test key holder"
-
-    # role setup needs devices inserted one at a time (taf refuses to guess
-    # which of several not-yet-loaded devices a role means), but the actual
-    # metadata signing that follows happens as one batch across all roles,
-    # needing every device that was used present at once - so device_b is
-    # brought back once timestamp (the last role) finishes its own setup,
-    # before any signing happens.
-    real_setup_yubikey = taf_keys._setup_yubikey
-
-    def _setup_yubikey_wrapper(auth_repo, role_name, key_name, *args, **kwargs):
-        result = real_setup_yubikey(auth_repo, role_name, key_name, *args, **kwargs)
-        if role_name == "timestamp":
-            device_b.insert()
-        return result
-
-    with mock.patch(
-        "click.confirm", side_effect=_make_confirm_side_effect(device_a, device_b)
-    ), mock.patch("click.prompt", side_effect=[2, 1]), mock.patch(
-        "builtins.input", side_effect=_input_side_effect
-    ), mock.patch(
-        "taf.keys._setup_yubikey", side_effect=_setup_yubikey_wrapper
-    ):
-        create_repository(
-            str(repo_path),
-            pin_manager,
-            keystore=str(scratch_keystore),
-            roles_key_infos=str(roles_key_infos_path),
-            commit=True,
-            test=True,
-        )
+    create_repository(
+        str(repo_path),
+        pin_manager,
+        keystore=str(creation_keystore),
+        roles_key_infos=str(roles_key_infos_path),
+        commit=True,
+        test=True,
+    )
 
     metadata_path = repo_path / "metadata"
     root_md = Metadata.from_file(str(metadata_path / "root.json"))
@@ -154,18 +70,20 @@ def test_create_repo_and_sign_target_update_across_devices_and_slots(
         root_md.verify_delegate(role, role_md)
         versions_before[role] = role_md.signed.version
 
-    # add a target file and sign the update - both devices stay inserted;
-    # this goes through _read_and_check_yubikeys (role-validity-based
-    # discovery), not the interactive setup flow, so no confirm/prompt
-    # mocking is needed here
+    # add a target file and sign the update using the YubiKeys - an empty
+    # keystore dir means load_signers finds no matching keystore file and
+    # falls through to _load_yubikeys, discovering the inserted devices
     auth_repo = AuthenticationRepository(path=str(repo_path), pin_manager=pin_manager)
     target_file = auth_repo.targets_path / "a-new-target.txt"
     target_file.write_text("hello")
 
+    signing_keystore = tmp_path / "signing_keystore"
+    signing_keystore.mkdir()
+
     register_target_files(
         str(repo_path),
         pin_manager,
-        keystore=str(scratch_keystore),
+        keystore=str(signing_keystore),
         update_snapshot_and_timestamp=True,
         push=False,
     )

--- a/taf/tests/tuf/test_keys/test_yubikey_setup.py
+++ b/taf/tests/tuf/test_keys/test_yubikey_setup.py
@@ -6,6 +6,8 @@ which is how the standalone setup command calls into the prompt: there is no
 authentication repository involved when provisioning a fresh key.
 """
 
+from yubikit.piv import SLOT
+
 import taf.yubikey.yubikey as yk
 from taf.yubikey.yubikey import yubikey_prompt
 from taf.yubikey.yubikey_manager import PinManager
@@ -23,6 +25,10 @@ def test_setup_new_yubikey_without_taf_repo_does_not_crash(
     monkeypatch.setattr(yk, "get_pin_for", lambda *a, **k: "111111")
     # If the (separate) validate-against-card path runs, don't let it loop/lock.
     monkeypatch.setattr(yk, "is_valid_pin", lambda *a, **k: (True, None))
+    # slot selection isn't under test here - fake_single_yubikey has no real
+    # PIV backend behind it to read occupancy from
+    monkeypatch.setattr(yk, "get_piv_public_keys_tuf", lambda *a, **k: {})
+    monkeypatch.setattr(yk, "_prompt_for_new_key_slot", lambda *a, **k: SLOT.SIGNATURE)
 
     pin_manager = PinManager()
     result = yubikey_prompt(
@@ -58,6 +64,10 @@ def test_setup_new_yubikey_pin_is_not_validated_against_card(
         return (False, 0)
 
     monkeypatch.setattr(yk, "is_valid_pin", fake_is_valid_pin)
+    # slot selection isn't under test here - fake_single_yubikey has no real
+    # PIV backend behind it to read occupancy from
+    monkeypatch.setattr(yk, "get_piv_public_keys_tuf", lambda *a, **k: {})
+    monkeypatch.setattr(yk, "_prompt_for_new_key_slot", lambda *a, **k: SLOT.SIGNATURE)
 
     pin_manager = PinManager()
     result = yubikey_prompt(

--- a/taf/tests/tuf/test_keys/test_yubikey_slots.py
+++ b/taf/tests/tuf/test_keys/test_yubikey_slots.py
@@ -1,5 +1,6 @@
 import secrets
 from pathlib import Path
+from typing import Optional
 from unittest import mock
 
 import pytest
@@ -34,7 +35,9 @@ class _MinimalTafRepo:
     tested without building a full repository on disk just to check
     role/key validity."""
 
-    def __init__(self, key_names_by_keyid: dict, pin_manager: PinManager = None):
+    def __init__(
+        self, key_names_by_keyid: dict, pin_manager: Optional[PinManager] = None
+    ):
         self.path = Path.cwd()
         self.yubikey_store = YubiKeyStore()
         self.keys_name_mappings = dict(key_names_by_keyid)

--- a/taf/tests/tuf/test_keys/test_yubikey_slots.py
+++ b/taf/tests/tuf/test_keys/test_yubikey_slots.py
@@ -1,12 +1,21 @@
+from pathlib import Path
+from unittest import mock
+
 import pytest
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
 from yubikit.core import NotSupportedError
 from yubikit.piv import DEFAULT_MANAGEMENT_KEY, SLOT
 
 import taf.api.yubikey as yk_api
+import taf.keys as taf_keys
 import taf.yubikey.yubikey as yk
 from taf.exceptions import YubikeyError
 from taf.tools.yubikey.yubikey_utils import FakePivController
-from taf.yubikey.yubikey_manager import PinManager
+from taf.tuf.keys import YkSigner, load_signer_from_file
+from taf.yubikey.yubikey_manager import PinManager, YubiKeyStore
 
 
 def _pin_manager(fake_yubikey) -> PinManager:
@@ -15,6 +24,22 @@ def _pin_manager(fake_yubikey) -> PinManager:
     pin_manager = PinManager()
     pin_manager.add_pin(fake_yubikey.serial, fake_yubikey.pin)
     return pin_manager
+
+
+class _MinimalTafRepo:
+    """Stand-in for the parts of AuthenticationRepository that
+    _read_and_check_yubikeys/_load_and_verify_yubikey need, so this can be
+    tested without building a full repository on disk just to check
+    role/key validity."""
+
+    def __init__(self, key_names_by_keyid: dict, pin_manager: PinManager = None):
+        self.path = Path.cwd()
+        self.yubikey_store = YubiKeyStore()
+        self.keys_name_mappings = dict(key_names_by_keyid)
+        self.pin_manager = pin_manager if pin_manager is not None else PinManager()
+
+    def is_valid_metadata_yubikey(self, role, public_key):
+        return public_key is not None and public_key.keyid in self.keys_name_mappings
 
 
 def test_resolve_slot_rejects_retired_slots():
@@ -247,3 +272,303 @@ def test_setup_test_yubikey_explicit_reset_wipes_other_slots(
         new_cert.public_key().public_numbers() != fake_yubikey.pub_key.public_numbers()
     )
     assert status[SLOT.AUTHENTICATION] is None
+
+
+def test_sign_piv_rsa_pkcs1v15_uses_given_slot(fake_yubikey, keystore):
+    new_key_pem = (keystore / "root2").read_bytes()
+    yk.setup(
+        pin="123456",
+        serial=fake_yubikey.serial,
+        cert_cn="Second key",
+        private_key_pem=new_key_pem,
+        slot=SLOT.AUTHENTICATION,
+    )
+
+    sig = yk.sign_piv_rsa_pkcs1v15(
+        b"data", "123456", serial=fake_yubikey.serial, slot=SLOT.AUTHENTICATION
+    )
+
+    auth_priv_key = serialization.load_pem_private_key(
+        new_key_pem, None, default_backend()
+    )
+    # signed with the AUTHENTICATION slot's key, not SIGNATURE's
+    auth_priv_key.public_key().verify(sig, b"data", padding.PKCS1v15(), hashes.SHA256())
+    with pytest.raises(InvalidSignature):
+        fake_yubikey.pub_key.verify(sig, b"data", padding.PKCS1v15(), hashes.SHA256())
+
+
+def test_read_and_check_yubikeys_finds_role_key_in_non_signature_slot(
+    fake_yubikey, keystore
+):
+    new_key_pem = (keystore / "root2").read_bytes()
+    yk.setup(
+        pin="123456",
+        serial=fake_yubikey.serial,
+        cert_cn="Second key",
+        private_key_pem=new_key_pem,
+        slot=SLOT.AUTHENTICATION,
+    )
+    auth_key = load_signer_from_file(keystore / "root2").public_key
+    taf_repo = _MinimalTafRepo({auth_key.keyid: "root2"})
+
+    result = yk._read_and_check_yubikeys(
+        role="root",
+        taf_repo=taf_repo,
+        pin_manager=_pin_manager(fake_yubikey),
+        pin_confirm=False,
+        pin_repeat=False,
+        prompt_message=None,
+        key_names=["root2"],
+        retrying=False,
+        hide_already_loaded_message=True,
+        hide_threshold_message=True,
+        key_id_pins=None,
+    )
+
+    assert len(result) == 1
+    public_key, serial_num, key_name, slot = result[0]
+    assert slot == SLOT.AUTHENTICATION
+    assert public_key.keyid == auth_key.keyid
+
+    # the discovered slot must actually be used to sign, not SIGNATURE
+    signer = YkSigner(
+        public_key, serial_num, lambda name: "123456", key_name, slot=slot
+    )
+    sig = signer.sign(b"hello").signature
+    auth_priv_key = serialization.load_pem_private_key(
+        new_key_pem, None, default_backend()
+    )
+    auth_priv_key.public_key().verify(
+        bytes.fromhex(sig), b"hello", padding.PKCS1v15(), hashes.SHA256()
+    )
+
+
+def test_read_and_check_yubikeys_counts_every_valid_key_on_one_device(
+    fake_yubikey, keystore
+):
+    # one physical device can hold 2 keys valid for the same role (one per
+    # slot) - both must count toward that role's threshold, not just the
+    # first one found
+    new_key_pem = (keystore / "root2").read_bytes()
+    yk.setup(
+        pin="123456",
+        serial=fake_yubikey.serial,
+        cert_cn="Second key",
+        private_key_pem=new_key_pem,
+        slot=SLOT.AUTHENTICATION,
+    )
+    sig_key = fake_yubikey.tuf_key.public_key
+    auth_key = load_signer_from_file(keystore / "root2").public_key
+    taf_repo = _MinimalTafRepo({sig_key.keyid: "root1", auth_key.keyid: "root2"})
+
+    result = yk._read_and_check_yubikeys(
+        role="root",
+        taf_repo=taf_repo,
+        pin_manager=_pin_manager(fake_yubikey),
+        pin_confirm=False,
+        pin_repeat=False,
+        prompt_message=None,
+        key_names=["root1", "root2"],
+        retrying=False,
+        hide_already_loaded_message=True,
+        hide_threshold_message=True,
+        key_id_pins=None,
+    )
+
+    assert len(result) == 2
+    found = {(entry[0].keyid, entry[3]) for entry in result}
+    assert found == {
+        (sig_key.keyid, SLOT.SIGNATURE),
+        (auth_key.keyid, SLOT.AUTHENTICATION),
+    }
+
+
+def test_read_and_check_single_yubikey_auto_selects_sole_occupied_slot(
+    fake_yubikey,
+):
+    # only one slot (SIGNATURE, the fixture's default) is occupied, so there
+    # is nothing to disambiguate - no prompt should be shown.
+    taf_repo = _MinimalTafRepo({fake_yubikey.tuf_key.public_key.keyid: "root1"})
+
+    result = yk._read_and_check_single_yubikey(
+        role="root",
+        key_name="root1",
+        taf_repo=taf_repo,
+        pin_manager=_pin_manager(fake_yubikey),
+        registering_new_key=True,
+        creating_new_key=False,
+        pin_confirm=False,
+        pin_repeat=False,
+        prompt_message=None,
+        retrying=False,
+        yubikeys_to_skip=None,
+        key_id_pins=None,
+    )
+
+    assert result is not None
+    public_key, serial_num, key_name, slot = result
+    assert slot == SLOT.SIGNATURE
+    assert public_key.keyid == fake_yubikey.tuf_key.public_key.keyid
+    assert serial_num == fake_yubikey.serial
+
+
+def test_read_and_check_single_yubikey_prompts_when_multiple_slots_occupied(
+    fake_yubikey, keystore
+):
+    # more than one key is set up on this device - there's no way to know
+    # which one the user means, so they must be asked to pick.
+    new_key_pem = (keystore / "root2").read_bytes()
+    yk.setup(
+        pin="123456",
+        serial=fake_yubikey.serial,
+        cert_cn="Second key",
+        private_key_pem=new_key_pem,
+        slot=SLOT.AUTHENTICATION,
+    )
+    auth_key = load_signer_from_file(keystore / "root2").public_key
+    taf_repo = _MinimalTafRepo(
+        {
+            fake_yubikey.tuf_key.public_key.keyid: "root1",
+            auth_key.keyid: "root2",
+        }
+    )
+
+    # AUTHENTICATION (slot value 154) sorts before SIGNATURE (156), so
+    # option 1 is AUTHENTICATION - select it to prove the user's choice
+    # (not SIGNATURE) is what gets used.
+    with mock.patch("click.prompt", return_value=1) as prompt:
+        result = yk._read_and_check_single_yubikey(
+            role="root",
+            key_name="root2",
+            taf_repo=taf_repo,
+            pin_manager=_pin_manager(fake_yubikey),
+            registering_new_key=True,
+            creating_new_key=False,
+            pin_confirm=False,
+            pin_repeat=False,
+            prompt_message=None,
+            retrying=False,
+            yubikeys_to_skip=None,
+            key_id_pins=None,
+        )
+    prompt.assert_called_once()
+
+    assert result is not None
+    public_key, serial_num, key_name, slot = result
+    assert slot == SLOT.AUTHENTICATION
+    assert public_key.keyid == auth_key.keyid
+
+
+def test_load_and_verify_yubikey_uses_the_slot_the_user_picked(fake_yubikey, keystore):
+    new_key_pem = (keystore / "root2").read_bytes()
+    yk.setup(
+        pin="123456",
+        serial=fake_yubikey.serial,
+        cert_cn="Second key",
+        private_key_pem=new_key_pem,
+        slot=SLOT.AUTHENTICATION,
+    )
+    auth_key = load_signer_from_file(keystore / "root2").public_key
+    taf_repo = _MinimalTafRepo(
+        {
+            fake_yubikey.tuf_key.public_key.keyid: "root1",
+            auth_key.keyid: "root2",
+        },
+        pin_manager=_pin_manager(fake_yubikey),
+    )
+
+    # option 1 is AUTHENTICATION - the correct one for root2
+    with mock.patch("click.prompt", return_value=1), mock.patch(
+        "click.confirm", return_value=True
+    ):
+        result = taf_keys._load_and_verify_yubikey(
+            "root", "root2", auth_key, taf_repo=taf_repo
+        )
+
+    assert result == (fake_yubikey.serial, SLOT.AUTHENTICATION)
+
+
+def test_load_and_verify_yubikey_reports_mismatch_when_wrong_slot_picked(
+    fake_yubikey, keystore
+):
+    # the caller already knows which key it wants (public_key) - if the
+    # user picks a different slot at the prompt, that must be caught as a
+    # mismatch rather than silently accepted.
+    new_key_pem = (keystore / "root2").read_bytes()
+    yk.setup(
+        pin="123456",
+        serial=fake_yubikey.serial,
+        cert_cn="Second key",
+        private_key_pem=new_key_pem,
+        slot=SLOT.AUTHENTICATION,
+    )
+    auth_key = load_signer_from_file(keystore / "root2").public_key
+    taf_repo = _MinimalTafRepo(
+        {
+            fake_yubikey.tuf_key.public_key.keyid: "root1",
+            auth_key.keyid: "root2",
+        },
+        pin_manager=_pin_manager(fake_yubikey),
+    )
+
+    # option 2 is SIGNATURE (the fixture's default key) - the wrong one,
+    # since we're looking for root2 (AUTHENTICATION). First confirm is
+    # "Sign using ... Yubikey?" (yes), second is "Try again?" (no, so it
+    # gives up instead of looping and re-prompting for a slot forever).
+    with mock.patch("click.prompt", return_value=2), mock.patch(
+        "click.confirm", side_effect=[True, False]
+    ):
+        result = taf_keys._load_and_verify_yubikey(
+            "root", "root2", auth_key, taf_repo=taf_repo
+        )
+
+    assert result is None
+
+
+class TestYubiKeyStore:
+    def test_add_key_data_preserves_roles_across_multiple_calls(self):
+        # a single key can be used to sign more than one role - previously
+        # recorded roles for the same key_name must not be lost when it's
+        # registered for another role afterwards.
+        store = YubiKeyStore()
+        store.add_key_data("root1", "111", "pubkey-obj", "root", slot=SLOT.SIGNATURE)
+        store.add_key_data("root1", "111", "pubkey-obj", "targets", slot=SLOT.SIGNATURE)
+
+        assert store.is_loaded_for_role("111", "root")
+        assert store.is_loaded_for_role("111", "targets")
+
+    def test_add_key_data_dedupes_role(self):
+        store = YubiKeyStore()
+        store.add_key_data("root1", "111", "pubkey-obj", "root")
+        store.add_key_data("root1", "111", "pubkey-obj", "root")
+
+        assert store.get_roles_of_key("111") == ["root"]
+
+    def test_get_key_data_returns_slot(self):
+        store = YubiKeyStore()
+        store.add_key_data(
+            "root1", "111", "pubkey-obj", "root", slot=SLOT.AUTHENTICATION
+        )
+
+        public_key, serial_num, slot = store.get_key_data("root1")
+        assert public_key == "pubkey-obj"
+        assert serial_num == "111"
+        assert slot == SLOT.AUTHENTICATION
+
+    def test_get_roles_of_key_isolates_keys_sharing_one_device(self):
+        # two different keys (different slots) on the same physical device,
+        # each used for a different role - each key's own role count must
+        # not be inflated by the other key sharing its serial number.
+        class _FakeKey:
+            def __init__(self, keyid):
+                self.keyid = keyid
+
+        key_a = _FakeKey("keyid-a")
+        key_b = _FakeKey("keyid-b")
+        store = YubiKeyStore()
+        store.add_key_data("root1", "111", key_a, "root", slot=SLOT.SIGNATURE)
+        store.add_key_data("root2", "111", key_b, "targets", slot=SLOT.AUTHENTICATION)
+
+        assert store.get_roles_of_key("111", public_key=key_a) == ["root"]
+        assert store.get_roles_of_key("111", public_key=key_b) == ["targets"]
+        assert set(store.get_roles_of_key("111")) == {"root", "targets"}

--- a/taf/tests/tuf/test_keys/test_yubikey_slots.py
+++ b/taf/tests/tuf/test_keys/test_yubikey_slots.py
@@ -539,6 +539,72 @@ def test_read_and_check_single_yubikey_prompts_when_multiple_slots_occupied(
     assert public_key.keyid == auth_key.keyid
 
 
+def test_prompt_for_new_key_slot_auto_selects_sole_free_slot():
+    # SIGNATURE, KEY_MANAGEMENT and CARD_AUTH are occupied - AUTHENTICATION
+    # is the only free slot, so there's nothing to ask about.
+    occupied = {SLOT.SIGNATURE, SLOT.KEY_MANAGEMENT, SLOT.CARD_AUTH}
+    with mock.patch("click.prompt") as prompt:
+        slot = yk._prompt_for_new_key_slot("123456", occupied)
+    prompt.assert_not_called()
+    assert slot == SLOT.AUTHENTICATION
+
+
+def test_prompt_for_new_key_slot_prompts_when_multiple_free_slots():
+    # only SIGNATURE is occupied - AUTHENTICATION, KEY_MANAGEMENT and
+    # CARD_AUTH are all free, so the user must pick one.
+    occupied = {SLOT.SIGNATURE}
+    # sorted by slot value: AUTHENTICATION(154), KEY_MANAGEMENT(157),
+    # CARD_AUTH(158) - option 2 is KEY_MANAGEMENT
+    with mock.patch("click.prompt", return_value=2) as prompt:
+        slot = yk._prompt_for_new_key_slot("123456", occupied)
+    prompt.assert_called_once()
+    assert slot == SLOT.KEY_MANAGEMENT
+
+
+def test_prompt_for_new_key_slot_raises_when_no_free_slot():
+    occupied = {
+        SLOT.SIGNATURE,
+        SLOT.AUTHENTICATION,
+        SLOT.KEY_MANAGEMENT,
+        SLOT.CARD_AUTH,
+    }
+    with mock.patch("click.prompt") as prompt:
+        with pytest.raises(YubikeyError, match="no free slot"):
+            yk._prompt_for_new_key_slot("123456", occupied)
+    prompt.assert_not_called()
+
+
+def test_setup_yubikey_creates_new_key_in_a_free_non_signature_slot(
+    fake_yubikey, monkeypatch
+):
+    # SIGNATURE is already occupied by the fixture's default key - creating
+    # a new key must land in a different, free slot instead of failing.
+    monkeypatch.setattr("builtins.input", lambda prompt="": "New signer")
+    auth_repo = _MinimalTafRepo({}, pin_manager=_pin_manager(fake_yubikey))
+
+    def _confirm_side_effect(message, *args, **kwargs):
+        # "reuse already set up Yubikey?" -> no, create a new one; every
+        # other confirm (the now-stale delete-everything warning) -> proceed
+        if message == "Do you want to reuse already set up Yubikey?":
+            return False
+        return True
+
+    with mock.patch("click.confirm", side_effect=_confirm_side_effect), mock.patch(
+        "click.prompt", return_value=1
+    ):
+        key, serial_num, slot = taf_keys._setup_yubikey(
+            auth_repo, "root", "root1", key_size=2048
+        )
+
+    assert slot == SLOT.AUTHENTICATION
+    status = yk.get_slot_status(serial=fake_yubikey.serial)[fake_yubikey.serial]
+    assert status[SLOT.AUTHENTICATION] is not None
+    assert (
+        status[SLOT.SIGNATURE].public_key().public_numbers()
+        == fake_yubikey.pub_key.public_numbers()
+    )
+
+
 def test_load_and_verify_yubikey_uses_the_slot_the_user_picked(fake_yubikey, keystore):
     new_key_pem = (keystore / "root2").read_bytes()
     yk.setup(

--- a/taf/tests/tuf/test_keys/test_yubikey_slots.py
+++ b/taf/tests/tuf/test_keys/test_yubikey_slots.py
@@ -414,8 +414,6 @@ def test_signs_correctly_with_each_key_when_multiple_slots_occupied(
         private_key_pem=new_key_pem,
         slot=SLOT.AUTHENTICATION,
     )
-    sig_key = fake_yubikey.tuf_key.public_key
-    auth_key = load_signer_from_file(keystore / "root2").public_key
     taf_repo = create_auth_repo()
 
     result = yk._read_and_check_yubikeys(
@@ -726,17 +724,6 @@ class TestYubiKeyStore:
         store.add_key_data("root1", "111", "pubkey-obj", "root")
 
         assert store.get_roles_of_key("111") == ["root"]
-
-    def test_get_key_data_returns_slot(self):
-        store = YubiKeyStore()
-        store.add_key_data(
-            "root1", "111", "pubkey-obj", "root", slot=SLOT.AUTHENTICATION
-        )
-
-        public_key, serial_num, slot = store.get_key_data("root1")
-        assert public_key == "pubkey-obj"
-        assert serial_num == "111"
-        assert slot == SLOT.AUTHENTICATION
 
     def test_get_roles_of_key_isolates_keys_sharing_one_device(self):
         # two different keys (different slots) on the same physical device,

--- a/taf/tests/tuf/test_keys/test_yubikey_slots.py
+++ b/taf/tests/tuf/test_keys/test_yubikey_slots.py
@@ -515,6 +515,39 @@ def test_read_and_check_single_yubikey_auto_selects_sole_occupied_slot(
     assert serial_num == fake_yubikey.serial
 
 
+def test_read_and_check_single_yubikey_returns_none_when_reusing_empty_device(
+    fake_yubikey, monkeypatch
+):
+    # "reuse an already set up Yubikey" was chosen, but this device has no
+    # key on any slot - there's nothing to reuse. Must fail clearly and
+    # without ever asking for a PIN, instead of proceeding with
+    # public_key=None (which crashed certificate export downstream).
+    monkeypatch.setattr(yk, "get_piv_public_keys_tuf", lambda *a, **k: {})
+
+    def _unexpected_prompt(*args, **kwargs):
+        raise AssertionError("should not ask for a PIN - nothing to reuse")
+
+    with mock.patch("click.prompt", side_effect=_unexpected_prompt), mock.patch(
+        "taf.yubikey.yubikey.get_pin_for", side_effect=_unexpected_prompt
+    ):
+        result = yk._read_and_check_single_yubikey(
+            role="root",
+            key_name="root1",
+            taf_repo=_MinimalTafRepo({}),
+            pin_manager=PinManager(),
+            registering_new_key=True,
+            creating_new_key=False,
+            pin_confirm=False,
+            pin_repeat=False,
+            prompt_message=None,
+            retrying=False,
+            yubikeys_to_skip=None,
+            key_id_pins=None,
+        )
+
+    assert result is None
+
+
 def test_read_and_check_single_yubikey_prompts_when_multiple_slots_occupied(
     fake_yubikey, keystore
 ):
@@ -605,14 +638,9 @@ def test_setup_yubikey_creates_new_key_in_a_free_non_signature_slot(
     monkeypatch.setattr("builtins.input", lambda prompt="": "New signer")
     auth_repo = _MinimalTafRepo({}, pin_manager=_pin_manager(fake_yubikey))
 
-    def _confirm_side_effect(message, *args, **kwargs):
-        # "reuse already set up Yubikey?" -> no, create a new one; every
-        # other confirm (the now-stale delete-everything warning) -> proceed
-        if message == "Do you want to reuse already set up Yubikey?":
-            return False
-        return True
-
-    with mock.patch("click.confirm", side_effect=_confirm_side_effect), mock.patch(
+    with mock.patch(
+        "click.confirm", return_value=False
+    ), mock.patch(  # "reuse already set up Yubikey?" -> no, create a new one
         "click.prompt", return_value=1
     ):
         key, serial_num, slot = taf_keys._setup_yubikey(
@@ -626,6 +654,30 @@ def test_setup_yubikey_creates_new_key_in_a_free_non_signature_slot(
         status[SLOT.SIGNATURE].public_key().public_numbers()
         == fake_yubikey.pub_key.public_numbers()
     )
+
+
+def test_setup_yubikey_updates_store_with_generated_key_for_cert_export(
+    fake_yubikey, monkeypatch, tmp_path
+):
+    # a newly created key is recorded in yubikey_store with public_key=None
+    # (it doesn't exist yet at that point) - _setup_yubikey must refresh
+    # that entry once the key is actually generated, since certs_dir export
+    # relies on get_roles_of_key(serial, key) finding a real public key
+    # there, not crashing or silently keeping the stale None.
+    monkeypatch.setattr("builtins.input", lambda prompt="": "New signer")
+    auth_repo = _MinimalTafRepo({}, pin_manager=_pin_manager(fake_yubikey))
+
+    with mock.patch(
+        "click.confirm", return_value=False
+    ), mock.patch(  # "reuse already set up Yubikey?" -> no, create a new one
+        "click.prompt", return_value=1
+    ):
+        key, serial_num, slot = taf_keys._setup_yubikey(
+            auth_repo, "root", "root1", key_size=2048, certs_dir=str(tmp_path)
+        )
+
+    assert auth_repo.yubikey_store.get_key_data("root1") == (key, serial_num, slot)
+    assert list(tmp_path.glob(f"{key.keyid}.cert"))
 
 
 def test_load_and_verify_yubikey_uses_the_slot_the_user_picked(fake_yubikey, keystore):

--- a/taf/tests/tuf/test_keys/test_yubikey_slots.py
+++ b/taf/tests/tuf/test_keys/test_yubikey_slots.py
@@ -273,6 +273,29 @@ def test_setup_test_yubikey_validates_pin_against_card(
     assert status[SLOT.AUTHENTICATION] is not None
 
 
+def test_setup_test_yubikey_uses_pin_from_environment_variable(
+    fake_yubikey, keystore, monkeypatch
+):
+    # _prepare_setup must go through the same env-var-then-validate PIN
+    # flow used everywhere else a PIN is entered (_resolve_and_cache_pin),
+    # not a partial reimplementation that skips the environment variable.
+    monkeypatch.setenv(f"PIN_{fake_yubikey.serial}", fake_yubikey.pin)
+
+    def _unexpected_prompt(*args, **kwargs):
+        raise AssertionError("should not prompt - PIN available from environment")
+
+    with mock.patch("click.prompt", side_effect=_unexpected_prompt), mock.patch(
+        "taf.yubikey.yubikey.get_pin_for", side_effect=_unexpected_prompt
+    ):
+        new_key_path = keystore / "root2"
+        yk_api.setup_test_yubikey(
+            PinManager(), str(new_key_path), slot="AUTHENTICATION"
+        )
+
+    status = yk.get_slot_status(serial=fake_yubikey.serial)[fake_yubikey.serial]
+    assert status[SLOT.AUTHENTICATION] is not None
+
+
 def test_setup_test_yubikey_refuses_occupied_slot_without_prompting(
     fake_yubikey, keystore
 ):

--- a/taf/tests/tuf/test_keys/test_yubikey_slots.py
+++ b/taf/tests/tuf/test_keys/test_yubikey_slots.py
@@ -1,6 +1,4 @@
 import secrets
-from pathlib import Path
-from typing import Optional
 from unittest import mock
 
 import pytest
@@ -27,24 +25,6 @@ def _pin_manager(fake_yubikey) -> PinManager:
     pin_manager = PinManager()
     pin_manager.add_pin(fake_yubikey.serial, fake_yubikey.pin)
     return pin_manager
-
-
-class _MinimalTafRepo:
-    """Stand-in for the parts of AuthenticationRepository that
-    _read_and_check_yubikeys/_load_and_verify_yubikey need, so this can be
-    tested without building a full repository on disk just to check
-    role/key validity."""
-
-    def __init__(
-        self, key_names_by_keyid: dict, pin_manager: Optional[PinManager] = None
-    ):
-        self.path = Path.cwd()
-        self.yubikey_store = YubiKeyStore()
-        self.keys_name_mappings = dict(key_names_by_keyid)
-        self.pin_manager = pin_manager if pin_manager is not None else PinManager()
-
-    def is_valid_metadata_yubikey(self, role, public_key):
-        return public_key is not None and public_key.keyid in self.keys_name_mappings
 
 
 def test_resolve_slot_rejects_retired_slots():
@@ -338,23 +318,19 @@ def test_sign_piv_rsa_pkcs1v15_uses_given_slot(fake_yubikey, keystore):
 
 
 def test_read_and_check_yubikeys_finds_role_key_in_non_signature_slot(
-    fake_yubikey, keystore
+    keystore, make_fake_yubikey, create_auth_repo
 ):
-    new_key_pem = (keystore / "root2").read_bytes()
-    yk.setup(
-        pin="123456",
-        serial=fake_yubikey.serial,
-        cert_cn="Second key",
-        private_key_pem=new_key_pem,
-        slot=SLOT.AUTHENTICATION,
-    )
+    # SIGNATURE holds "targets"' key - a real key, but not one of root's -
+    # it must be excluded even though it's on the same device as a real
+    # root key (root2) in AUTHENTICATION.
+    device = make_fake_yubikey("targets", extra_slots={SLOT.AUTHENTICATION: "root2"})
     auth_key = load_signer_from_file(keystore / "root2").public_key
-    taf_repo = _MinimalTafRepo({auth_key.keyid: "root2"})
+    taf_repo = create_auth_repo()
 
     result = yk._read_and_check_yubikeys(
         role="root",
         taf_repo=taf_repo,
-        pin_manager=_pin_manager(fake_yubikey),
+        pin_manager=_pin_manager(device),
         pin_confirm=False,
         pin_repeat=False,
         prompt_message=None,
@@ -372,9 +348,10 @@ def test_read_and_check_yubikeys_finds_role_key_in_non_signature_slot(
 
     # the discovered slot must actually be used to sign, not SIGNATURE
     signer = YkSigner(
-        public_key, serial_num, lambda name: "123456", key_name, slot=slot
+        public_key, serial_num, lambda name: device.pin, key_name, slot=slot
     )
     sig = signer.sign(b"hello").signature
+    new_key_pem = (keystore / "root2").read_bytes()
     auth_priv_key = serialization.load_pem_private_key(
         new_key_pem, None, default_backend()
     )
@@ -384,7 +361,7 @@ def test_read_and_check_yubikeys_finds_role_key_in_non_signature_slot(
 
 
 def test_read_and_check_yubikeys_counts_every_valid_key_on_one_device(
-    fake_yubikey, keystore
+    fake_yubikey, keystore, create_auth_repo
 ):
     # one physical device can hold 2 keys valid for the same role (one per
     # slot) - both must count toward that role's threshold, not just the
@@ -399,7 +376,7 @@ def test_read_and_check_yubikeys_counts_every_valid_key_on_one_device(
     )
     sig_key = fake_yubikey.tuf_key.public_key
     auth_key = load_signer_from_file(keystore / "root2").public_key
-    taf_repo = _MinimalTafRepo({sig_key.keyid: "root1", auth_key.keyid: "root2"})
+    taf_repo = create_auth_repo()
 
     result = yk._read_and_check_yubikeys(
         role="root",
@@ -424,7 +401,7 @@ def test_read_and_check_yubikeys_counts_every_valid_key_on_one_device(
 
 
 def test_signs_correctly_with_each_key_when_multiple_slots_occupied(
-    fake_yubikey, keystore
+    fake_yubikey, keystore, create_auth_repo
 ):
     # discovering 2 valid keys on one device is only half the story - each
     # one must actually sign with its own key when used, not get mixed up
@@ -439,7 +416,7 @@ def test_signs_correctly_with_each_key_when_multiple_slots_occupied(
     )
     sig_key = fake_yubikey.tuf_key.public_key
     auth_key = load_signer_from_file(keystore / "root2").public_key
-    taf_repo = _MinimalTafRepo({sig_key.keyid: "root1", auth_key.keyid: "root2"})
+    taf_repo = create_auth_repo()
 
     result = yk._read_and_check_yubikeys(
         role="root",
@@ -487,11 +464,11 @@ def test_signs_correctly_with_each_key_when_multiple_slots_occupied(
 
 
 def test_read_and_check_single_yubikey_auto_selects_sole_occupied_slot(
-    fake_yubikey,
+    fake_yubikey, create_auth_repo
 ):
     # only one slot (SIGNATURE, the fixture's default) is occupied, so there
     # is nothing to disambiguate - no prompt should be shown.
-    taf_repo = _MinimalTafRepo({fake_yubikey.tuf_key.public_key.keyid: "root1"})
+    taf_repo = create_auth_repo()
 
     result = yk._read_and_check_single_yubikey(
         role="root",
@@ -516,7 +493,7 @@ def test_read_and_check_single_yubikey_auto_selects_sole_occupied_slot(
 
 
 def test_read_and_check_single_yubikey_returns_none_when_reusing_empty_device(
-    fake_yubikey, monkeypatch
+    fake_yubikey, monkeypatch, create_auth_repo
 ):
     # "reuse an already set up Yubikey" was chosen, but this device has no
     # key on any slot - there's nothing to reuse. Must fail clearly and
@@ -533,7 +510,7 @@ def test_read_and_check_single_yubikey_returns_none_when_reusing_empty_device(
         result = yk._read_and_check_single_yubikey(
             role="root",
             key_name="root1",
-            taf_repo=_MinimalTafRepo({}),
+            taf_repo=create_auth_repo(),
             pin_manager=PinManager(),
             registering_new_key=True,
             creating_new_key=False,
@@ -549,7 +526,7 @@ def test_read_and_check_single_yubikey_returns_none_when_reusing_empty_device(
 
 
 def test_read_and_check_single_yubikey_prompts_when_multiple_slots_occupied(
-    fake_yubikey, keystore
+    fake_yubikey, keystore, create_auth_repo
 ):
     # more than one key is set up on this device - there's no way to know
     # which one the user means, so they must be asked to pick.
@@ -562,12 +539,7 @@ def test_read_and_check_single_yubikey_prompts_when_multiple_slots_occupied(
         slot=SLOT.AUTHENTICATION,
     )
     auth_key = load_signer_from_file(keystore / "root2").public_key
-    taf_repo = _MinimalTafRepo(
-        {
-            fake_yubikey.tuf_key.public_key.keyid: "root1",
-            auth_key.keyid: "root2",
-        }
-    )
+    taf_repo = create_auth_repo()
 
     # AUTHENTICATION (slot value 154) sorts before SIGNATURE (156), so
     # option 1 is AUTHENTICATION - select it to prove the user's choice
@@ -631,12 +603,12 @@ def test_prompt_for_new_key_slot_raises_when_no_free_slot():
 
 
 def test_setup_yubikey_creates_new_key_in_a_free_non_signature_slot(
-    fake_yubikey, monkeypatch
+    fake_yubikey, monkeypatch, create_auth_repo
 ):
     # SIGNATURE is already occupied by the fixture's default key - creating
     # a new key must land in a different, free slot instead of failing.
     monkeypatch.setattr("builtins.input", lambda prompt="": "New signer")
-    auth_repo = _MinimalTafRepo({}, pin_manager=_pin_manager(fake_yubikey))
+    auth_repo = create_auth_repo(pin_manager=_pin_manager(fake_yubikey))
 
     with mock.patch(
         "click.confirm", return_value=False
@@ -657,7 +629,7 @@ def test_setup_yubikey_creates_new_key_in_a_free_non_signature_slot(
 
 
 def test_setup_yubikey_updates_store_with_generated_key_for_cert_export(
-    fake_yubikey, monkeypatch, tmp_path
+    fake_yubikey, monkeypatch, tmp_path, create_auth_repo
 ):
     # a newly created key is recorded in yubikey_store with public_key=None
     # (it doesn't exist yet at that point) - _setup_yubikey must refresh
@@ -665,7 +637,7 @@ def test_setup_yubikey_updates_store_with_generated_key_for_cert_export(
     # relies on get_roles_of_key(serial, key) finding a real public key
     # there, not crashing or silently keeping the stale None.
     monkeypatch.setattr("builtins.input", lambda prompt="": "New signer")
-    auth_repo = _MinimalTafRepo({}, pin_manager=_pin_manager(fake_yubikey))
+    auth_repo = create_auth_repo(pin_manager=_pin_manager(fake_yubikey))
 
     with mock.patch(
         "click.confirm", return_value=False
@@ -680,7 +652,9 @@ def test_setup_yubikey_updates_store_with_generated_key_for_cert_export(
     assert list(tmp_path.glob(f"{key.keyid}.cert"))
 
 
-def test_load_and_verify_yubikey_uses_the_slot_the_user_picked(fake_yubikey, keystore):
+def test_load_and_verify_yubikey_uses_the_slot_the_user_picked(
+    fake_yubikey, keystore, create_auth_repo
+):
     new_key_pem = (keystore / "root2").read_bytes()
     yk.setup(
         pin="123456",
@@ -690,13 +664,7 @@ def test_load_and_verify_yubikey_uses_the_slot_the_user_picked(fake_yubikey, key
         slot=SLOT.AUTHENTICATION,
     )
     auth_key = load_signer_from_file(keystore / "root2").public_key
-    taf_repo = _MinimalTafRepo(
-        {
-            fake_yubikey.tuf_key.public_key.keyid: "root1",
-            auth_key.keyid: "root2",
-        },
-        pin_manager=_pin_manager(fake_yubikey),
-    )
+    taf_repo = create_auth_repo(pin_manager=_pin_manager(fake_yubikey))
 
     # option 1 is AUTHENTICATION - the correct one for root2
     with mock.patch("click.prompt", return_value=1), mock.patch(
@@ -710,7 +678,7 @@ def test_load_and_verify_yubikey_uses_the_slot_the_user_picked(fake_yubikey, key
 
 
 def test_load_and_verify_yubikey_reports_mismatch_when_wrong_slot_picked(
-    fake_yubikey, keystore
+    fake_yubikey, keystore, create_auth_repo
 ):
     # the caller already knows which key it wants (public_key) - if the
     # user picks a different slot at the prompt, that must be caught as a
@@ -724,13 +692,7 @@ def test_load_and_verify_yubikey_reports_mismatch_when_wrong_slot_picked(
         slot=SLOT.AUTHENTICATION,
     )
     auth_key = load_signer_from_file(keystore / "root2").public_key
-    taf_repo = _MinimalTafRepo(
-        {
-            fake_yubikey.tuf_key.public_key.keyid: "root1",
-            auth_key.keyid: "root2",
-        },
-        pin_manager=_pin_manager(fake_yubikey),
-    )
+    taf_repo = create_auth_repo(pin_manager=_pin_manager(fake_yubikey))
 
     # option 2 is SIGNATURE (the fixture's default key) - the wrong one,
     # since we're looking for root2 (AUTHENTICATION). First confirm is

--- a/taf/tests/tuf/test_keys/test_yubikey_slots.py
+++ b/taf/tests/tuf/test_keys/test_yubikey_slots.py
@@ -1,3 +1,4 @@
+import secrets
 from pathlib import Path
 from unittest import mock
 
@@ -6,13 +7,14 @@ from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
+from ykman.piv import MANAGEMENT_KEY_TYPE, pivman_set_mgm_key
 from yubikit.core import NotSupportedError
-from yubikit.piv import DEFAULT_MANAGEMENT_KEY, SLOT
+from yubikit.piv import SLOT
 
 import taf.api.yubikey as yk_api
 import taf.keys as taf_keys
 import taf.yubikey.yubikey as yk
-from taf.exceptions import YubikeyError
+from taf.exceptions import KeystoreError, YubikeyError
 from taf.tools.yubikey.yubikey_utils import FakePivController
 from taf.tuf.keys import YkSigner, load_signer_from_file
 from taf.yubikey.yubikey_manager import PinManager, YubiKeyStore
@@ -86,43 +88,26 @@ def test_is_slot_occupied_falls_back_to_certificate_on_older_firmware(
     assert yk.is_slot_occupied(fake_yubikey.serial, SLOT.SIGNATURE)
 
 
-def test_setup_reset_randomizes_and_stores_protected_management_key(fake_yubikey):
-    yk.setup(
-        pin="654321",
-        serial=fake_yubikey.serial,
-        cert_cn="Reset key",
-        reset=True,
-    )
-
-    # the management key must no longer be the well-known PIV default...
-    assert fake_yubikey.management_key != DEFAULT_MANAGEMENT_KEY
-    # ...and it must be recoverable with the PIN that was just set
+def test_setup_recovers_stored_management_key(fake_yubikey, keystore):
+    # simulate a card that was previously set up (by another tool, or an
+    # earlier taf version) with a randomized, PIN-protected management key -
+    # setup() must recover it on its own and authenticate successfully with
+    # it, not the PIV default
+    new_mgm_key = secrets.token_bytes(24)
     with yk._yk_piv_ctrl(serial=fake_yubikey.serial) as [(ctrl, _)]:
-        ctrl.verify_pin("654321")
-        assert yk._get_protected_management_key(ctrl) == fake_yubikey.management_key
+        ctrl.verify_pin(fake_yubikey.pin)
+        pivman_set_mgm_key(
+            ctrl, new_mgm_key, MANAGEMENT_KEY_TYPE.TDES, store_on_device=True
+        )
+    assert fake_yubikey.management_key == new_mgm_key
 
-
-def test_setup_non_reset_recovers_stored_management_key(fake_yubikey, keystore):
-    # reset first, choosing a new PIN - this randomizes the management key
-    # and stores it protected by that PIN
-    yk.setup(
-        pin="654321",
-        serial=fake_yubikey.serial,
-        cert_cn="Reset key",
-        reset=True,
-    )
-
-    # a later non-reset call, using the same PIN, must recover the stored
-    # (randomized, no longer default) management key on its own and
-    # authenticate successfully with it - not the PIV default
     new_key_pem = (keystore / "root2").read_bytes()
     yk.setup(
-        pin="654321",
+        pin=fake_yubikey.pin,
         serial=fake_yubikey.serial,
         cert_cn="Second key",
         private_key_pem=new_key_pem,
         slot=SLOT.AUTHENTICATION,
-        reset=False,
     )
 
     status = yk.get_slot_status(serial=fake_yubikey.serial)[fake_yubikey.serial]
@@ -168,110 +153,139 @@ def test_setup_into_free_slot_does_not_touch_existing_key(fake_yubikey, keystore
     )
 
 
-def test_setup_refuses_to_overwrite_occupied_slot_without_force(fake_yubikey):
+def test_setup_refuses_to_overwrite_occupied_slot(fake_yubikey):
     with pytest.raises(YubikeyError):
         yk.setup(
             pin="123456",
             serial=fake_yubikey.serial,
             cert_cn="Should not be written",
             slot=SLOT.SIGNATURE,
-            reset=False,
         )
 
-
-def test_setup_overwrites_occupied_slot_with_force(fake_yubikey, keystore):
-    new_key_pem = (keystore / "root2").read_bytes()
-
-    yk.setup(
-        pin="123456",
-        serial=fake_yubikey.serial,
-        cert_cn="Replacement key",
-        private_key_pem=new_key_pem,
-        slot=SLOT.SIGNATURE,
-        reset=False,
-        force=True,
-    )
-
+    # the original key must be untouched
     status = yk.get_slot_status(serial=fake_yubikey.serial)[fake_yubikey.serial]
-    new_cert = status[SLOT.SIGNATURE]
     assert (
-        new_cert.public_key().public_numbers() != fake_yubikey.pub_key.public_numbers()
-    )
-
-
-def test_setup_signing_yubikey_can_write_signature_slot_without_resetting(
-    fake_yubikey, monkeypatch
-):
-    monkeypatch.setattr(yk_api.click, "confirm", lambda *args, **kwargs: True)
-    monkeypatch.setattr(yk, "export_yk_certificate", lambda *args, **kwargs: None)
-    monkeypatch.setattr("builtins.input", lambda prompt="": "New signer")
-
-    # SIGNATURE is already occupied by the fixture's default key, so
-    # force=True is required, exactly like any other non-reset overwrite.
-    yk_api.setup_signing_yubikey(
-        _pin_manager(fake_yubikey),
-        key_size=2048,
-        slot="SIGNATURE",
-        reset=False,
-        force=True,
-    )
-
-    status = yk.get_slot_status(serial=fake_yubikey.serial)[fake_yubikey.serial]
-    new_cert = status[SLOT.SIGNATURE]
-    assert (
-        new_cert.public_key().public_numbers() != fake_yubikey.pub_key.public_numbers()
-    )
-
-
-def test_setup_test_yubikey_declining_occupied_slot_confirmation_leaves_key_untouched(
-    fake_yubikey, monkeypatch, keystore
-):
-    monkeypatch.setattr(yk_api.click, "confirm", lambda *args, **kwargs: False)
-
-    new_key_path = keystore / "root2"
-
-    yk_api.setup_test_yubikey(_pin_manager(fake_yubikey), str(new_key_path))
-
-    status = yk.get_slot_status(serial=fake_yubikey.serial)[fake_yubikey.serial]
-    original_cert = status[SLOT.SIGNATURE]
-    assert (
-        original_cert.public_key().public_numbers()
+        status[SLOT.SIGNATURE].public_key().public_numbers()
         == fake_yubikey.pub_key.public_numbers()
     )
 
 
-def test_setup_test_yubikey_force_skips_occupied_slot_confirmation(
+def test_setup_refuses_occupied_slot_without_verifying_pin(fake_yubikey, monkeypatch):
+    # checking slot occupancy is an unauthenticated PIV read - an occupied
+    # slot must be refused before the PIN is ever verified, so a doomed
+    # attempt doesn't burn one of the card's limited PIN retries.
+    # raise_yubikey_err would wrap *any* unexpected exception (including one
+    # raised by this mock) into a YubikeyError too, so match on the expected
+    # message specifically rather than just the exception type - otherwise
+    # this would pass even if verify_pin actually got called.
+    def _unexpected_verify_pin(self, pin):
+        raise AssertionError("should not verify the PIN for an occupied slot")
+
+    monkeypatch.setattr(FakePivController, "verify_pin", _unexpected_verify_pin)
+
+    with pytest.raises(YubikeyError, match="already has a key"):
+        yk.setup(
+            pin="123456",
+            serial=fake_yubikey.serial,
+            cert_cn="Should not be written",
+            slot=SLOT.SIGNATURE,
+        )
+
+
+def test_setup_signing_yubikey_refuses_occupied_slot_without_prompting(
+    fake_yubikey, monkeypatch
+):
+    # SIGNATURE is already occupied by the fixture's default key - taf must
+    # refuse outright. There's no overwrite/reset flow to confirm anymore,
+    # so click.confirm must never even be called.
+    def _unexpected_confirm(*args, **kwargs):
+        raise AssertionError("should not prompt to overwrite an occupied slot")
+
+    monkeypatch.setattr("builtins.input", lambda prompt="": "")
+
+    with mock.patch("click.confirm", side_effect=_unexpected_confirm):
+        with pytest.raises(YubikeyError):
+            yk_api.setup_signing_yubikey(
+                _pin_manager(fake_yubikey),
+                key_size=2048,
+                slot="SIGNATURE",
+            )
+
+    status = yk.get_slot_status(serial=fake_yubikey.serial)[fake_yubikey.serial]
+    assert (
+        status[SLOT.SIGNATURE].public_key().public_numbers()
+        == fake_yubikey.pub_key.public_numbers()
+    )
+
+
+def test_setup_test_yubikey_refuses_occupied_slot_without_prompting_for_pin(
+    fake_yubikey, keystore, monkeypatch
+):
+    # an empty PinManager means _prepare_setup would have to prompt for a
+    # PIN via get_and_validate_pin if it got that far - it must not, since
+    # checking slot occupancy needs no PIN at all (an unauthenticated PIV
+    # read).
+    def _unexpected_get_and_validate_pin(*args, **kwargs):
+        raise AssertionError("should not prompt for a PIN for an occupied slot")
+
+    monkeypatch.setattr(yk, "get_and_validate_pin", _unexpected_get_and_validate_pin)
+
+    new_key_path = keystore / "root2"
+    with pytest.raises(YubikeyError, match="already has a key"):
+        yk_api.setup_test_yubikey(PinManager(), str(new_key_path))
+
+
+def test_setup_test_yubikey_missing_key_file_raises_keystore_error(
+    fake_yubikey, monkeypatch
+):
+    # a bad key path is a plain file error, not a YubiKey problem - and it
+    # must be caught before ever resolving a device/prompting for a PIN.
+    def _unexpected_get_and_validate_pin(*args, **kwargs):
+        raise AssertionError("should not prompt for a PIN for a missing key file")
+
+    monkeypatch.setattr(yk, "get_and_validate_pin", _unexpected_get_and_validate_pin)
+
+    with pytest.raises(KeystoreError, match="does not exist"):
+        yk_api.setup_test_yubikey(PinManager(), "/no/such/key/file")
+
+
+def test_setup_test_yubikey_validates_pin_against_card(
+    fake_yubikey, keystore, monkeypatch
+):
+    # the PIN entered here is always the card's existing PIN (taf never sets
+    # a new one) - a wrong entry must be caught and retried against the
+    # card itself, not silently accepted like a "choose a new secret"
+    # confirm-by-retyping prompt would.
+    wrong_then_right_pins = iter(["000000", fake_yubikey.pin])
+    monkeypatch.setattr(yk, "get_pin_for", lambda *a, **k: next(wrong_then_right_pins))
+
+    new_key_path = keystore / "root2"
+    with mock.patch("click.confirm", return_value=True) as confirm:
+        yk_api.setup_test_yubikey(
+            PinManager(), str(new_key_path), slot="AUTHENTICATION"
+        )
+    confirm.assert_called_once()
+
+    status = yk.get_slot_status(serial=fake_yubikey.serial)[fake_yubikey.serial]
+    assert status[SLOT.AUTHENTICATION] is not None
+
+
+def test_setup_test_yubikey_refuses_occupied_slot_without_prompting(
     fake_yubikey, keystore
 ):
-    # force=True on an already-occupied slot must succeed without any
-    # interactive confirmation, so click.confirm is deliberately left
-    # unmocked here.
-    new_key_path = keystore / "root2"
-
-    yk_api.setup_test_yubikey(_pin_manager(fake_yubikey), str(new_key_path), force=True)
-
-    status = yk.get_slot_status(serial=fake_yubikey.serial)[fake_yubikey.serial]
-    new_cert = status[SLOT.SIGNATURE]
-    assert (
-        new_cert.public_key().public_numbers() != fake_yubikey.pub_key.public_numbers()
-    )
-
-
-def test_setup_test_yubikey_explicit_reset_wipes_other_slots(
-    fake_yubikey, monkeypatch, keystore
-):
-    monkeypatch.setattr(yk_api.click, "confirm", lambda *args, **kwargs: True)
+    def _unexpected_confirm(*args, **kwargs):
+        raise AssertionError("should not prompt to overwrite an occupied slot")
 
     new_key_path = keystore / "root2"
-
-    yk_api.setup_test_yubikey(PinManager(), str(new_key_path), reset=True)
+    with mock.patch("click.confirm", side_effect=_unexpected_confirm):
+        with pytest.raises(YubikeyError):
+            yk_api.setup_test_yubikey(_pin_manager(fake_yubikey), str(new_key_path))
 
     status = yk.get_slot_status(serial=fake_yubikey.serial)[fake_yubikey.serial]
-    new_cert = status[SLOT.SIGNATURE]
     assert (
-        new_cert.public_key().public_numbers() != fake_yubikey.pub_key.public_numbers()
+        status[SLOT.SIGNATURE].public_key().public_numbers()
+        == fake_yubikey.pub_key.public_numbers()
     )
-    assert status[SLOT.AUTHENTICATION] is None
 
 
 def test_sign_piv_rsa_pkcs1v15_uses_given_slot(fake_yubikey, keystore):
@@ -381,6 +395,69 @@ def test_read_and_check_yubikeys_counts_every_valid_key_on_one_device(
         (sig_key.keyid, SLOT.SIGNATURE),
         (auth_key.keyid, SLOT.AUTHENTICATION),
     }
+
+
+def test_signs_correctly_with_each_key_when_multiple_slots_occupied(
+    fake_yubikey, keystore
+):
+    # discovering 2 valid keys on one device is only half the story - each
+    # one must actually sign with its own key when used, not get mixed up
+    # with the other slot's key on the same physical device.
+    new_key_pem = (keystore / "root2").read_bytes()
+    yk.setup(
+        pin="123456",
+        serial=fake_yubikey.serial,
+        cert_cn="Second key",
+        private_key_pem=new_key_pem,
+        slot=SLOT.AUTHENTICATION,
+    )
+    sig_key = fake_yubikey.tuf_key.public_key
+    auth_key = load_signer_from_file(keystore / "root2").public_key
+    taf_repo = _MinimalTafRepo({sig_key.keyid: "root1", auth_key.keyid: "root2"})
+
+    result = yk._read_and_check_yubikeys(
+        role="root",
+        taf_repo=taf_repo,
+        pin_manager=_pin_manager(fake_yubikey),
+        pin_confirm=False,
+        pin_repeat=False,
+        prompt_message=None,
+        key_names=["root1", "root2"],
+        retrying=False,
+        hide_already_loaded_message=True,
+        hide_threshold_message=True,
+        key_id_pins=None,
+    )
+    assert len(result) == 2
+
+    auth_priv_key = serialization.load_pem_private_key(
+        new_key_pem, None, default_backend()
+    )
+    payload = b"shared payload signed by both keys"
+    signed_slots = set()
+    for public_key, serial_num, key_name, slot in result:
+        signer = YkSigner(
+            public_key, serial_num, lambda name: "123456", key_name, slot=slot
+        )
+        sig = bytes.fromhex(signer.sign(payload).signature)
+
+        correct_key = (
+            fake_yubikey.pub_key
+            if slot == SLOT.SIGNATURE
+            else auth_priv_key.public_key()
+        )
+        wrong_key = (
+            auth_priv_key.public_key()
+            if slot == SLOT.SIGNATURE
+            else fake_yubikey.pub_key
+        )
+
+        correct_key.verify(sig, payload, padding.PKCS1v15(), hashes.SHA256())
+        with pytest.raises(InvalidSignature):
+            wrong_key.verify(sig, payload, padding.PKCS1v15(), hashes.SHA256())
+        signed_slots.add(slot)
+
+    assert signed_slots == {SLOT.SIGNATURE, SLOT.AUTHENTICATION}
 
 
 def test_read_and_check_single_yubikey_auto_selects_sole_occupied_slot(

--- a/taf/tools/yubikey/__init__.py
+++ b/taf/tools/yubikey/__init__.py
@@ -8,7 +8,7 @@ from taf.api.yubikey import (
     setup_signing_yubikey,
     setup_test_yubikey,
 )
-from taf.exceptions import YubikeyError
+from taf.exceptions import KeystoreError, YubikeyError
 from taf.repository_utils import find_valid_repository
 from taf.tools.cli import catch_cli_exception
 from taf.tools.repo import pin_managed
@@ -127,7 +127,8 @@ def setup_signing_key_command():
     @click.command(
         help="""Generate a new key on the yubikey and copy it to the given PIV slot.
         Export the generated certificate to the specified directory.
-        WARNING - --reset will factory-reset the card, deleting everything on it first."""
+        Refuses to touch a slot that already has a key in it - reset the
+        YubiKey's PIV application outside of taf first if you need to redo it."""
     )
     @click.option(
         "--certs-dir",
@@ -139,24 +140,10 @@ def setup_signing_key_command():
         default="SIGNATURE",
         help="PIV slot to set the key up in. Defaults to SIGNATURE.",
     )
-    @click.option(
-        "--force",
-        is_flag=True,
-        default=False,
-        help="Overwrite the target slot if it's already occupied. Has no effect if "
-        "resetting, since that always leaves every slot empty regardless",
-    )
-    @click.option(
-        "--reset/--no-reset",
-        default=False,
-        help="Whether to factory-reset the card first. Defaults to False.",
-    )
     @catch_cli_exception(handle=YubikeyError)
     @pin_managed
-    def setup_signing_key(certs_dir, slot, force, reset, pin_manager):
-        setup_signing_yubikey(
-            pin_manager, certs_dir, key_size=2048, slot=slot, force=force, reset=reset
-        )
+    def setup_signing_key(certs_dir, slot, pin_manager):
+        setup_signing_yubikey(pin_manager, certs_dir, key_size=2048, slot=slot)
 
     return setup_signing_key
 
@@ -164,7 +151,8 @@ def setup_signing_key_command():
 def setup_test_key_command():
     @click.command(
         help="""Copies the specified key onto the given PIV slot of the inserted YubiKey.
-        WARNING - --reset will factory-reset the card, deleting everything on it first."""
+        Refuses to touch a slot that already has a key in it - reset the
+        YubiKey's PIV application outside of taf first if you need to redo it."""
     )
     @click.argument("key-path")
     @click.option(
@@ -173,22 +161,10 @@ def setup_test_key_command():
         default="SIGNATURE",
         help="PIV slot to copy the key into. Defaults to SIGNATURE.",
     )
-    @click.option(
-        "--force",
-        is_flag=True,
-        default=False,
-        help="Overwrite the target slot if it's already occupied. Has no effect if "
-        "resetting, since that always leaves every slot empty regardless",
-    )
-    @click.option(
-        "--reset/--no-reset",
-        default=False,
-        help="Whether to factory-reset the card first. Defaults to False.",
-    )
-    @catch_cli_exception(handle=YubikeyError)
+    @catch_cli_exception(handle=(YubikeyError, KeystoreError))
     @pin_managed
-    def setup_test_key(key_path, slot, force, reset, pin_manager):
-        setup_test_yubikey(pin_manager, key_path, slot=slot, force=force, reset=reset)
+    def setup_test_key(key_path, slot, pin_manager):
+        setup_test_yubikey(pin_manager, key_path, slot=slot)
 
     return setup_test_key
 

--- a/taf/tools/yubikey/yubikey_utils.py
+++ b/taf/tools/yubikey/yubikey_utils.py
@@ -44,6 +44,7 @@ class FakeYubiKey:
         self.data_objects: dict = {}
         self.pin_verified = False
         self.management_key = DEFAULT_MANAGEMENT_KEY
+        self.pin_attempts_remaining = 3
 
     @property
     def driver(self):
@@ -139,8 +140,8 @@ class FakePivController:
     def generate_self_signed_certificate(self, *args, **kwargs):
         pass
 
-    def get_pin_tries(self):
-        return 1
+    def get_pin_attempts(self):
+        return self._driver.pin_attempts_remaining
 
     def put_key(self, slot, private_key, pin_policy=None, touch_policy=None):
         self._slots[slot] = {
@@ -172,6 +173,7 @@ class FakePivController:
         self._driver.pin_verified = False
         self._driver.management_key = DEFAULT_MANAGEMENT_KEY
         self._driver.pin = VALID_PIN
+        self._driver.pin_attempts_remaining = 3
 
     def get_object(self, object_id):
         if (
@@ -209,7 +211,9 @@ class FakePivController:
 
     def verify_pin(self, pin):
         if self._driver.pin != pin:
+            self._driver.pin_attempts_remaining -= 1
             raise InvalidPinError(0)
+        self._driver.pin_attempts_remaining = 3
         self._driver.pin_verified = True
 
 

--- a/taf/tools/yubikey/yubikey_utils.py
+++ b/taf/tools/yubikey/yubikey_utils.py
@@ -13,7 +13,8 @@ from yubikit.piv import DEFAULT_MANAGEMENT_KEY, SLOT, InvalidPinError
 VALID_PIN = "123456"
 WRONG_PIN = "111111"
 
-INSERTED_YUBIKEY = None
+# serial -> FakeYubiKey, supports multiple inserted at once
+INSERTED_YUBIKEYS: dict = {}
 
 
 class FakeYubiKey:
@@ -64,19 +65,16 @@ class FakeYubiKey:
 
     def insert(self):
         """Insert YubiKey in USB slot."""
-        global INSERTED_YUBIKEY
-        INSERTED_YUBIKEY = self
+        INSERTED_YUBIKEYS[self.serial] = self
 
     def is_inserted(self):
         """Check if YubiKey is in USB slot."""
-        global INSERTED_YUBIKEY
-        return INSERTED_YUBIKEY is self
+        return INSERTED_YUBIKEYS.get(self.serial) is self
 
     def remove(self):
         """Removes YubiKey from USB slot."""
-        global INSERTED_YUBIKEY
-        if INSERTED_YUBIKEY is self:
-            INSERTED_YUBIKEY = None
+        if INSERTED_YUBIKEYS.get(self.serial) is self:
+            del INSERTED_YUBIKEYS[self.serial]
 
 
 class FakePivController:
@@ -241,9 +239,16 @@ class Root3YubiKey(FakeYubiKey):
 
 @contextmanager
 def _yk_piv_ctrl_mock(serial=None):
-    global INSERTED_YUBIKEY
-
-    if INSERTED_YUBIKEY is None:
+    if not INSERTED_YUBIKEYS:
         raise ValueError("No YubiKey found with the given interface(s)")
 
-    yield [(FakePivController(INSERTED_YUBIKEY), INSERTED_YUBIKEY.serial)]
+    if serial is not None:
+        driver = INSERTED_YUBIKEYS.get(serial)
+        if driver is None:
+            raise ValueError("No YubiKey found with the given interface(s)")
+        yield [(FakePivController(driver), driver.serial)]
+    else:
+        yield [
+            (FakePivController(driver), driver.serial)
+            for driver in INSERTED_YUBIKEYS.values()
+        ]

--- a/taf/tuf/keys.py
+++ b/taf/tuf/keys.py
@@ -217,12 +217,17 @@ class YkSigner(Signer):
         serial_num: str,
         pin_handler: SecretsHandler,
         key_name: str,
+        slot=None,
     ):
 
         self._public_key = public_key
         self._pin_handler = pin_handler
         self._serial_num = serial_num
         self._key_name = key_name
+        # the PIV slot holding this key; None defaults to SLOT.SIGNATURE in
+        # sign() - kept untyped here so this module stays importable without
+        # yubikey-manager installed (an optional extra)
+        self._slot = slot
 
     @property
     def public_key(self) -> SSlibKey:
@@ -236,6 +241,10 @@ class YkSigner(Signer):
     def key_name(self) -> str:
         return self._key_name
 
+    @property
+    def slot(self):
+        return self._slot
+
     @classmethod
     def import_(cls) -> SSlibKey:
         """Import rsa public key from Yubikey.
@@ -246,6 +255,10 @@ class YkSigner(Signer):
         TODO: Consider returning priv key uri along with public key.
         See e.g. `self.from_priv_key_uri` and other `import_` methods on
         securesystemslib signers, e.g. `HSMSigner.import_`.
+
+        TODO: only checks SLOT.SIGNATURE, same as export_piv_pub_key -
+        test-only helper per the comment below, so not extended to other
+        slots for now.
         """
         # if multiple keys are inserted, we need to know from which key should be imported
         # TODO
@@ -261,9 +274,11 @@ class YkSigner(Signer):
     def sign(self, payload: bytes) -> Signature:
         pin = self._pin_handler(self._SECRET_PROMPT)
         from taf.yubikey.yubikey import sign_piv_rsa_pkcs1v15, verify_yk_inserted
+        from yubikit.piv import SLOT
 
         verify_yk_inserted(self.serial_num, self.key_name)
-        sig = sign_piv_rsa_pkcs1v15(payload, pin, serial=self.serial_num)
+        slot = self._slot if self._slot is not None else SLOT.SIGNATURE
+        sig = sign_piv_rsa_pkcs1v15(payload, pin, serial=self.serial_num, slot=slot)
         return Signature(self.public_key.keyid, sig.hex())
 
     @classmethod

--- a/taf/yubikey/yubikey.py
+++ b/taf/yubikey/yubikey.py
@@ -26,9 +26,7 @@ from ykman.piv import (
     MANAGEMENT_KEY_TYPE,
     SLOT,
     PivSession,
-    generate_random_management_key,
     get_pivman_protected_data,
-    pivman_set_mgm_key,
 )
 from yubikit.piv import (
     DEFAULT_MANAGEMENT_KEY,
@@ -44,8 +42,6 @@ from taf.log import taf_logger
 
 from securesystemslib.signer._key import SSlibKey
 
-DEFAULT_PIN = "123456"
-DEFAULT_PUK = "12345678"
 EXPIRATION_INTERVAL = 36500
 
 
@@ -449,10 +445,7 @@ def _resolve_and_cache_pin(
     taf_logger.debug("Attempting to load key pin from environment variables")
     pin = get_pin_from_env(public_key, serial_num, taf_dir)
     if creating_new_key:
-        # A new key is being provisioned: the entered PIN becomes the new
-        # PIN written to the freshly reset YubiKey. It must not be validated
-        # against the card's current PIN, since doing so would fail on every
-        # attempt and eventually lock the key.
+        # skips validation against the card, unlike get_and_validate_pin below
         if pin is None:
             pin = get_pin_for(key_name, pin_confirm, pin_repeat)
     elif pin is None:
@@ -636,12 +629,9 @@ def _read_and_check_yubikeys(
     for index, serial_num in enumerate(serials):
         if not taf_repo.yubikey_store.is_loaded_for_role(serial_num, role):
             all_loaded = False
-            # a role's key can live in any occupied PIV slot, not just
-            # SIGNATURE, and a single device can hold more than one key
-            # valid for this role (each in its own slot) - every one of
-            # them counts toward the threshold, so collect them all instead
-            # of stopping at the first match. SIGNATURE is checked first to
-            # keep today's behavior when that's the only one present.
+            # a device can hold more than one key valid for this role (one
+            # per slot) - collect them all instead of stopping at the first
+            # match. SIGNATURE is checked first to match prior behavior.
             device_keys = get_piv_public_keys_tuf(serial=serial_num).get(serial_num, {})
             ordered_slots = [SLOT.SIGNATURE] + [
                 s for s in device_keys if s != SLOT.SIGNATURE
@@ -725,10 +715,8 @@ def sign_piv_rsa_pkcs1v15(data, pin, serial=None, slot=SLOT.SIGNATURE):
 
 def _get_protected_management_key(ctrl):
     """Return the management key stored in the card's PIN-protected data
-    object - a general-purpose PIV data object, unrelated to the 4 signing
-    slots taf uses - or None if it was never stored there (e.g. a card set
-    up by an older version of taf). Requires the PIN to already be verified
-    on this session.
+    object, or None if it was never stored there. Requires the PIN to
+    already be verified on this session.
     """
     try:
         key = get_pivman_protected_data(ctrl).key
@@ -742,13 +730,9 @@ def _get_protected_management_key(ctrl):
 def _slot_occupied(ctrl, slot) -> bool:
     """Check whether a PIV slot already has a key in it.
 
-    A slot's key and certificate are separate objects, so checking only for
-    a certificate would miss a key left behind without one (e.g. an
-    interrupted setup(), or a slot provisioned by another tool). Prefer
-    get_slot_metadata, which reflects the key directly, and fall back to
-    checking for a certificate on firmware that doesn't support it (requires
-    5.3+; older devices like the YubiKey 4 can't detect a key without a
-    certificate this way).
+    Prefers get_slot_metadata, which detects a key even without a
+    certificate (e.g. an interrupted setup()), falling back to
+    get_certificate on firmware older than 5.3 that doesn't support it.
     """
     try:
         ctrl.get_slot_metadata(slot)
@@ -762,16 +746,6 @@ def _slot_occupied(ctrl, slot) -> bool:
         return True
     except Exception:
         return False
-
-
-def _store_protected_management_key(ctrl, mgm_key):
-    """Set a new management key and store it in the card's PIN-protected
-    data object, so it can be recovered later with the PIN alone instead of
-    needing to be remembered separately. Requires the PIN to already be
-    verified on this session.
-    """
-    pivman_set_mgm_key(ctrl, mgm_key, MANAGEMENT_KEY_TYPE.TDES, store_on_device=True)
-    taf_logger.debug("Stored new management key in protected data object.")
 
 
 def get_slot_status(serial=None) -> dict:
@@ -817,54 +791,26 @@ def setup(
     serial,
     cert_cn,
     cert_exp_days=365,
-    pin_retries=10,
     private_key_pem=None,
-    mgm_key=None,
     key_size=2048,
     slot=SLOT.SIGNATURE,
-    reset=None,
     management_key=None,
-    force=False,
 ):
-    """Set up a key in a PIV slot of the inserted YubiKey.
-
-    When resetting, the following steps are performed, in order:
-      - reset to factory settings
-      - authenticate with the default management key
-      - generate a random management key (unless mgm_key is given) and store
-        it in the card's PIN-protected data object, so it can be recovered
-        with the PIN alone on a later non-reset call
-      - generate key(RSA) or import given one
-      - generate and import self-signed certificate(X509)
-      - set pin retries
-      - set pin
-      - set puk(same as pin)
-
-    When not resetting, only the given slot is touched: authenticate with
-    the card's management key (the stored, PIN-protected one if available,
-    otherwise the PIV default - covering cards reset before this scheme
-    existed - unless management_key is explicitly given), generate/import
-    the key and its certificate into the chosen slot, and leave every other
-    slot and the PUK untouched. Refuses to overwrite an already-occupied
-    slot unless force=True.
+    """Generate or import a key (and self-signed certificate) into a single
+    PIV slot of the inserted YubiKey. Every other slot, and the PIN/PUK, are
+    left untouched. Raises if the target slot is already occupied - taf
+    never resets or overwrites a card.
 
     Args:
         - cert_cn(str): x509 common name
         - cert_exp_days(int): x509 expiration (in days from now)
-        - pin_retries(int): Number of retries for PIN. Only used when resetting.
         - private_key_pem(str): Private key in PEM format. If given, it will be
                                 imported to Yubikey.
-        - mgm_key(bytes): Management key to set instead of generating a random
-                          one. Only used when resetting.
         - slot(SLOT): The PIV slot to write the key and certificate to.
                       Defaults to SLOT.SIGNATURE.
-        - reset(bool): Whether to factory-reset the card first. Defaults to
-                       False.
         - management_key(bytes): The card's current management key, used to
-                                 authenticate when reset=False instead of
-                                 looking up the stored, PIN-protected one.
-        - force(bool): When reset=False, whether to overwrite the target
-                       slot if it's already occupied.
+                                 authenticate instead of looking up the
+                                 stored, PIN-protected one.
 
     Returns:
         PIV public key in PEM format (bytes)
@@ -872,41 +818,30 @@ def setup(
     Raises:
         - YubikeyError
     """
-    if reset is None:
-        reset = False
-
     taf_logger.debug(
         f"Initializing YubiKey setup for serial={serial}, key_size={key_size}, "
-        f"cert_cn='{cert_cn}', slot={slot}, reset={reset}"
+        f"cert_cn='{cert_cn}', slot={slot}"
     )
     with _yk_piv_ctrl(serial=serial) as [(ctrl, _)]:
-        if reset:
-            taf_logger.debug(
-                f"Resetting YubiKey to factory settings for serial={serial}"
+        # checking slot occupancy is an unauthenticated PIV read - do it
+        # before verifying the PIN or authenticating with the management
+        # key, so an occupied slot fails fast without spending a PIN retry
+        # attempt on an operation that's going to be refused anyway
+        if _slot_occupied(ctrl, slot):
+            raise YubikeyError(
+                f"Slot {slot.name} already has a key. taf will not overwrite "
+                "or reset it - reset the YubiKey's PIV application outside of "
+                "taf and try again."
             )
-            ctrl.reset()
 
-            taf_logger.debug("Authenticating with the default management key...")
-            ctrl.authenticate(MANAGEMENT_KEY_TYPE.TDES, DEFAULT_MANAGEMENT_KEY)
-            # PIN is still the factory default at this point (changed further
-            # below), and is required to store the management key protected
-            ctrl.verify_pin(DEFAULT_PIN)
-            if mgm_key is None:
-                mgm_key = generate_random_management_key(MANAGEMENT_KEY_TYPE.TDES)
-            _store_protected_management_key(ctrl, mgm_key)
+        if management_key is not None:
+            ctrl.authenticate(MANAGEMENT_KEY_TYPE.TDES, management_key)
         else:
-            if management_key is not None:
-                ctrl.authenticate(MANAGEMENT_KEY_TYPE.TDES, management_key)
-            else:
-                ctrl.verify_pin(pin)
-                stored_key = _get_protected_management_key(ctrl)
-                ctrl.authenticate(
-                    MANAGEMENT_KEY_TYPE.TDES, stored_key or DEFAULT_MANAGEMENT_KEY
-                )
-            if not force and _slot_occupied(ctrl, slot):
-                raise YubikeyError(
-                    f"Slot {slot.name} already has a key. Pass force=True to overwrite it."
-                )
+            ctrl.verify_pin(pin)
+            stored_key = _get_protected_management_key(ctrl)
+            ctrl.authenticate(
+                MANAGEMENT_KEY_TYPE.TDES, stored_key or DEFAULT_MANAGEMENT_KEY
+            )
 
         if private_key_pem is None:
             taf_logger.debug("Generating RSA private key on the fly...")
@@ -930,10 +865,6 @@ def setup(
         ctrl.put_key(slot, private_key, PIN_POLICY.ALWAYS)
         pub_key = private_key.public_key()
 
-        if reset:
-            ctrl.authenticate(MANAGEMENT_KEY_TYPE.TDES, mgm_key)
-            ctrl.verify_pin(DEFAULT_PIN)
-
         now = datetime.datetime.now()
         valid_to = now + datetime.timedelta(days=cert_exp_days)
 
@@ -952,12 +883,6 @@ def setup(
 
         ctrl.put_certificate(slot, cert)
 
-        if reset:
-            taf_logger.debug("Setting PIN attempts and changing default PIN/PUK...")
-            ctrl.set_pin_attempts(pin_attempts=pin_retries, puk_attempts=pin_retries)
-            ctrl.change_pin(DEFAULT_PIN, pin)
-            ctrl.change_puk(DEFAULT_PUK, pin)
-
     taf_logger.debug("YubiKey setup complete.")
     return pub_key.public_bytes(
         serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
@@ -970,12 +895,10 @@ def setup_new_yubikey(
     scheme: Optional[str] = DEFAULT_RSA_SIGNATURE_SCHEME,
     key_size: Optional[int] = 2048,
     slot=SLOT.SIGNATURE,
-    force: bool = False,
-    reset: Optional[bool] = None,
 ) -> SSlibKey:
     taf_logger.debug(
         f"Starting new YubiKey setup for serial={serial}, scheme={scheme}, "
-        f"key_size={key_size}, slot={slot}, reset={reset}"
+        f"key_size={key_size}, slot={slot}"
     )
     pin = pin_manager.get_pin(serial)
     cert_cn = input("Enter key holder's name: ")
@@ -987,8 +910,6 @@ def setup_new_yubikey(
         cert_exp_days=EXPIRATION_INTERVAL,
         key_size=key_size,
         slot=slot,
-        force=force,
-        reset=reset,
     ).decode("utf-8")
     scheme = DEFAULT_RSA_SIGNATURE_SCHEME
     key = get_sslib_key_from_value(pub_key_pem, scheme)

--- a/taf/yubikey/yubikey.py
+++ b/taf/yubikey/yubikey.py
@@ -431,6 +431,42 @@ def list_connected_yubikeys():
             print(f"  Form Factor: {info.form_factor}")
 
 
+def _resolve_and_cache_pin(
+    pin_manager,
+    serial_num,
+    public_key,
+    taf_dir,
+    key_name,
+    pin_confirm,
+    pin_repeat,
+    key_id_pins,
+    creating_new_key=False,
+):
+    """Resolve a YubiKey's PIN (environment variable, then interactive
+    prompt/validation) and cache it in pin_manager, unless already cached."""
+    if pin_manager.get_pin(serial_num) is not None:
+        return
+    taf_logger.debug("Attempting to load key pin from environment variables")
+    pin = get_pin_from_env(public_key, serial_num, taf_dir)
+    if creating_new_key:
+        # A new key is being provisioned: the entered PIN becomes the new
+        # PIN written to the freshly reset YubiKey. It must not be validated
+        # against the card's current PIN, since doing so would fail on every
+        # attempt and eventually lock the key.
+        if pin is None:
+            pin = get_pin_for(key_name, pin_confirm, pin_repeat)
+    elif pin is None:
+        pin = get_and_validate_pin(
+            key_name,
+            pin_confirm,
+            pin_repeat,
+            serial_num,
+            key_id_pins=key_id_pins,
+            public_key=public_key,
+        )
+    pin_manager.add_pin(serial_num, pin)
+
+
 def _read_and_check_single_yubikey(
     role,
     key_name,
@@ -503,30 +539,19 @@ def _read_and_check_single_yubikey(
             taf_logger.debug(f"Public key not valid for role='{role}'.")
             return None
 
-    pin = None
-    if pin_manager.get_pin(serial_num) is None:
-        taf_logger.debug("Attempting to load key pin from environment variables")
-        lookup_path = taf_repo.path if taf_repo is not None else Path.cwd()
-        taf_dir = find_taf_directory(lookup_path)
-        pin = get_pin_from_env(public_key, serial_num, taf_dir)
-
-        if creating_new_key:
-            # A new key is being provisioned: the entered PIN becomes the new
-            # PIN written to the freshly reset YubiKey. It must not be validated
-            # against the card's current PIN, since doing so would fail on every
-            # attempt and eventually lock the key.
-            if pin is None:
-                pin = get_pin_for(key_name, pin_confirm, pin_repeat)
-        elif pin is None:
-            pin = get_and_validate_pin(
-                key_name,
-                pin_confirm,
-                pin_repeat,
-                serial_num,
-                key_id_pins=key_id_pins,
-                public_key=public_key,
-            )
-        pin_manager.add_pin(serial_num, pin)
+    lookup_path = taf_repo.path if taf_repo is not None else Path.cwd()
+    taf_dir = find_taf_directory(lookup_path)
+    _resolve_and_cache_pin(
+        pin_manager,
+        serial_num,
+        public_key,
+        taf_dir,
+        key_name,
+        pin_confirm,
+        pin_repeat,
+        key_id_pins,
+        creating_new_key=creating_new_key,
+    )
 
     if taf_repo is not None:
         # when reusing the same yubikey, public key will already be in the public keys dictionary
@@ -603,19 +628,16 @@ def _read_and_check_yubikeys(
             taf_logger.debug(
                 f"Potential YubiKey with serial={serial_num}, associated key_name='{key_name}'."
             )
-            pin = None
-            if pin_manager.get_pin(serial_num) is None:
-                pin = get_pin_from_env(public_key, serial_num, taf_dir)
-                if pin is None:
-                    pin = get_and_validate_pin(
-                        key_name,
-                        pin_confirm,
-                        pin_repeat,
-                        serial_num,
-                        key_id_pins=key_id_pins,
-                        public_key=public_key,
-                    )
-                pin_manager.add_pin(serial_num, pin)
+            _resolve_and_cache_pin(
+                pin_manager,
+                serial_num,
+                public_key,
+                taf_dir,
+                key_name,
+                pin_confirm,
+                pin_repeat,
+                key_id_pins,
+            )
 
             # when reusing the same yubikey, public key will already be in the public keys dictionary
             # but the key name still needs to be added to the key id mapping dictionary

--- a/taf/yubikey/yubikey.py
+++ b/taf/yubikey/yubikey.py
@@ -44,6 +44,9 @@ from securesystemslib.signer._key import SSlibKey
 
 EXPIRATION_INTERVAL = 36500
 
+# Retired slots (RETIRED1-RETIRED20) are reserved for key history/decryption, not signing.
+SETUP_SLOTS = {SLOT.SIGNATURE, SLOT.AUTHENTICATION, SLOT.KEY_MANAGEMENT, SLOT.CARD_AUTH}
+
 
 def raise_yubikey_err(msg: Optional[str] = None) -> Callable:
     """Decorator used to catch all errors raised by yubikey-manager and raise
@@ -460,15 +463,40 @@ def _resolve_and_cache_pin(
     pin_manager.add_pin(serial_num, pin)
 
 
+def _prompt_for_slot(serial_num, options):
+    """Ask the user to pick one of `options` (a list of (SLOT, label) pairs,
+    already ordered) and return the chosen SLOT. Auto-selects without
+    prompting if there's only one option."""
+    if len(options) == 1:
+        return options[0][0]
+    print(f"YubiKey serial={serial_num}:")
+    for index, (slot, label) in enumerate(options, start=1):
+        print(f"  {index}. slot={slot.name} {label}")
+    choice = click.prompt("Select a slot", type=click.IntRange(1, len(options)))
+    return options[choice - 1][0]
+
+
 def _prompt_for_slot_selection(serial_num, device_keys):
     """Ask the user which of a device's occupied PIV slots holds the key
     they want."""
     ordered = sorted(device_keys.items(), key=lambda item: item[0].value)
-    print(f"YubiKey serial={serial_num} has more than one key set up:")
-    for index, (slot, key) in enumerate(ordered, start=1):
-        print(f"  {index}. slot={slot.name} keyid={key.keyid}")
-    choice = click.prompt("Select the key to use", type=click.IntRange(1, len(ordered)))
-    return ordered[choice - 1]
+    options = [(slot, f"keyid={key.keyid}") for slot, key in ordered]
+    slot = _prompt_for_slot(serial_num, options)
+    return slot, device_keys[slot]
+
+
+def _prompt_for_new_key_slot(serial_num, occupied_slots):
+    """Pick a free PIV slot to write a newly generated key into. Raises
+    YubikeyError if every setup slot is already occupied."""
+    free_slots = sorted(SETUP_SLOTS - set(occupied_slots), key=lambda s: s.value)
+    if not free_slots:
+        raise YubikeyError(
+            f"YubiKey serial={serial_num} has no free slot. taf will not "
+            "overwrite or reset it - reset the YubiKey's PIV application "
+            "outside of taf and try again."
+        )
+    options = [(slot, "free") for slot in free_slots]
+    return _prompt_for_slot(serial_num, options)
 
 
 def _read_and_check_single_yubikey(

--- a/taf/yubikey/yubikey.py
+++ b/taf/yubikey/yubikey.py
@@ -467,6 +467,19 @@ def _resolve_and_cache_pin(
     pin_manager.add_pin(serial_num, pin)
 
 
+def _prompt_for_slot_selection(serial_num, device_keys):
+    """Ask the user which of a device's occupied PIV slots holds the key
+    they want. Used when more than one slot is occupied and there's no
+    other way (e.g. a role's validity check) to tell which one they mean.
+    """
+    ordered = sorted(device_keys.items(), key=lambda item: item[0].value)
+    print(f"YubiKey serial={serial_num} has more than one key set up:")
+    for index, (slot, key) in enumerate(ordered, start=1):
+        print(f"  {index}. slot={slot.name} keyid={key.keyid}")
+    choice = click.prompt("Select the key to use", type=click.IntRange(1, len(ordered)))
+    return ordered[choice - 1]
+
+
 def _read_and_check_single_yubikey(
     role,
     key_name,
@@ -529,9 +542,18 @@ def _read_and_check_single_yubikey(
     # check if this key is already loaded as the provided role's key (we can use the same key
     # to sign different metadata)
     # read the public key, unless a new key needs to be generated on the yubikey
-    public_key = (
-        get_piv_public_key_tuf(serial=serial_num) if not creating_new_key else None
-    )
+    slot = None
+    if creating_new_key:
+        public_key = None
+    else:
+        device_keys = get_piv_public_keys_tuf(serial=serial_num).get(serial_num, {})
+        if not device_keys:
+            public_key = None
+        elif len(device_keys) == 1:
+            ((slot, public_key),) = device_keys.items()
+        else:
+            slot, public_key = _prompt_for_slot_selection(serial_num, device_keys)
+
     # check if this yubikey is can be used for signing the provided role's metadata
     # if the key was already registered as that role's key
     if not registering_new_key and role is not None and taf_repo is not None:
@@ -556,12 +578,14 @@ def _read_and_check_single_yubikey(
     if taf_repo is not None:
         # when reusing the same yubikey, public key will already be in the public keys dictionary
         # but the key name still needs to be added to the key id mapping dictionary
-        taf_repo.yubikey_store.add_key_data(key_name, serial_num, public_key, role)
+        taf_repo.yubikey_store.add_key_data(
+            key_name, serial_num, public_key, role, slot=slot
+        )
 
     taf_logger.debug(
         f"_read_and_check_single_yubikey returning for serial={serial_num}, key_name='{key_name}'"
     )
-    return public_key, serial_num, key_name
+    return public_key, serial_num, key_name, slot
 
 
 def _read_and_check_yubikeys(
@@ -612,37 +636,55 @@ def _read_and_check_yubikeys(
     for index, serial_num in enumerate(serials):
         if not taf_repo.yubikey_store.is_loaded_for_role(serial_num, role):
             all_loaded = False
-            # read the public key, unless a new key needs to be generated on the yubikey
-            public_key = get_piv_public_key_tuf(serial=serial_num)
-            # check if this yubikey is can be used for signing the provided role's metadata
-            # if the key was already registered as that role's key
-            if role is not None and taf_repo is not None:
-                if not taf_repo.is_valid_metadata_yubikey(role, public_key):
-                    invalid_keys.append(serial_num)
-                    taf_logger.debug(
-                        f"Serial={serial_num} not valid for role='{role}'."
-                    )
+            # a role's key can live in any occupied PIV slot, not just
+            # SIGNATURE, and a single device can hold more than one key
+            # valid for this role (each in its own slot) - every one of
+            # them counts toward the threshold, so collect them all instead
+            # of stopping at the first match. SIGNATURE is checked first to
+            # keep today's behavior when that's the only one present.
+            device_keys = get_piv_public_keys_tuf(serial=serial_num).get(serial_num, {})
+            ordered_slots = [SLOT.SIGNATURE] + [
+                s for s in device_keys if s != SLOT.SIGNATURE
+            ]
+            found_valid_key = False
+            for candidate_slot in ordered_slots:
+                public_key = device_keys.get(candidate_slot)
+                if public_key is None:
                     continue
+                if not (
+                    role is None
+                    or taf_repo is None
+                    or taf_repo.is_valid_metadata_yubikey(role, public_key)
+                ):
+                    continue
+                slot = candidate_slot
+                found_valid_key = True
 
-            key_name = taf_repo.keys_name_mappings.get(public_key.keyid)
-            taf_logger.debug(
-                f"Potential YubiKey with serial={serial_num}, associated key_name='{key_name}'."
-            )
-            _resolve_and_cache_pin(
-                pin_manager,
-                serial_num,
-                public_key,
-                taf_dir,
-                key_name,
-                pin_confirm,
-                pin_repeat,
-                key_id_pins,
-            )
+                key_name = taf_repo.keys_name_mappings.get(public_key.keyid)
+                taf_logger.debug(
+                    f"Potential YubiKey with serial={serial_num}, associated key_name='{key_name}', slot={slot}."
+                )
+                _resolve_and_cache_pin(
+                    pin_manager,
+                    serial_num,
+                    public_key,
+                    taf_dir,
+                    key_name,
+                    pin_confirm,
+                    pin_repeat,
+                    key_id_pins,
+                )
 
-            # when reusing the same yubikey, public key will already be in the public keys dictionary
-            # but the key name still needs to be added to the key id mapping dictionary
-            taf_repo.yubikey_store.add_key_data(key_name, serial_num, public_key, role)
-            yubikeys.append((public_key, serial_num, key_name))
+                # when reusing the same yubikey, public key will already be in the public keys dictionary
+                # but the key name still needs to be added to the key id mapping dictionary
+                taf_repo.yubikey_store.add_key_data(
+                    key_name, serial_num, public_key, role, slot=slot
+                )
+                yubikeys.append((public_key, serial_num, key_name, slot))
+
+            if not found_valid_key:
+                invalid_keys.append(serial_num)
+                taf_logger.debug(f"Serial={serial_num} not valid for role='{role}'.")
 
     if not hide_already_loaded_message and all_loaded:
         print("All inserted YubiKeys already loaded")
@@ -654,7 +696,7 @@ def _read_and_check_yubikeys(
 
 
 @raise_yubikey_err("Cannot sign data.")
-def sign_piv_rsa_pkcs1v15(data, pin, serial=None):
+def sign_piv_rsa_pkcs1v15(data, pin, serial=None, slot=SLOT.SIGNATURE):
     """Sign data with key from YubiKey's piv slot.
 
     Args:
@@ -662,6 +704,8 @@ def sign_piv_rsa_pkcs1v15(data, pin, serial=None):
         - pin(str): Pin for piv slot login.
         - pub_key_pem(str): Match Yubikey's public key (PEM) if multiple keys
                             are inserted
+        - slot(SLOT): The PIV slot holding the signing key. Defaults to
+                      SLOT.SIGNATURE.
 
     Returns:
         Signature (bytes)
@@ -669,11 +713,11 @@ def sign_piv_rsa_pkcs1v15(data, pin, serial=None):
     Raises:
         - YubikeyError
     """
-    taf_logger.debug(f"Signing data using YubiKey serial={serial}.")
+    taf_logger.debug(f"Signing data using YubiKey serial={serial}, slot={slot}.")
     with _yk_piv_ctrl(serial=serial) as [(ctrl, _)]:
         ctrl.verify_pin(pin)
         sig = ctrl.sign(
-            SLOT.SIGNATURE, KEY_TYPE.RSA2048, data, hashes.SHA256(), padding.PKCS1v15()
+            slot, KEY_TYPE.RSA2048, data, hashes.SHA256(), padding.PKCS1v15()
         )
         taf_logger.debug("Data signed successfully.")
         return sig
@@ -1035,7 +1079,7 @@ def yubikey_prompt(
 
         if not yubikeys and not retry_on_failure:
             taf_logger.debug("No YubiKeys found and retry_on_failure=False. Returning.")
-            return [(None, None, None)]
+            return [(None, None, None, None)]
         if yubikeys:
             taf_logger.debug(f"Returning discovered YubiKeys: {yubikeys}")
             return yubikeys

--- a/taf/yubikey/yubikey.py
+++ b/taf/yubikey/yubikey.py
@@ -189,13 +189,17 @@ def get_serial_nums():
 
 
 @raise_yubikey_err("Cannot export x509 certificate.")
-def export_piv_x509(cert_format=serialization.Encoding.PEM, serial=None):
+def export_piv_x509(
+    cert_format=serialization.Encoding.PEM, serial=None, slot=SLOT.SIGNATURE
+):
     """Exports YubiKey's piv slot x509.
 
     Args:
         - cert_format(str): One of 'serialization.Encoding' formats.
         - pub_key_pem(str): Match Yubikey's public key (PEM) if multiple keys
                             are inserted
+        - slot(SLOT): The PIV slot to read the certificate from. Defaults to
+                      SLOT.SIGNATURE.
 
     Returns:
         PIV x509 certificate in a given format (bytes)
@@ -203,9 +207,9 @@ def export_piv_x509(cert_format=serialization.Encoding.PEM, serial=None):
     Raises:
         - YubikeyError
     """
-    taf_logger.debug(f"Exporting X509 certificate for serial={serial}")
+    taf_logger.debug(f"Exporting X509 certificate for serial={serial}, slot={slot}")
     with _yk_piv_ctrl(serial=serial) as [(ctrl, _)]:
-        x509_cert = ctrl.get_certificate(SLOT.SIGNATURE)
+        x509_cert = ctrl.get_certificate(slot)
         return x509_cert.public_bytes(encoding=cert_format)
 
 
@@ -238,7 +242,7 @@ def export_piv_pub_key(pub_key_format=serialization.Encoding.PEM, serial=None):
 
 
 @raise_yubikey_err("Cannot export yk certificate.")
-def export_yk_certificate(certs_dir, key: SSlibKey, serial: str):
+def export_yk_certificate(certs_dir, key: SSlibKey, serial: str, slot=SLOT.SIGNATURE):
     if certs_dir is None:
         certs_dir = Path.home()
     else:
@@ -248,7 +252,7 @@ def export_yk_certificate(certs_dir, key: SSlibKey, serial: str):
     print(f"Exporting certificate to {cert_path}")
     taf_logger.debug(f"Writing certificate file for keyid={key.keyid}, serial={serial}")
     with open(cert_path, "wb") as f:
-        f.write(export_piv_x509(serial=serial))
+        f.write(export_piv_x509(serial=serial, slot=slot))
 
 
 def get_and_validate_pin(
@@ -468,7 +472,11 @@ def _prompt_for_slot(serial_num, options):
     already ordered) and return the chosen SLOT. Auto-selects without
     prompting if there's only one option."""
     if len(options) == 1:
-        return options[0][0]
+        slot, label = options[0]
+        print(
+            f"YubiKey serial={serial_num}: using the only available slot={slot.name} ({label})"
+        )
+        return slot
     print(f"YubiKey serial={serial_num}:")
     for index, (slot, label) in enumerate(options, start=1):
         print(f"  {index}. slot={slot.name} {label}")
@@ -563,11 +571,20 @@ def _read_and_check_single_yubikey(
     # read the public key, unless a new key needs to be generated on the yubikey
     slot = None
     if creating_new_key:
+        # occupancy is an unauthenticated PIV read - resolve the slot before
+        # ever asking for a PIN, and abort outright if none is free
+        occupied = get_piv_public_keys_tuf(serial=serial_num).get(serial_num, {})
+        slot = _prompt_for_new_key_slot(serial_num, occupied.keys())
         public_key = None
     else:
         device_keys = get_piv_public_keys_tuf(serial=serial_num).get(serial_num, {})
         if not device_keys:
-            public_key = None
+            print(
+                f"YubiKey serial={serial_num} has no key set up yet - nothing to "
+                "reuse. Insert a YubiKey that has already been set up, or answer "
+                "'n' to create a new key instead."
+            )
+            return None
         elif len(device_keys) == 1:
             ((slot, public_key),) = device_keys.items()
         else:

--- a/taf/yubikey/yubikey.py
+++ b/taf/yubikey/yubikey.py
@@ -462,9 +462,7 @@ def _resolve_and_cache_pin(
 
 def _prompt_for_slot_selection(serial_num, device_keys):
     """Ask the user which of a device's occupied PIV slots holds the key
-    they want. Used when more than one slot is occupied and there's no
-    other way (e.g. a role's validity check) to tell which one they mean.
-    """
+    they want."""
     ordered = sorted(device_keys.items(), key=lambda item: item[0].value)
     print(f"YubiKey serial={serial_num} has more than one key set up:")
     for index, (slot, key) in enumerate(ordered, start=1):
@@ -728,16 +726,13 @@ def _get_protected_management_key(ctrl):
 
 
 def _slot_occupied(ctrl, slot) -> bool:
-    """Check whether a PIV slot already has a key in it.
-
-    Prefers get_slot_metadata, which detects a key even without a
-    certificate (e.g. an interrupted setup()), falling back to
-    get_certificate on firmware older than 5.3 that doesn't support it.
-    """
+    """Check whether a PIV slot already has a key in it."""
     try:
+        # detects a key even without a certificate (e.g. an interrupted setup())
         ctrl.get_slot_metadata(slot)
         return True
     except NotSupportedError:
+        # firmware older than 5.3 - fall back to checking for a certificate
         pass
     except Exception:
         return False
@@ -798,8 +793,7 @@ def setup(
 ):
     """Generate or import a key (and self-signed certificate) into a single
     PIV slot of the inserted YubiKey. Every other slot, and the PIN/PUK, are
-    left untouched. Raises if the target slot is already occupied - taf
-    never resets or overwrites a card.
+    left untouched. Raises if the target slot is already occupied.
 
     Args:
         - cert_cn(str): x509 common name

--- a/taf/yubikey/yubikey.py
+++ b/taf/yubikey/yubikey.py
@@ -20,7 +20,7 @@ from taf.yubikey.yubikey_manager import PinManager
 from taf.models.types import KeysMapping
 from ykman.device import list_all_devices
 from yubikit.core import NotSupportedError
-from yubikit.core.smartcard import SmartCardConnection
+from yubikit.core.smartcard import ApduError, SW, SmartCardConnection
 from ykman.piv import (
     KEY_TYPE,
     MANAGEMENT_KEY_TYPE,
@@ -873,14 +873,24 @@ def setup(
                 "taf and try again."
             )
 
-        if management_key is not None:
-            ctrl.authenticate(MANAGEMENT_KEY_TYPE.TDES, management_key)
-        else:
-            ctrl.verify_pin(pin)
-            stored_key = _get_protected_management_key(ctrl)
-            ctrl.authenticate(
-                MANAGEMENT_KEY_TYPE.TDES, stored_key or DEFAULT_MANAGEMENT_KEY
-            )
+        try:
+            if management_key is not None:
+                ctrl.authenticate(MANAGEMENT_KEY_TYPE.TDES, management_key)
+            else:
+                ctrl.verify_pin(pin)
+                stored_key = _get_protected_management_key(ctrl)
+                ctrl.authenticate(
+                    MANAGEMENT_KEY_TYPE.TDES, stored_key or DEFAULT_MANAGEMENT_KEY
+                )
+        except ApduError as e:
+            if e.sw == SW.SECURITY_CONDITION_NOT_SATISFIED:
+                raise YubikeyError(
+                    "Could not authenticate with the YubiKey's management key. "
+                    "This can happen if its PIV application was previously set "
+                    "up by a different tool or is in an inconsistent state - "
+                    "reset it (e.g. `ykman piv reset`) and try again."
+                ) from e
+            raise
 
         if private_key_pem is None:
             taf_logger.debug("Generating RSA private key on the fly...")

--- a/taf/yubikey/yubikey_manager.py
+++ b/taf/yubikey/yubikey_manager.py
@@ -34,27 +34,43 @@ class YubiKeyStore:
         serial_num: str,
         public_key: SSlibKey,
         role_name: str,
+        slot=None,
     ) -> None:
         """Add data associated with a YubiKey."""
-        if role_name in self._yubikeys_data:
+        if key_name in self._yubikeys_data:
             key_data = self._yubikeys_data[key_name]
         else:
-            key_data = {"serial": serial_num, "public_key": public_key, "roles": []}
-        key_data["roles"].append(role_name)
+            key_data = {
+                "serial": serial_num,
+                "public_key": public_key,
+                "roles": [],
+                "slot": None,
+            }
+        key_data["serial"] = serial_num
+        key_data["public_key"] = public_key
+        if slot is not None:
+            key_data["slot"] = slot
+        if role_name not in key_data["roles"]:
+            key_data["roles"].append(role_name)
         self._yubikeys_data[key_name] = key_data
 
-    def get_key_data(self, key_name: str) -> Optional[Tuple[str, SSlibKey]]:
+    def get_key_data(self, key_name: str) -> Optional[Tuple[SSlibKey, str, object]]:
         """Retrieve data associated with a given YubiKey name."""
         if not self.is_key_name_loaded(key_name):
             return None
         key_data = self._yubikeys_data.get(key_name)
-        return key_data["public_key"], key_data["serial"]
+        return key_data["public_key"], key_data["serial"], key_data.get("slot")
 
-    def get_roles_of_key(self, serial_number: str) -> List[str]:
+    def get_roles_of_key(
+        self, serial_number: str, public_key: Optional[SSlibKey] = None
+    ) -> List[str]:
         roles = []
         for data in self._yubikeys_data.values():
-            if data["serial"] == serial_number:
-                roles.extend(data["roles"])
+            if data["serial"] != serial_number:
+                continue
+            if public_key is not None and data["public_key"].keyid != public_key.keyid:
+                continue
+            roles.extend(data["roles"])
         return roles
 
     def remove_key_data(self, key_name: str) -> bool:

--- a/taf/yubikey/yubikey_manager.py
+++ b/taf/yubikey/yubikey_manager.py
@@ -68,7 +68,10 @@ class YubiKeyStore:
         for data in self._yubikeys_data.values():
             if data["serial"] != serial_number:
                 continue
-            if public_key is not None and data["public_key"].keyid != public_key.keyid:
+            if public_key is not None and (
+                data["public_key"] is None
+                or data["public_key"].keyid != public_key.keyid
+            ):
                 continue
             roles.extend(data["roles"])
         return roles


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

Closes #758

Also remove the option to reset a YK in TAF. Show an error instead

## Testing

Manually tested on real hardware with 2 physical YubiKeys:

- Multi-device, multi-slot signing: one YubiKey held 2 keys across 2 different PIV slots (e.g. `snapshot` in SIGNATURE, `timestamp` in AUTHENTICATION), the second YubiKey held 1 key (`targets`) in its SIGNATURE slot. Created a repo and signed a target update - all three roles signed correctly with the right key from the right slot on the right device.
- Threshold > 1 across slots on one device: configured a role (`targets`) with 2 required keys/threshold 2, with both keys living on the same physical device's 2 different slots. Confirmed both slots' signatures were discovered and counted toward satisfying the threshold, and the resulting metadata verified correctly.


## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
