### PR TITLE
fix(yubikey): allow --key-pin with multiple YubiKeys inserted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Allow `--key-pin` with multiple YubiKeys inserted ([770])
 - Detect signing scheme from key material instead of assuming RSA ([757])
 - Clone no longer fails when the repository path contains a space (e.g. a Windows home directory with a space in the user name) ([762])
 - Surface the underlying git error when a clone fails, instead of hiding it behind a generic access message ([762])
@@ -30,6 +31,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 
 [771]: https://github.com/openlawlibrary/taf/pull/771
+[770]: https://github.com/openlawlibrary/taf/pull/770
 [767]: https://github.com/openlawlibrary/taf/pull/767
 [762]: https://github.com/openlawlibrary/taf/pull/762
 [759]: https://github.com/openlawlibrary/taf/pull/759

--- a/taf/api/api_workflow.py
+++ b/taf/api/api_workflow.py
@@ -198,12 +198,12 @@ def _resolve_key_id_pins(
     Given a single --key-pin and the roles about to be loaded, figure out which
     of the currently inserted YubiKeys the pin belongs to.
 
-    A YubiKey is a candidate if it is a valid signing key for at least one of
-    `all_roles`. If exactly one candidate is found, the pin is bound to its
-    keyid. Otherwise (no candidates, or more than one), the pin is not bound
-    to anything and a warning is logged - the caller falls back to the normal
-    interactive PIN prompt (or PIN_<serial>/PIN_<key_name> env vars) instead
-    of erroring out.
+    A YubiKey is a candidate if any of its occupied PIV slots holds a valid
+    signing key for at least one of `all_roles`. If exactly one candidate is
+    found, the pin is bound to its keyid. Otherwise (no candidates, or more
+    than one), the pin is not bound to anything and a warning is logged - the
+    caller falls back to the normal interactive PIN prompt (or
+    PIN_<serial>/PIN_<key_name> env vars) instead of erroring out.
     """
     import taf.yubikey.yubikey as yk
 
@@ -214,34 +214,35 @@ def _resolve_key_id_pins(
             "Passed in a --key-pin but no YubiKeys inserted. Please insert a YubiKey and try again."
         )
 
+    roles_of_interest = set(all_roles)
     candidates = []
     for serial_num in serial_nums:
         try:
-            public_key = yk.get_piv_public_key_tuf(serial=serial_num)
+            slot_keys = yk.get_piv_public_keys_tuf(serial=serial_num).get(
+                serial_num, {}
+            )
         except Exception as e:
             taf_logger.debug(
-                f"Could not read public key of YubiKey serial={serial_num}: {e}"
+                f"Could not read public keys of YubiKey serial={serial_num}: {e}"
             )
             continue
 
-        for role in all_roles:
-            try:
-                if auth_repo.is_valid_metadata_yubikey(role, public_key):
-                    candidates.append((serial_num, public_key))
-                    break
-            except TAFError:
-                continue
+        for public_key in slot_keys.values():
+            associated_roles = auth_repo.find_associated_roles_of_key(public_key)
+            if roles_of_interest.intersection(associated_roles):
+                candidates.append((serial_num, public_key))
 
     if len(candidates) == 1:
-        serial_num, public_key = candidates[0]
+        _, public_key = candidates[0]
         keyid = _get_legacy_keyid(public_key)
         return {keyid: key_pin}
 
-    candidate_serials = [serial_num for serial_num, _ in candidates]
+    serial_nums_str = [str(serial_num) for serial_num in serial_nums]
+    candidate_serials = [str(serial_num) for serial_num, _ in candidates]
     if not candidates:
         taf_logger.warning(
             f"Passed in a --key-pin, but none of the inserted YubiKeys "
-            f"({', '.join(serial_nums)}) are valid signing keys for "
+            f"({', '.join(serial_nums_str)}) are valid signing keys for "
             f"{', '.join(all_roles)}. Ignoring --key-pin."
         )
     else:

--- a/taf/api/api_workflow.py
+++ b/taf/api/api_workflow.py
@@ -139,7 +139,6 @@ def _setup_auth_repo_and_signers(
     Returns the auth_repo instance.
     """
     from taf.api.yubikey import get_yk_roles
-    import taf.yubikey.yubikey as yk
 
     keystore_path = kwargs.get("keystore")
 
@@ -166,26 +165,14 @@ def _setup_auth_repo_and_signers(
         raise TAFError("No roles specified")
     taf_logger.info(f"Loading keys of roles {', '.join(all_roles)}")
 
-    key_id_pins = None
+    key_pin = kwargs.get("key_pin")
+    key_id_pins: Dict = {}
+    if key_pin is not None:
+        key_id_pins = _resolve_key_id_pins(auth_repo, all_roles, key_pin)
 
-    if kwargs.get("key_pin") is not None:
-        serial_nums = yk.get_serial_nums()
-        if len(serial_nums) == 0:
-            taf_logger.error("No Yubikeys found")
-            raise TAFError(
-                "Passed in a --key-pin but no YubiKeys inserted. Please insert a YubiKey and try again."
-            )
-        if len(serial_nums) > 1:
-            taf_logger.error("Multiple Yubikeys found")
-            raise TAFError(
-                "Passed in a --key-pin but multiple YubiKeys inserted. Please insert only one YubiKey and try again."
-            )
-        serial_num = serial_nums[0]
-        public_key = yk.get_piv_public_key_tuf(serial=serial_num)
-        keyid = _get_legacy_keyid(public_key)
-        key_id_pins = {keyid: kwargs.get("key_pin")}
-
-    use_yubikeys_to_sign = key_id_pins is not None
+    # a supplied key pin still means "sign using YubiKeys", even if that pin
+    # could not be bound to a specific key
+    use_yubikeys_to_sign = key_pin is not None
     sorted_roles = sorted(all_roles, key=role_priority)
     auth_repo.pin_manager.auto_continue = True
 
@@ -202,6 +189,68 @@ def _setup_auth_repo_and_signers(
             auth_repo.add_signers_to_cache({role: yubikey_signers})
 
     return auth_repo
+
+
+def _resolve_key_id_pins(
+    auth_repo: AuthenticationRepository, all_roles: List[str], key_pin: str
+) -> Dict:
+    """
+    Given a single --key-pin and the roles about to be loaded, figure out which
+    of the currently inserted YubiKeys the pin belongs to.
+
+    A YubiKey is a candidate if it is a valid signing key for at least one of
+    `all_roles`. If exactly one candidate is found, the pin is bound to its
+    keyid. Otherwise (no candidates, or more than one), the pin is not bound
+    to anything and a warning is logged - the caller falls back to the normal
+    interactive PIN prompt (or PIN_<serial>/PIN_<key_name> env vars) instead
+    of erroring out.
+    """
+    import taf.yubikey.yubikey as yk
+
+    serial_nums = yk.get_serial_nums()
+    if len(serial_nums) == 0:
+        taf_logger.error("No Yubikeys found")
+        raise TAFError(
+            "Passed in a --key-pin but no YubiKeys inserted. Please insert a YubiKey and try again."
+        )
+
+    candidates = []
+    for serial_num in serial_nums:
+        try:
+            public_key = yk.get_piv_public_key_tuf(serial=serial_num)
+        except Exception as e:
+            taf_logger.debug(
+                f"Could not read public key of YubiKey serial={serial_num}: {e}"
+            )
+            continue
+
+        for role in all_roles:
+            try:
+                if auth_repo.is_valid_metadata_yubikey(role, public_key):
+                    candidates.append((serial_num, public_key))
+                    break
+            except TAFError:
+                continue
+
+    if len(candidates) == 1:
+        serial_num, public_key = candidates[0]
+        keyid = _get_legacy_keyid(public_key)
+        return {keyid: key_pin}
+
+    candidate_serials = [serial_num for serial_num, _ in candidates]
+    if not candidates:
+        taf_logger.warning(
+            f"Passed in a --key-pin, but none of the inserted YubiKeys "
+            f"({', '.join(serial_nums)}) are valid signing keys for "
+            f"{', '.join(all_roles)}. Ignoring --key-pin."
+        )
+    else:
+        taf_logger.warning(
+            f"Passed in a --key-pin, but multiple inserted YubiKeys "
+            f"({', '.join(candidate_serials)}) are valid signing keys for "
+            f"{', '.join(all_roles)}. --key-pin is ambiguous and will be ignored."
+        )
+    return {}
 
 
 def _map_keynames_to_keyids(

--- a/taf/api/api_workflow.py
+++ b/taf/api/api_workflow.py
@@ -170,8 +170,6 @@ def _setup_auth_repo_and_signers(
     if key_pin is not None:
         key_id_pins = _resolve_key_id_pins(auth_repo, all_roles, key_pin)
 
-    # a supplied key pin still means "sign using YubiKeys", even if that pin
-    # could not be bound to a specific key
     use_yubikeys_to_sign = key_pin is not None
     sorted_roles = sorted(all_roles, key=role_priority)
     auth_repo.pin_manager.auto_continue = True
@@ -199,10 +197,14 @@ def _resolve_key_id_pins(
     of the currently inserted YubiKeys the pin belongs to.
 
     A YubiKey is a candidate if any of its occupied PIV slots holds a valid
-    signing key for at least one of `all_roles`. If exactly one candidate is
-    found, the pin is bound to its keyid. Otherwise (no candidates, or more
-    than one), the pin is not bound to anything and a warning is logged - the
-    caller falls back to the normal interactive PIN prompt (or
+    signing key for at least one of `all_roles`. A single physical YubiKey
+    uses one PIN across all of its PIV slots, so if every candidate key comes
+    from the same device, the pin is bound to all of their keyids - that is
+    not ambiguous, even if more than one of its slots matched. It is only
+    ambiguous when candidate keys come from more than one distinct device. If
+    the pin can't be bound to a single device (no candidates, or candidates on
+    more than one device), it is not bound to anything and a warning is
+    logged - the caller falls back to the normal interactive PIN prompt (or
     PIN_<serial>/PIN_<key_name> env vars) instead of erroring out.
     """
     import taf.yubikey.yubikey as yk
@@ -232,13 +234,11 @@ def _resolve_key_id_pins(
             if roles_of_interest.intersection(associated_roles):
                 candidates.append((serial_num, public_key))
 
-    if len(candidates) == 1:
-        _, public_key = candidates[0]
-        keyid = _get_legacy_keyid(public_key)
-        return {keyid: key_pin}
+    candidate_serials = {serial_num for serial_num, _ in candidates}
+    if len(candidate_serials) == 1:
+        return {_get_legacy_keyid(public_key): key_pin for _, public_key in candidates}
 
     serial_nums_str = [str(serial_num) for serial_num in serial_nums]
-    candidate_serials = [str(serial_num) for serial_num, _ in candidates]
     if not candidates:
         taf_logger.warning(
             f"Passed in a --key-pin, but none of the inserted YubiKeys "
@@ -248,8 +248,9 @@ def _resolve_key_id_pins(
     else:
         taf_logger.warning(
             f"Passed in a --key-pin, but multiple inserted YubiKeys "
-            f"({', '.join(candidate_serials)}) are valid signing keys for "
-            f"{', '.join(all_roles)}. --key-pin is ambiguous and will be ignored."
+            f"({', '.join(str(s) for s in candidate_serials)}) are valid signing "
+            f"keys for {', '.join(all_roles)}. --key-pin is ambiguous and will be "
+            "ignored."
         )
     return {}
 

--- a/taf/tests/conftest.py
+++ b/taf/tests/conftest.py
@@ -59,6 +59,16 @@ def keystore_delegations():
 
 
 @pytest.fixture(scope="session")
+def real_public_key(keystore_delegations):
+    """Factory returning the real public key of a named key file in keystore_delegations."""
+
+    def _real_public_key(key_name):
+        return load_signer_from_file(keystore_delegations / key_name).public_key
+
+    return _real_public_key
+
+
+@pytest.fixture(scope="session")
 def mirrors_json_path():
     return MIRRORS_JSON_PATH
 

--- a/taf/tests/test_api/test_key_id_pins.py
+++ b/taf/tests/test_api/test_key_id_pins.py
@@ -1,15 +1,12 @@
 """Unit tests for `_resolve_key_id_pins` in `taf.api.api_workflow`."""
 
 import pytest
+from yubikit.piv import SLOT
 
 import taf.api.api_workflow as api_workflow
 import taf.yubikey.yubikey as yk
 from taf.exceptions import TAFError
-from taf.tuf.keys import _get_legacy_keyid, load_signer_from_file
-
-
-def _real_public_key(keystore_delegations, key_name):
-    return load_signer_from_file(keystore_delegations / key_name).public_key
+from taf.tuf.keys import _get_legacy_keyid
 
 
 def test_no_yubikeys_inserted_raises(monkeypatch, auth_repo):
@@ -20,12 +17,14 @@ def test_no_yubikeys_inserted_raises(monkeypatch, auth_repo):
 
 
 def test_single_yubikey_valid_for_role_binds_pin(
-    monkeypatch, auth_repo, keystore_delegations
+    monkeypatch, auth_repo, real_public_key
 ):
-    targets_key = _real_public_key(keystore_delegations, "targets1")
-    monkeypatch.setattr(yk, "get_serial_nums", lambda: ["1"])
+    targets_key = real_public_key("targets1")
+    monkeypatch.setattr(yk, "get_serial_nums", lambda: [1])
     monkeypatch.setattr(
-        yk, "get_piv_public_key_tuf", lambda serial: {"1": targets_key}[serial]
+        yk,
+        "get_piv_public_keys_tuf",
+        lambda serial: {serial: {SLOT.SIGNATURE: targets_key}},
     )
 
     result = api_workflow._resolve_key_id_pins(auth_repo, ["targets"], "111111")
@@ -34,19 +33,23 @@ def test_single_yubikey_valid_for_role_binds_pin(
 
 
 def test_multiple_yubikeys_only_one_valid_binds_pin_no_error(
-    monkeypatch, auth_repo, keystore_delegations
+    monkeypatch, auth_repo, real_public_key
 ):
     """The core bug fix: several YubiKeys inserted, only one of them is a
     valid signing key for the role(s) being loaded -> pin is bound to that
     one key, no TAFError is raised."""
-    root_key = _real_public_key(keystore_delegations, "root1")
-    targets_key = _real_public_key(keystore_delegations, "targets1")
-    unrelated_key = _real_public_key(keystore_delegations, "delegated_role1")
-    serial_to_key = {"1": root_key, "2": targets_key, "3": unrelated_key}
+    root_key = real_public_key("root1")
+    targets_key = real_public_key("targets1")
+    unrelated_key = real_public_key("delegated_role1")
+    serial_to_keys = {
+        1: {SLOT.SIGNATURE: root_key},
+        2: {SLOT.SIGNATURE: targets_key},
+        3: {SLOT.SIGNATURE: unrelated_key},
+    }
 
-    monkeypatch.setattr(yk, "get_serial_nums", lambda: ["1", "2", "3"])
+    monkeypatch.setattr(yk, "get_serial_nums", lambda: [1, 2, 3])
     monkeypatch.setattr(
-        yk, "get_piv_public_key_tuf", lambda serial: serial_to_key[serial]
+        yk, "get_piv_public_keys_tuf", lambda serial: {serial: serial_to_keys[serial]}
     )
 
     result = api_workflow._resolve_key_id_pins(auth_repo, ["targets"], "222222")
@@ -55,17 +58,20 @@ def test_multiple_yubikeys_only_one_valid_binds_pin_no_error(
 
 
 def test_multiple_yubikeys_multiple_valid_returns_empty_and_warns(
-    monkeypatch, auth_repo, keystore_delegations
+    monkeypatch, auth_repo, real_public_key
 ):
     # targets' threshold is 1 out of 2 keys, so both targets1 and targets2
     # are independently valid signing keys for "targets" -> ambiguous
-    targets1_key = _real_public_key(keystore_delegations, "targets1")
-    targets2_key = _real_public_key(keystore_delegations, "targets2")
-    serial_to_key = {"1": targets1_key, "2": targets2_key}
+    targets1_key = real_public_key("targets1")
+    targets2_key = real_public_key("targets2")
+    serial_to_keys = {
+        1: {SLOT.SIGNATURE: targets1_key},
+        2: {SLOT.SIGNATURE: targets2_key},
+    }
 
-    monkeypatch.setattr(yk, "get_serial_nums", lambda: ["1", "2"])
+    monkeypatch.setattr(yk, "get_serial_nums", lambda: [1, 2])
     monkeypatch.setattr(
-        yk, "get_piv_public_key_tuf", lambda serial: serial_to_key[serial]
+        yk, "get_piv_public_keys_tuf", lambda serial: {serial: serial_to_keys[serial]}
     )
 
     result = api_workflow._resolve_key_id_pins(auth_repo, ["targets"], "333333")
@@ -74,12 +80,16 @@ def test_multiple_yubikeys_multiple_valid_returns_empty_and_warns(
 
 
 def test_single_yubikey_not_valid_for_role_returns_empty_and_warns(
-    monkeypatch, auth_repo, keystore_delegations
+    monkeypatch, auth_repo, real_public_key
 ):
-    unrelated_key = _real_public_key(keystore_delegations, "delegated_role1")
+    unrelated_key = real_public_key("delegated_role1")
 
-    monkeypatch.setattr(yk, "get_serial_nums", lambda: ["1"])
-    monkeypatch.setattr(yk, "get_piv_public_key_tuf", lambda serial: unrelated_key)
+    monkeypatch.setattr(yk, "get_serial_nums", lambda: [1])
+    monkeypatch.setattr(
+        yk,
+        "get_piv_public_keys_tuf",
+        lambda serial: {serial: {SLOT.SIGNATURE: unrelated_key}},
+    )
 
     result = api_workflow._resolve_key_id_pins(auth_repo, ["targets"], "444444")
 
@@ -87,18 +97,38 @@ def test_single_yubikey_not_valid_for_role_returns_empty_and_warns(
 
 
 def test_unreadable_yubikey_is_skipped_others_still_resolved(
-    monkeypatch, auth_repo, keystore_delegations
+    monkeypatch, auth_repo, real_public_key
 ):
-    targets_key = _real_public_key(keystore_delegations, "targets1")
+    targets_key = real_public_key("targets1")
 
-    def fake_get_piv_public_key_tuf(serial):
-        if serial == "1":
+    def fake_get_piv_public_keys_tuf(serial):
+        if serial == 1:
             raise Exception("card error")
-        return targets_key
+        return {serial: {SLOT.SIGNATURE: targets_key}}
 
-    monkeypatch.setattr(yk, "get_serial_nums", lambda: ["1", "2"])
-    monkeypatch.setattr(yk, "get_piv_public_key_tuf", fake_get_piv_public_key_tuf)
+    monkeypatch.setattr(yk, "get_serial_nums", lambda: [1, 2])
+    monkeypatch.setattr(yk, "get_piv_public_keys_tuf", fake_get_piv_public_keys_tuf)
 
     result = api_workflow._resolve_key_id_pins(auth_repo, ["targets"], "555555")
 
     assert result == {_get_legacy_keyid(targets_key): "555555"}
+
+
+def test_key_on_non_signature_slot_still_resolved(
+    monkeypatch, auth_repo, real_public_key
+):
+    """A valid signing key sitting in a non-SIGNATURE PIV slot must still be
+    found - _resolve_key_id_pins should not assume SIGNATURE is the only
+    occupied slot."""
+    targets_key = real_public_key("targets1")
+
+    monkeypatch.setattr(yk, "get_serial_nums", lambda: [1])
+    monkeypatch.setattr(
+        yk,
+        "get_piv_public_keys_tuf",
+        lambda serial: {serial: {SLOT.AUTHENTICATION: targets_key}},
+    )
+
+    result = api_workflow._resolve_key_id_pins(auth_repo, ["targets"], "666666")
+
+    assert result == {_get_legacy_keyid(targets_key): "666666"}

--- a/taf/tests/test_api/test_key_id_pins.py
+++ b/taf/tests/test_api/test_key_id_pins.py
@@ -1,142 +1,104 @@
-"""Unit tests for `_resolve_key_id_pins` in `taf.api.api_workflow`.
-
-These cover the behavior that lets `--key-pin` be used even when multiple
-YubiKeys are inserted, as long as the PIN can be unambiguously associated
-with one of them (i.e. exactly one inserted YubiKey is a valid signing key
-for the roles being loaded).
-"""
-
-from unittest.mock import MagicMock
+"""Unit tests for `_resolve_key_id_pins` in `taf.api.api_workflow`."""
 
 import pytest
 
 import taf.api.api_workflow as api_workflow
 import taf.yubikey.yubikey as yk
 from taf.exceptions import TAFError
-from taf.tuf.keys import _get_legacy_keyid
+from taf.tuf.keys import _get_legacy_keyid, load_signer_from_file
 
 
-class FakeAuthRepo:
-    """Minimal stand-in for AuthenticationRepository.
-
-    `valid_for` maps a role name to the set of public keys (by identity)
-    that are considered valid signing keys for that role.
-    """
-
-    def __init__(self, valid_for):
-        self.valid_for = valid_for
-
-    def is_valid_metadata_yubikey(self, role, public_key=None):
-        return public_key in self.valid_for.get(role, set())
+def _real_public_key(keystore_delegations, key_name):
+    return load_signer_from_file(keystore_delegations / key_name).public_key
 
 
-def _fake_public_key(name):
-    # A distinct sentinel object per "key"; only used for identity comparisons
-    # and passed through _get_legacy_keyid, which is monkeypatched in tests
-    # that need a concrete keyid.
-    return MagicMock(name=name)
-
-
-def test_no_yubikeys_inserted_raises(monkeypatch):
+def test_no_yubikeys_inserted_raises(monkeypatch, auth_repo):
     monkeypatch.setattr(yk, "get_serial_nums", lambda: [])
-    auth_repo = FakeAuthRepo(valid_for={})
 
     with pytest.raises(TAFError):
         api_workflow._resolve_key_id_pins(auth_repo, ["targets"], "111111")
 
 
-def test_single_yubikey_valid_for_role_binds_pin(monkeypatch):
-    key = _fake_public_key("key-1234")
-    monkeypatch.setattr(yk, "get_serial_nums", lambda: ["1234"])
+def test_single_yubikey_valid_for_role_binds_pin(
+    monkeypatch, auth_repo, keystore_delegations
+):
+    targets_key = _real_public_key(keystore_delegations, "targets1")
+    monkeypatch.setattr(yk, "get_serial_nums", lambda: ["1"])
     monkeypatch.setattr(
-        yk, "get_piv_public_key_tuf", lambda serial: {"1234": key}[serial]
+        yk, "get_piv_public_key_tuf", lambda serial: {"1": targets_key}[serial]
     )
-    monkeypatch.setattr(
-        api_workflow, "_get_legacy_keyid", lambda public_key: "keyid-1234"
-    )
-    auth_repo = FakeAuthRepo(valid_for={"targets": {key}})
 
     result = api_workflow._resolve_key_id_pins(auth_repo, ["targets"], "111111")
 
-    assert result == {"keyid-1234": "111111"}
+    assert result == {_get_legacy_keyid(targets_key): "111111"}
 
 
-def test_multiple_yubikeys_only_one_valid_binds_pin_no_error(monkeypatch):
+def test_multiple_yubikeys_only_one_valid_binds_pin_no_error(
+    monkeypatch, auth_repo, keystore_delegations
+):
     """The core bug fix: several YubiKeys inserted, only one of them is a
     valid signing key for the role(s) being loaded -> pin is bound to that
     one key, no TAFError is raised."""
-    key_a = _fake_public_key("key-a")
-    key_b = _fake_public_key("key-b")
-    key_c = _fake_public_key("key-c")
-    serial_to_key = {"1": key_a, "2": key_b, "3": key_c}
+    root_key = _real_public_key(keystore_delegations, "root1")
+    targets_key = _real_public_key(keystore_delegations, "targets1")
+    unrelated_key = _real_public_key(keystore_delegations, "delegated_role1")
+    serial_to_key = {"1": root_key, "2": targets_key, "3": unrelated_key}
 
     monkeypatch.setattr(yk, "get_serial_nums", lambda: ["1", "2", "3"])
     monkeypatch.setattr(
         yk, "get_piv_public_key_tuf", lambda serial: serial_to_key[serial]
     )
-    monkeypatch.setattr(
-        api_workflow,
-        "_get_legacy_keyid",
-        lambda public_key: {key_a: "keyid-a", key_b: "keyid-b", key_c: "keyid-c"}[
-            public_key
-        ],
-    )
-    # Only key_b is valid for "targets"
-    auth_repo = FakeAuthRepo(valid_for={"targets": {key_b}})
 
     result = api_workflow._resolve_key_id_pins(auth_repo, ["targets"], "222222")
 
-    assert result == {"keyid-b": "222222"}
+    assert result == {_get_legacy_keyid(targets_key): "222222"}
 
 
-def test_multiple_yubikeys_multiple_valid_returns_empty_and_warns(monkeypatch):
-    key_a = _fake_public_key("key-a")
-    key_b = _fake_public_key("key-b")
-    serial_to_key = {"1": key_a, "2": key_b}
+def test_multiple_yubikeys_multiple_valid_returns_empty_and_warns(
+    monkeypatch, auth_repo, keystore_delegations
+):
+    # targets' threshold is 1 out of 2 keys, so both targets1 and targets2
+    # are independently valid signing keys for "targets" -> ambiguous
+    targets1_key = _real_public_key(keystore_delegations, "targets1")
+    targets2_key = _real_public_key(keystore_delegations, "targets2")
+    serial_to_key = {"1": targets1_key, "2": targets2_key}
 
     monkeypatch.setattr(yk, "get_serial_nums", lambda: ["1", "2"])
     monkeypatch.setattr(
         yk, "get_piv_public_key_tuf", lambda serial: serial_to_key[serial]
     )
-    # Both keys are valid for "targets" -> ambiguous
-    auth_repo = FakeAuthRepo(valid_for={"targets": {key_a, key_b}})
 
     result = api_workflow._resolve_key_id_pins(auth_repo, ["targets"], "333333")
 
     assert result == {}
 
 
-def test_single_yubikey_not_valid_for_role_returns_empty_and_warns(monkeypatch):
-    key_a = _fake_public_key("key-a")
+def test_single_yubikey_not_valid_for_role_returns_empty_and_warns(
+    monkeypatch, auth_repo, keystore_delegations
+):
+    unrelated_key = _real_public_key(keystore_delegations, "delegated_role1")
 
     monkeypatch.setattr(yk, "get_serial_nums", lambda: ["1"])
-    monkeypatch.setattr(yk, "get_piv_public_key_tuf", lambda serial: key_a)
-    # No roles valid for this key
-    auth_repo = FakeAuthRepo(valid_for={})
+    monkeypatch.setattr(yk, "get_piv_public_key_tuf", lambda serial: unrelated_key)
 
     result = api_workflow._resolve_key_id_pins(auth_repo, ["targets"], "444444")
 
     assert result == {}
 
 
-def test_unreadable_yubikey_is_skipped_others_still_resolved(monkeypatch):
-    key_b = _fake_public_key("key-b")
+def test_unreadable_yubikey_is_skipped_others_still_resolved(
+    monkeypatch, auth_repo, keystore_delegations
+):
+    targets_key = _real_public_key(keystore_delegations, "targets1")
 
     def fake_get_piv_public_key_tuf(serial):
         if serial == "1":
             raise Exception("card error")
-        return key_b
+        return targets_key
 
     monkeypatch.setattr(yk, "get_serial_nums", lambda: ["1", "2"])
     monkeypatch.setattr(yk, "get_piv_public_key_tuf", fake_get_piv_public_key_tuf)
-    monkeypatch.setattr(api_workflow, "_get_legacy_keyid", lambda public_key: "keyid-b")
-    auth_repo = FakeAuthRepo(valid_for={"targets": {key_b}})
 
     result = api_workflow._resolve_key_id_pins(auth_repo, ["targets"], "555555")
 
-    assert result == {"keyid-b": "555555"}
-
-
-def test_get_legacy_keyid_still_importable():
-    # sanity check the real helper is importable from where api_workflow expects it
-    assert callable(_get_legacy_keyid)
+    assert result == {_get_legacy_keyid(targets_key): "555555"}

--- a/taf/tests/test_api/test_key_id_pins.py
+++ b/taf/tests/test_api/test_key_id_pins.py
@@ -60,8 +60,6 @@ def test_multiple_yubikeys_only_one_valid_binds_pin_no_error(
 def test_multiple_yubikeys_multiple_valid_returns_empty_and_warns(
     monkeypatch, auth_repo, real_public_key
 ):
-    # targets' threshold is 1 out of 2 keys, so both targets1 and targets2
-    # are independently valid signing keys for "targets" -> ambiguous
     targets1_key = real_public_key("targets1")
     targets2_key = real_public_key("targets2")
     serial_to_keys = {
@@ -112,6 +110,32 @@ def test_unreadable_yubikey_is_skipped_others_still_resolved(
     result = api_workflow._resolve_key_id_pins(auth_repo, ["targets"], "555555")
 
     assert result == {_get_legacy_keyid(targets_key): "555555"}
+
+
+def test_single_yubikey_two_valid_slots_binds_pin_to_both_not_ambiguous(
+    monkeypatch, auth_repo, real_public_key
+):
+    """A single physical YubiKey uses one PIN for every PIV slot, so finding
+    two valid signing keys on it (one per slot) must not be treated as
+    ambiguous - the pin is bound to both keyids."""
+    root1_key = real_public_key("root1")
+    root2_key = real_public_key("root2")
+
+    monkeypatch.setattr(yk, "get_serial_nums", lambda: [1])
+    monkeypatch.setattr(
+        yk,
+        "get_piv_public_keys_tuf",
+        lambda serial: {
+            serial: {SLOT.SIGNATURE: root1_key, SLOT.AUTHENTICATION: root2_key}
+        },
+    )
+
+    result = api_workflow._resolve_key_id_pins(auth_repo, ["root"], "777777")
+
+    assert result == {
+        _get_legacy_keyid(root1_key): "777777",
+        _get_legacy_keyid(root2_key): "777777",
+    }
 
 
 def test_key_on_non_signature_slot_still_resolved(

--- a/taf/tests/test_api/test_key_id_pins.py
+++ b/taf/tests/test_api/test_key_id_pins.py
@@ -1,0 +1,142 @@
+"""Unit tests for `_resolve_key_id_pins` in `taf.api.api_workflow`.
+
+These cover the behavior that lets `--key-pin` be used even when multiple
+YubiKeys are inserted, as long as the PIN can be unambiguously associated
+with one of them (i.e. exactly one inserted YubiKey is a valid signing key
+for the roles being loaded).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import taf.api.api_workflow as api_workflow
+import taf.yubikey.yubikey as yk
+from taf.exceptions import TAFError
+from taf.tuf.keys import _get_legacy_keyid
+
+
+class FakeAuthRepo:
+    """Minimal stand-in for AuthenticationRepository.
+
+    `valid_for` maps a role name to the set of public keys (by identity)
+    that are considered valid signing keys for that role.
+    """
+
+    def __init__(self, valid_for):
+        self.valid_for = valid_for
+
+    def is_valid_metadata_yubikey(self, role, public_key=None):
+        return public_key in self.valid_for.get(role, set())
+
+
+def _fake_public_key(name):
+    # A distinct sentinel object per "key"; only used for identity comparisons
+    # and passed through _get_legacy_keyid, which is monkeypatched in tests
+    # that need a concrete keyid.
+    return MagicMock(name=name)
+
+
+def test_no_yubikeys_inserted_raises(monkeypatch):
+    monkeypatch.setattr(yk, "get_serial_nums", lambda: [])
+    auth_repo = FakeAuthRepo(valid_for={})
+
+    with pytest.raises(TAFError):
+        api_workflow._resolve_key_id_pins(auth_repo, ["targets"], "111111")
+
+
+def test_single_yubikey_valid_for_role_binds_pin(monkeypatch):
+    key = _fake_public_key("key-1234")
+    monkeypatch.setattr(yk, "get_serial_nums", lambda: ["1234"])
+    monkeypatch.setattr(
+        yk, "get_piv_public_key_tuf", lambda serial: {"1234": key}[serial]
+    )
+    monkeypatch.setattr(
+        api_workflow, "_get_legacy_keyid", lambda public_key: "keyid-1234"
+    )
+    auth_repo = FakeAuthRepo(valid_for={"targets": {key}})
+
+    result = api_workflow._resolve_key_id_pins(auth_repo, ["targets"], "111111")
+
+    assert result == {"keyid-1234": "111111"}
+
+
+def test_multiple_yubikeys_only_one_valid_binds_pin_no_error(monkeypatch):
+    """The core bug fix: several YubiKeys inserted, only one of them is a
+    valid signing key for the role(s) being loaded -> pin is bound to that
+    one key, no TAFError is raised."""
+    key_a = _fake_public_key("key-a")
+    key_b = _fake_public_key("key-b")
+    key_c = _fake_public_key("key-c")
+    serial_to_key = {"1": key_a, "2": key_b, "3": key_c}
+
+    monkeypatch.setattr(yk, "get_serial_nums", lambda: ["1", "2", "3"])
+    monkeypatch.setattr(
+        yk, "get_piv_public_key_tuf", lambda serial: serial_to_key[serial]
+    )
+    monkeypatch.setattr(
+        api_workflow,
+        "_get_legacy_keyid",
+        lambda public_key: {key_a: "keyid-a", key_b: "keyid-b", key_c: "keyid-c"}[
+            public_key
+        ],
+    )
+    # Only key_b is valid for "targets"
+    auth_repo = FakeAuthRepo(valid_for={"targets": {key_b}})
+
+    result = api_workflow._resolve_key_id_pins(auth_repo, ["targets"], "222222")
+
+    assert result == {"keyid-b": "222222"}
+
+
+def test_multiple_yubikeys_multiple_valid_returns_empty_and_warns(monkeypatch):
+    key_a = _fake_public_key("key-a")
+    key_b = _fake_public_key("key-b")
+    serial_to_key = {"1": key_a, "2": key_b}
+
+    monkeypatch.setattr(yk, "get_serial_nums", lambda: ["1", "2"])
+    monkeypatch.setattr(
+        yk, "get_piv_public_key_tuf", lambda serial: serial_to_key[serial]
+    )
+    # Both keys are valid for "targets" -> ambiguous
+    auth_repo = FakeAuthRepo(valid_for={"targets": {key_a, key_b}})
+
+    result = api_workflow._resolve_key_id_pins(auth_repo, ["targets"], "333333")
+
+    assert result == {}
+
+
+def test_single_yubikey_not_valid_for_role_returns_empty_and_warns(monkeypatch):
+    key_a = _fake_public_key("key-a")
+
+    monkeypatch.setattr(yk, "get_serial_nums", lambda: ["1"])
+    monkeypatch.setattr(yk, "get_piv_public_key_tuf", lambda serial: key_a)
+    # No roles valid for this key
+    auth_repo = FakeAuthRepo(valid_for={})
+
+    result = api_workflow._resolve_key_id_pins(auth_repo, ["targets"], "444444")
+
+    assert result == {}
+
+
+def test_unreadable_yubikey_is_skipped_others_still_resolved(monkeypatch):
+    key_b = _fake_public_key("key-b")
+
+    def fake_get_piv_public_key_tuf(serial):
+        if serial == "1":
+            raise Exception("card error")
+        return key_b
+
+    monkeypatch.setattr(yk, "get_serial_nums", lambda: ["1", "2"])
+    monkeypatch.setattr(yk, "get_piv_public_key_tuf", fake_get_piv_public_key_tuf)
+    monkeypatch.setattr(api_workflow, "_get_legacy_keyid", lambda public_key: "keyid-b")
+    auth_repo = FakeAuthRepo(valid_for={"targets": {key_b}})
+
+    result = api_workflow._resolve_key_id_pins(auth_repo, ["targets"], "555555")
+
+    assert result == {"keyid-b": "555555"}
+
+
+def test_get_legacy_keyid_still_importable():
+    # sanity check the real helper is importable from where api_workflow expects it
+    assert callable(_get_legacy_keyid)


### PR DESCRIPTION
Previously any --key-pin usage hard-errored as soon as more than one YubiKey was inserted, since the pin could only be bound to "the" single detected key. Instead, narrow the inserted YubiKeys down to those that are valid signing keys for the roles being loaded; if exactly one candidate remains, bind the pin to it. If the result is still ambiguous (zero or multiple candidates), fall back to the existing interactive PIN prompt instead of raising.

## Description (e.g. "Related to ...", etc.)

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
