### PR TITLE
fix: allow overriding TempPartition's temp directory via TAF_TMP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Added
 
+- Allow overriding the temp directory used when cloning repositories via an anv var ([771])
 - Sign and discover keys across all YubiKey PIV slots, not just SIGNATURE ([767])
 - Support choosing a YubiKey PIV slot when setting up signing keys ([759])
 
@@ -26,7 +27,6 @@ and this project adheres to [Semantic Versioning][semver].
 - Clone no longer fails when the repository path contains a space (e.g. a Windows home directory with a space in the user name) ([762])
 - Surface the underlying git error when a clone fails, instead of hiding it behind a generic access message ([762])
 - Correct the clone access error that rendered as "Cannot None ..." and stop misattributing a local failure to an access/authentication problem ([762])
-- Allow overriding the temp directory used when cloning repositories via the `TAF_TMP` environment variable, to avoid permission errors when the default location isn't writable ([771])
 
 
 [771]: https://github.com/openlawlibrary/taf/pull/771

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,10 @@ and this project adheres to [Semantic Versioning][semver].
 - Clone no longer fails when the repository path contains a space (e.g. a Windows home directory with a space in the user name) ([762])
 - Surface the underlying git error when a clone fails, instead of hiding it behind a generic access message ([762])
 - Correct the clone access error that rendered as "Cannot None ..." and stop misattributing a local failure to an access/authentication problem ([762])
+- Allow overriding the temp directory used when cloning repositories via the `TAF_TMP` environment variable, to avoid permission errors when the default location isn't writable ([771])
 
 
+[771]: https://github.com/openlawlibrary/taf/pull/771
 [762]: https://github.com/openlawlibrary/taf/pull/762
 [759]: https://github.com/openlawlibrary/taf/pull/759
 [757]: https://github.com/openlawlibrary/taf/pull/757

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ kwargs = {
         "colorama>=0.3.9",
         "tuf==5.*",
         "cryptography==43.0.*",
-        "securesystemslib==1.*",
+        "securesystemslib==1.4.*",
         "loguru==0.7.*",
         'pygit2==1.9.*; python_version < "3.11"',
         'pygit2==1.14.*; python_version >= "3.11"',

--- a/taf/utils.py
+++ b/taf/utils.py
@@ -575,14 +575,20 @@ class TempPartition:
 
     def __init__(self, ref_path):
         self.ref_partition = self.get_partition_root(ref_path)
-        temp_dir_partition = self.get_partition_root(Path(tempfile.gettempdir()))
+        configured_dir = os.environ.get("TAF_TMP")
 
-        if temp_dir_partition == self.ref_partition:
-            self.temp_dir = Path(tempfile.mkdtemp())
+        if configured_dir:
+            taf_dir = Path(configured_dir)
+            taf_dir.mkdir(parents=True, exist_ok=True)
+            self.temp_dir = Path(tempfile.mkdtemp(dir=str(taf_dir)))
         else:
-            taf_dir = self.ref_partition / ".taf"
-            taf_dir.mkdir(exist_ok=True)
-            self.temp_dir = tempfile.mkdtemp(dir=str(taf_dir))
+            temp_dir_partition = self.get_partition_root(Path(tempfile.gettempdir()))
+            if temp_dir_partition == self.ref_partition:
+                self.temp_dir = Path(tempfile.mkdtemp())
+            else:
+                taf_dir = self.ref_partition / ".taf"
+                taf_dir.mkdir(exist_ok=True)
+                self.temp_dir = Path(tempfile.mkdtemp(dir=str(taf_dir)))
         self._sweep_stale_trash()
 
     def _sweep_stale_trash(self):


### PR DESCRIPTION

## Description (e.g. "Related to ...", etc.)

TempPartition falls back to creating a hidden .taf directory at the root of the filesystem partition containing the repository being updated whenever that partition differs from the system temp dir's. If the caller lacks write access to that partition root (e.g. it's /), updates fail with a permission error and there's no way to point it elsewhere. TAF_TMP, when set, is now used directly instead.


## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
