### PR TITLE
feat: safe_cleanup with graceful shutdown

### DIFF
--- a/taf/tests/test_updater/test_pipeline_cleanup.py
+++ b/taf/tests/test_updater/test_pipeline_cleanup.py
@@ -1,0 +1,87 @@
+import pytest
+import signal
+from unittest.mock import Mock, patch
+from taf.updater.lifecycle_handlers import Event
+from taf.tools.cli import safe_cleanup
+from taf.updater.updater_pipeline import AuthenticationRepositoryUpdatePipeline
+
+
+@pytest.fixture
+def dummy_pipeline():
+    """Mock pipeline with required attributes for testing the decorator."""
+    pipeline = Mock(spec=AuthenticationRepositoryUpdatePipeline)
+    pipeline.only_validate = False
+    pipeline.state = Mock()
+    pipeline.state.existing_repo = False
+    pipeline.state.users_auth_repo = "some_repo"
+    pipeline.state.event = None
+    pipeline.remove_temp_repositories = Mock()
+    return pipeline
+
+
+def test_pipeline_cleanup_calls_cleanup_on_success(dummy_pipeline):
+    """On normal completion, cleanup is called once."""
+
+    @safe_cleanup
+    def dummy_method(self):
+        return "success"
+
+    result = dummy_method(dummy_pipeline)
+    assert result == "success"
+    dummy_pipeline.remove_temp_repositories.assert_called_once()
+
+
+def test_pipeline_cleanup_handles_keyboard_interrupt(dummy_pipeline):
+    """On Ctrl+C, cleanup is called and state is set to FAILED."""
+
+    @safe_cleanup
+    def dummy_method(self):
+        raise KeyboardInterrupt("Simulated Ctrl+C")
+
+    with pytest.raises(KeyboardInterrupt):
+        dummy_method(dummy_pipeline)
+
+    dummy_pipeline.remove_temp_repositories.assert_called_once()
+    assert dummy_pipeline.state.event == Event.FAILED
+
+
+def test_pipeline_cleanup_handles_normal_exception(dummy_pipeline):
+    """On a normal exception, cleanup is still called."""
+
+    @safe_cleanup
+    def dummy_method(self):
+        raise ValueError("Something went wrong")
+
+    with pytest.raises(ValueError):
+        dummy_method(dummy_pipeline)
+
+    dummy_pipeline.remove_temp_repositories.assert_called_once()
+
+
+@patch("signal.signal")
+def test_pipeline_cleanup_registers_and_restores_signal_handlers(
+    mock_signal, dummy_pipeline
+):
+    """Ensure SIGINT and SIGTERM are overridden temporarily."""
+    original_sigint = Mock()
+    original_sigterm = Mock()
+    mock_signal.side_effect = [
+        original_sigint,
+        original_sigterm,
+        original_sigint,
+        original_sigterm,
+    ]
+
+    @safe_cleanup
+    def dummy_method(self):
+        return "ok"
+
+    dummy_method(dummy_pipeline)
+
+    assert mock_signal.call_count == 4
+    # Setting handlers
+    assert mock_signal.call_args_list[0][0][0] == signal.SIGINT
+    assert mock_signal.call_args_list[1][0][0] == signal.SIGTERM
+    # Restoring handlers
+    assert mock_signal.call_args_list[2][0][0] == signal.SIGINT
+    assert mock_signal.call_args_list[3][0][0] == signal.SIGTERM

--- a/taf/tests/test_updater/test_pipeline_cleanup.py
+++ b/taf/tests/test_updater/test_pipeline_cleanup.py
@@ -1,3 +1,4 @@
+import types
 import pytest
 import signal
 from unittest.mock import Mock, patch
@@ -8,7 +9,9 @@ from taf.updater.updater_pipeline import AuthenticationRepositoryUpdatePipeline
 
 @pytest.fixture
 def dummy_pipeline():
-    """Mock pipeline with required attributes for testing the decorator."""
+    """Mock pipeline with real cleanup/on_interrupt hooks bound, so safe_cleanup's
+    generalized dispatch is exercised against actual pipeline behavior rather than
+    just recording that a Mock was called."""
     pipeline = Mock(spec=AuthenticationRepositoryUpdatePipeline)
     pipeline.only_validate = False
     pipeline.state = Mock()
@@ -16,37 +19,40 @@ def dummy_pipeline():
     pipeline.state.users_auth_repo = "some_repo"
     pipeline.state.event = None
     pipeline.remove_temp_repositories = Mock()
+    pipeline.set_output = Mock()
+
+    # Bind the real hook implementations instead of leaving them as bare Mocks,
+    # so assertions check pipeline-specific side effects (state.event, temp repo
+    # removal), not just "was this called".
+    pipeline.cleanup = types.MethodType(
+        AuthenticationRepositoryUpdatePipeline.cleanup, pipeline
+    )
+    pipeline.on_interrupt = types.MethodType(
+        AuthenticationRepositoryUpdatePipeline.on_interrupt, pipeline
+    )
+    # Note: the pipeline defines no after_interrupt. Because this Mock uses
+    # spec=AuthenticationRepositoryUpdatePipeline, hasattr(pipeline, "after_interrupt")
+    # is False, matching production behavior.
     return pipeline
 
 
 def test_pipeline_cleanup_calls_cleanup_on_success(dummy_pipeline):
-    """On normal completion, cleanup is called once."""
+    """On normal completion, cleanup() runs: output is set and temp repos are removed."""
 
     @safe_cleanup
     def dummy_method(self):
         return "success"
 
     result = dummy_method(dummy_pipeline)
+
     assert result == "success"
-    dummy_pipeline.remove_temp_repositories.assert_called_once()
-
-
-def test_pipeline_cleanup_handles_keyboard_interrupt(dummy_pipeline):
-    """On Ctrl+C, cleanup is called and state is set to FAILED."""
-
-    @safe_cleanup
-    def dummy_method(self):
-        raise KeyboardInterrupt("Simulated Ctrl+C")
-
-    with pytest.raises(KeyboardInterrupt):
-        dummy_method(dummy_pipeline)
-
-    dummy_pipeline.remove_temp_repositories.assert_called_once()
-    assert dummy_pipeline.state.event == Event.FAILED
+    dummy_pipeline.set_output.assert_called_once()
+    dummy_pipeline.remove_temp_repositories.assert_called_once_with(final_cleanup=True)
+    assert dummy_pipeline.state.event is None
 
 
 def test_pipeline_cleanup_handles_normal_exception(dummy_pipeline):
-    """On a normal exception, cleanup is still called."""
+    """On a normal exception, cleanup still runs."""
 
     @safe_cleanup
     def dummy_method(self):
@@ -55,14 +61,86 @@ def test_pipeline_cleanup_handles_normal_exception(dummy_pipeline):
     with pytest.raises(ValueError):
         dummy_method(dummy_pipeline)
 
-    dummy_pipeline.remove_temp_repositories.assert_called_once()
+    dummy_pipeline.remove_temp_repositories.assert_called_once_with(final_cleanup=True)
+    assert dummy_pipeline.state.event is None
+
+
+def test_pipeline_cleanup_handles_keyboard_interrupt_without_signal(dummy_pipeline):
+    """A KeyboardInterrupt raised directly (not via the OS signal path) still triggers
+    cleanup, but does NOT mark the state as FAILED — that only happens through
+    on_interrupt, which is wired to the signal handler, and the pipeline defines no
+    after_interrupt hook for the except-block path."""
+
+    @safe_cleanup
+    def dummy_method(self):
+        raise KeyboardInterrupt("Simulated Ctrl+C")
+
+    with pytest.raises(KeyboardInterrupt):
+        dummy_method(dummy_pipeline)
+
+    dummy_pipeline.remove_temp_repositories.assert_called_once_with(final_cleanup=True)
+    assert dummy_pipeline.state.event is None
+
+
+@patch("signal.signal")
+def test_pipeline_on_interrupt_sets_failed_event_via_signal(
+    mock_signal, dummy_pipeline
+):
+    """A real interrupt (SIGINT/SIGTERM) fires the registered handler, which calls
+    on_interrupt and marks the update FAILED; cleanup still runs afterwards."""
+    captured_handlers = {}
+
+    def fake_signal(sig, handler):
+        captured_handlers[sig] = handler
+        return Mock()
+
+    mock_signal.side_effect = fake_signal
+
+    @safe_cleanup
+    def dummy_method(self):
+        # Simulate the OS delivering SIGINT mid-run
+        captured_handlers[signal.SIGINT](signal.SIGINT, None)
+
+    with pytest.raises(KeyboardInterrupt):
+        dummy_method(dummy_pipeline)
+
+    assert dummy_pipeline.state.event == Event.FAILED
+    dummy_pipeline.remove_temp_repositories.assert_called_once_with(final_cleanup=True)
+
+
+@patch("signal.signal")
+def test_pipeline_on_interrupt_skips_failed_event_when_repo_preexisting(
+    mock_signal, dummy_pipeline
+):
+    """on_interrupt only marks FAILED when the repo isn't pre-existing, validation-only
+    mode is off, and users_auth_repo is set. If the repo already existed, state.event
+    is left untouched."""
+    dummy_pipeline.state.existing_repo = True
+
+    captured_handlers = {}
+
+    def fake_signal(sig, handler):
+        captured_handlers[sig] = handler
+        return Mock()
+
+    mock_signal.side_effect = fake_signal
+
+    @safe_cleanup
+    def dummy_method(self):
+        captured_handlers[signal.SIGINT](signal.SIGINT, None)
+
+    with pytest.raises(KeyboardInterrupt):
+        dummy_method(dummy_pipeline)
+
+    assert dummy_pipeline.state.event is None
+    dummy_pipeline.remove_temp_repositories.assert_called_once_with(final_cleanup=True)
 
 
 @patch("signal.signal")
 def test_pipeline_cleanup_registers_and_restores_signal_handlers(
     mock_signal, dummy_pipeline
 ):
-    """Ensure SIGINT and SIGTERM are overridden temporarily."""
+    """Ensure SIGINT and SIGTERM are overridden temporarily and restored afterwards."""
     original_sigint = Mock()
     original_sigterm = Mock()
     mock_signal.side_effect = [

--- a/taf/tools/cli/__init__.py
+++ b/taf/tools/cli/__init__.py
@@ -1,6 +1,9 @@
 import shutil
 import sys
 import click
+import signal
+import threading
+import functools
 from functools import partial, wraps
 from logging import ERROR
 from logdecorator import log_on_error
@@ -15,6 +18,7 @@ from taf.log import taf_logger
 from taf.repository_utils import find_valid_repository
 from taf.git import GitRepository
 from taf.utils import is_run_from_python_executable, on_rm_error
+from taf.updater.lifecycle_handlers import Event
 
 
 def catch_cli_exception(
@@ -156,3 +160,93 @@ def common_repo_edit_options(func):
         help="Whether to skip the check if there are any remote changes. Can be used when the SSH key requires a passphrase",
     )(func)
     return func
+
+
+def safe_cleanup(method):
+    """
+    Decorator that handles gracefull shutdown (SIGINT and SIGTERM)
+    applicable for:
+    Pipeline
+    any with cleanup()
+    """
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+
+        is_pipeline = "Pipeline" in self.__class__.__name__
+
+        has_cleanup = hasattr(self, "cleanup") and callable(self.cleanup)
+
+        # Signal handler only mutates state; deletion is delegated to finally.
+        def _signal_handler(signum, frame):
+            if is_pipeline:
+                if (
+                    not self.only_validate
+                    and not self.state.existing_repo
+                    and self.state.users_auth_repo is not None
+                ):
+                    self.state.event = Event.FAILED
+            elif True:
+                pass  # Expand Here
+            raise KeyboardInterrupt(f"Received signal {signum}")
+
+        original_sigint = None
+        original_sigterm = None
+
+        if threading.current_thread() is threading.main_thread():
+            # Save and override handlers
+            original_sigint = signal.getsignal(signal.SIGINT)
+            try:
+                original_sigterm = signal.getsignal(signal.SIGTERM)
+            except Exception:
+                original_sigterm = None
+
+            try:
+                signal.signal(signal.SIGINT, _signal_handler)
+            except (OSError, ValueError):
+                pass  # Not allowed to set signal handler (e.g., in embedded interpreter)
+            try:
+                signal.signal(signal.SIGTERM, _signal_handler)
+            except (OSError, ValueError):
+                pass  # Windows: SIGTERM cannot be caught
+
+        try:
+            return method(self, *args, **kwargs)
+
+        except KeyboardInterrupt:
+            # Set state for non-KeyboardInterrupt exceptions (ValueError, SystemExit, etc.)
+            if is_pipeline:
+                if (
+                    not self.only_validate
+                    and not self.state.existing_repo
+                    and self.state.users_auth_repo is not None
+                ):
+                    self.state.event = Event.FAILED
+            elif True:
+                pass  # Expand Here
+            raise
+
+        finally:
+            # Restore original handlers if changed
+            if threading.current_thread() is threading.main_thread():
+                if original_sigint is not None:
+                    try:
+                        signal.signal(signal.SIGINT, original_sigint)
+                    except Exception:
+                        pass
+                if original_sigterm is not None:
+                    try:
+                        signal.signal(signal.SIGTERM, original_sigterm)
+                    except Exception:
+                        pass
+
+            # Cleanup lives here (and ONLY here)
+            if is_pipeline:
+                self.remove_temp_repositories(final_cleanup=True)
+            elif has_cleanup:
+                self.cleanup()  # Expand Here
+
+            # Add other object types here if needed
+            # elif hasattr(self, 'cleanup'): self.cleanup()
+
+    return wrapper

--- a/taf/tools/cli/__init__.py
+++ b/taf/tools/cli/__init__.py
@@ -18,7 +18,6 @@ from taf.log import taf_logger
 from taf.repository_utils import find_valid_repository
 from taf.git import GitRepository
 from taf.utils import is_run_from_python_executable, on_rm_error
-from taf.updater.lifecycle_handlers import Event
 
 
 def catch_cli_exception(
@@ -164,30 +163,23 @@ def common_repo_edit_options(func):
 
 def safe_cleanup(method):
     """
-    Decorator that handles gracefull shutdown (SIGINT and SIGTERM)
-    applicable for:
-    Pipeline
-    any with cleanup()
+    Decorator that handles gracefull shutdown and cleanup (SIGINT and SIGTERM)
+    applicable for objects with any: `cleanup`, `on_interrupt` and `after_interrupt` functions defined
     """
 
     @functools.wraps(method)
     def wrapper(self, *args, **kwargs):
 
-        is_pipeline = "Pipeline" in self.__class__.__name__
-
         has_cleanup = hasattr(self, "cleanup") and callable(self.cleanup)
+        has_on_interrupt = hasattr(self, "on_interrupt") and callable(self.on_interrupt)
+        has_after_interrupt = hasattr(self, "after_interrupt") and callable(
+            self.after_interrupt
+        )
 
         # Signal handler only mutates state; deletion is delegated to finally.
         def _signal_handler(signum, frame):
-            if is_pipeline:
-                if (
-                    not self.only_validate
-                    and not self.state.existing_repo
-                    and self.state.users_auth_repo is not None
-                ):
-                    self.state.event = Event.FAILED
-            elif True:
-                pass  # Expand Here
+            if has_on_interrupt:
+                self.on_interrupt()
             raise KeyboardInterrupt(f"Received signal {signum}")
 
         original_sigint = None
@@ -214,18 +206,9 @@ def safe_cleanup(method):
             return method(self, *args, **kwargs)
 
         except KeyboardInterrupt:
-            # Set state for non-KeyboardInterrupt exceptions (ValueError, SystemExit, etc.)
-            if is_pipeline:
-                if (
-                    not self.only_validate
-                    and not self.state.existing_repo
-                    and self.state.users_auth_repo is not None
-                ):
-                    self.state.event = Event.FAILED
-            elif True:
-                pass  # Expand Here
+            if has_after_interrupt:
+                self.after_interrupt()
             raise
-
         finally:
             # Restore original handlers if changed
             if threading.current_thread() is threading.main_thread():
@@ -240,13 +223,7 @@ def safe_cleanup(method):
                     except Exception:
                         pass
 
-            # Cleanup lives here (and ONLY here)
-            if is_pipeline:
-                self.remove_temp_repositories(final_cleanup=True)
-            elif has_cleanup:
-                self.cleanup()  # Expand Here
-
-            # Add other object types here if needed
-            # elif hasattr(self, 'cleanup'): self.cleanup()
+            if has_cleanup:
+                self.cleanup()
 
     return wrapper

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -31,6 +31,7 @@ from taf.updater.types.update import OperationType, UpdateType
 from taf.utils import TempPartition, on_rm_error, ensure_pre_push_hook
 from taf.updater.in_memory_updater import InMemoryUpdater
 from taf.log import taf_logger
+from taf.tools.cli import safe_cleanup
 
 EXPIRED_METADATA_ERROR = "ExpiredMetadataError"
 
@@ -211,35 +212,41 @@ class Pipeline:
         self.current_step = None
         self.run_mode = run_mode
 
+    @safe_cleanup
     def run(self):
         self.state.errors = []
         self.state.warnings = []
-        for step, step_run_mode, should_run_fn in self.steps:
-            try:
-                if (
-                    step_run_mode == RunMode.ALL or step_run_mode == self.run_mode
-                ) and (
-                    should_run_fn()
-                ):  # runs method like object
-                    self.current_step = step
-                    update_status = step()
-                    combined_status = combine_statuses(
-                        self.state.update_status, update_status
-                    )
-                    self.state.update_status = combined_status
-                    if combined_status == UpdateStatus.FAILED:
-                        message = "\n".join(str(error) for error in self.state.errors)
-                        raise UpdateFailedError(message)
+        try:
+            for step, step_run_mode, should_run_fn in self.steps:
+                try:
+                    if (
+                        step_run_mode == RunMode.ALL or step_run_mode == self.run_mode
+                    ) and (
+                        should_run_fn()
+                    ):  # runs method like object
+                        self.current_step = step
+                        update_status = step()
+                        combined_status = combine_statuses(
+                            self.state.update_status, update_status
+                        )
+                        self.state.update_status = combined_status
 
-            except Exception as e:
-                self.handle_error(e)
-                break
-            except KeyboardInterrupt as e:
-                self.handle_error(e)
-        self.set_output()
+                        if combined_status == UpdateStatus.FAILED:
+                            message = "\n".join(
+                                str(error) for error in self.state.errors
+                            )
+                            raise UpdateFailedError(message)
+
+                except Exception as e:
+                    self.handle_error(e)
+                    break
+                except KeyboardInterrupt as e:
+                    self.handle_error(e)
+                    raise
+        finally:
+            self.set_output()
 
     def handle_error(self, e):
-        self.remove_temp_repositories()
         self.state.event = Event.FAILED
         if self.state.auth_repo_name is not None:
             taf_logger.error(
@@ -2034,7 +2041,7 @@ but commit not on branch {current_branch}"
             self.state.event = Event.FAILED
             return UpdateStatus.FAILED
 
-    def remove_temp_repositories(self):
+    def remove_temp_repositories(self, final_cleanup=False):
         taf_logger.debug(f"{self.state.auth_repo_name}: Removing temp repositories...")
         if not self.state.temp_root:
             return self.state.update_status
@@ -2043,8 +2050,12 @@ but commit not on branch {current_branch}"
             # renaming/removing the temp directory on Windows
             for repo in self.state.temp_target_repositories.values():
                 repo.cleanup()
-            self.state.update_handler.cleanup()
+            # self.state.update_handler.cleanup() # This doesn't exist and is unnecesary
+
+            # finally clean temps
             self.state.temp_root.cleanup_async()
+            if final_cleanup:
+                self.state.temp_root = None  # Solves double cleanup issues
         except Exception:
             taf_logger.warning(
                 f"WARNING: Could not remove clean up temp folder: {self.state.temp_root}. Please remove it manually."

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -216,35 +216,30 @@ class Pipeline:
     def run(self):
         self.state.errors = []
         self.state.warnings = []
-        try:
-            for step, step_run_mode, should_run_fn in self.steps:
-                try:
-                    if (
-                        step_run_mode == RunMode.ALL or step_run_mode == self.run_mode
-                    ) and (
-                        should_run_fn()
-                    ):  # runs method like object
-                        self.current_step = step
-                        update_status = step()
-                        combined_status = combine_statuses(
-                            self.state.update_status, update_status
-                        )
-                        self.state.update_status = combined_status
+        for step, step_run_mode, should_run_fn in self.steps:
+            try:
+                if (
+                    step_run_mode == RunMode.ALL or step_run_mode == self.run_mode
+                ) and (
+                    should_run_fn()
+                ):  # runs method like object
+                    self.current_step = step
+                    update_status = step()
+                    combined_status = combine_statuses(
+                        self.state.update_status, update_status
+                    )
+                    self.state.update_status = combined_status
 
-                        if combined_status == UpdateStatus.FAILED:
-                            message = "\n".join(
-                                str(error) for error in self.state.errors
-                            )
-                            raise UpdateFailedError(message)
+                    if combined_status == UpdateStatus.FAILED:
+                        message = "\n".join(str(error) for error in self.state.errors)
+                        raise UpdateFailedError(message)
 
-                except Exception as e:
-                    self.handle_error(e)
-                    break
-                except KeyboardInterrupt as e:
-                    self.handle_error(e)
-                    raise
-        finally:
-            self.set_output()
+            except Exception as e:
+                self.handle_error(e)
+                break
+            except KeyboardInterrupt as e:
+                self.handle_error(e)
+                raise
 
     def handle_error(self, e):
         self.state.event = Event.FAILED
@@ -264,6 +259,9 @@ class Pipeline:
 
     def set_output(self):
         pass
+
+    def cleanup(self):
+        self.set_output()
 
 
 class AuthenticationRepositoryUpdatePipeline(Pipeline):
@@ -2066,7 +2064,7 @@ but commit not on branch {current_branch}"
             for repo in self.state.temp_target_repositories.values():
                 repo.cleanup()
             if self.state.update_handler is not None:
-                self.state.update_handler.cleanup() # TODO: This should not be None.
+                self.state.update_handler.cleanup()  # TODO: This should not be None.
 
             # finally clean temps
             self.state.temp_root.cleanup_async()
@@ -2447,6 +2445,19 @@ but commit not on branch {current_branch}"
             self.state.errors.append(e)
             self.state.event = Event.FAILED
             return UpdateStatus.FAILED
+
+    def cleanup(self):
+        self.set_output()
+        self.remove_temp_repositories(final_cleanup=True)
+        pass
+
+    def on_interrupt(self):
+        if (
+            not self.only_validate
+            and not self.state.existing_repo
+            and self.state.users_auth_repo is not None
+        ):
+            self.state.event = Event.FAILED
 
 
 def _get_repository_name_raise_error_if_not_defined(validation_repo, commit):

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -31,6 +31,7 @@ from taf.updater.types.update import OperationType, UpdateType
 from taf.utils import TempPartition, on_rm_error, ensure_pre_push_hook
 from taf.updater.in_memory_updater import InMemoryUpdater
 from taf.log import taf_logger
+from taf.tools.cli import safe_cleanup
 
 EXPIRED_METADATA_ERROR = "ExpiredMetadataError"
 
@@ -211,35 +212,41 @@ class Pipeline:
         self.current_step = None
         self.run_mode = run_mode
 
+    @safe_cleanup
     def run(self):
         self.state.errors = []
         self.state.warnings = []
-        for step, step_run_mode, should_run_fn in self.steps:
-            try:
-                if (
-                    step_run_mode == RunMode.ALL or step_run_mode == self.run_mode
-                ) and (
-                    should_run_fn()
-                ):  # runs method like object
-                    self.current_step = step
-                    update_status = step()
-                    combined_status = combine_statuses(
-                        self.state.update_status, update_status
-                    )
-                    self.state.update_status = combined_status
-                    if combined_status == UpdateStatus.FAILED:
-                        message = "\n".join(str(error) for error in self.state.errors)
-                        raise UpdateFailedError(message)
+        try:
+            for step, step_run_mode, should_run_fn in self.steps:
+                try:
+                    if (
+                        step_run_mode == RunMode.ALL or step_run_mode == self.run_mode
+                    ) and (
+                        should_run_fn()
+                    ):  # runs method like object
+                        self.current_step = step
+                        update_status = step()
+                        combined_status = combine_statuses(
+                            self.state.update_status, update_status
+                        )
+                        self.state.update_status = combined_status
 
-            except Exception as e:
-                self.handle_error(e)
-                break
-            except KeyboardInterrupt as e:
-                self.handle_error(e)
-        self.set_output()
+                        if combined_status == UpdateStatus.FAILED:
+                            message = "\n".join(
+                                str(error) for error in self.state.errors
+                            )
+                            raise UpdateFailedError(message)
+
+                except Exception as e:
+                    self.handle_error(e)
+                    break
+                except KeyboardInterrupt as e:
+                    self.handle_error(e)
+                    raise
+        finally:
+            self.set_output()
 
     def handle_error(self, e):
-        self.remove_temp_repositories()
         self.state.event = Event.FAILED
         if self.state.auth_repo_name is not None:
             taf_logger.error(
@@ -2049,7 +2056,7 @@ but commit not on branch {current_branch}"
             self.state.event = Event.FAILED
             return UpdateStatus.FAILED
 
-    def remove_temp_repositories(self):
+    def remove_temp_repositories(self, final_cleanup=False):
         taf_logger.debug(f"{self.state.auth_repo_name}: Removing temp repositories...")
         if not self.state.temp_root:
             return self.state.update_status
@@ -2058,8 +2065,13 @@ but commit not on branch {current_branch}"
             # renaming/removing the temp directory on Windows
             for repo in self.state.temp_target_repositories.values():
                 repo.cleanup()
-            self.state.update_handler.cleanup()
+            if self.state.update_handler is not None:
+                self.state.update_handler.cleanup() # TODO: This should not be None.
+
+            # finally clean temps
             self.state.temp_root.cleanup_async()
+            if final_cleanup:
+                self.state.temp_root = None  # Solves double cleanup issues
         except Exception:
             taf_logger.warning(
                 f"WARNING: Could not remove clean up temp folder: {self.state.temp_root}. Please remove it manually."


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

added safe_cleanup decorator in taf.tools.cli for handling Graceful Shutdown (and final cleanup)
used said decorator on Pipeline.run()
moved remove_temp_repositories from handle_error to safe_cleanup
attempted to fix bugs with cleanup on updates

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
