### PR TITLE
fix(updater): resolve allow-unauthenticated-commits per auth commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,14 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Disallowing unauthenticated commits no longer invalidates already-signed history ([774])
 - Detect signing scheme from key material instead of assuming RSA ([757])
 - Clone no longer fails when the repository path contains a space (e.g. a Windows home directory with a space in the user name) ([762])
 - Surface the underlying git error when a clone fails, instead of hiding it behind a generic access message ([762])
 - Correct the clone access error that rendered as "Cannot None ..." and stop misattributing a local failure to an access/authentication problem ([762])
 
 
+[774]: https://github.com/openlawlibrary/taf/pull/774
 [771]: https://github.com/openlawlibrary/taf/pull/771
 [767]: https://github.com/openlawlibrary/taf/pull/767
 [762]: https://github.com/openlawlibrary/taf/pull/762

--- a/taf/repositoriesdb.py
+++ b/taf/repositoriesdb.py
@@ -1,6 +1,6 @@
 import ast
 import json
-from typing import Callable, Dict, List, Optional, Type
+from typing import Any, Callable, Dict, List, Optional, Type
 from pathlib import Path
 from taf.auth_repo import AuthenticationRepository
 from taf.constants import TARGETS_DIRECTORY_NAME
@@ -940,6 +940,22 @@ def load_repositories_json(
             return None
         else:
             raise
+
+
+def get_repository_custom_at(
+    auth_repo: AuthenticationRepository,
+    repo_name: str,
+    commit: Commitish,
+    target_custom: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
+    repositories_json = load_repositories_json(auth_repo, commit)
+    if repositories_json is None:
+        return None
+    repo_data = (repositories_json.get("repositories") or {}).get(repo_name)
+    if repo_data is None:
+        return None
+    target = {"custom": target_custom} if target_custom is not None else None
+    return _get_custom_data(repo_data, target)
 
 
 def load_mirrors_json(

--- a/taf/tests/test_updater/conftest.py
+++ b/taf/tests/test_updater/conftest.py
@@ -596,6 +596,63 @@ def add_unauthenticated_commit_to_target_repo(target_repos: list, target_name: s
             update_target_repository(target_repo, "Update target files")
 
 
+def set_allow_unauthenticated_commits(
+    auth_repo: AuthenticationRepository,
+    pin_manager: PinManager,
+    target_repos: list,
+    allow: Optional[bool],
+    target_name: Optional[str] = None,
+    sign_target_pointers: bool = False,
+):
+    """Rewrite targets/repositories.json of the authentication repository, setting
+    allow-unauthenticated-commits of the matching target repositories to `allow`,
+    then sign and commit the change. If `allow` is None, the key is removed from
+    custom instead of being set, so that its absence (defaulting to False) can be
+    tested the same way as an explicit False.
+
+    If sign_target_pointers is False (the default), sign_target_files is used. It
+    signs the targets directory as-is, so the resulting authentication commit only
+    changes repositories.json and leaves every per-repo target file (its commit and
+    branch pointer) untouched.
+    If sign_target_pointers is True, sign_target_repositories is used instead. It
+    also regenerates the per-repo target files based on the current target HEADs,
+    meaning that the flag change and a target repository advance are recorded in
+    the same authentication commit.
+    """
+    repositories_json_path = (
+        auth_repo.path / TARGETS_DIRECTORY_NAME / REPOSITORIES_JSON_NAME
+    )
+    repositories_json = json.loads(repositories_json_path.read_text())
+    for name, repo_data in repositories_json["repositories"].items():
+        if target_name is None or target_name in name:
+            custom = repo_data.setdefault("custom", {})
+            if allow is None:
+                custom.pop("allow-unauthenticated-commits", None)
+            else:
+                custom["allow-unauthenticated-commits"] = allow
+    repositories_json_path.write_text(json.dumps(repositories_json, indent=4))
+
+    for target_repo in target_repos:
+        if target_name is None or target_name in target_repo.name:
+            if allow is None:
+                target_repo.custom.pop("allow-unauthenticated-commits", None)
+            else:
+                target_repo.custom["allow-unauthenticated-commits"] = allow
+
+    if sign_target_pointers:
+        update_target_repos_from_repositories_json(
+            str(Path(TEST_DATA_ORIGIN_PATH, auth_repo.name)),
+            pin_manager,
+            str(TEST_DATA_ORIGIN_PATH),
+            str(KEYSTORE_PATH),
+            skip_clean_check=True,
+        )
+    else:
+        sign_target_files(
+            TEST_DATA_ORIGIN_PATH, auth_repo.name, KEYSTORE_PATH, pin_manager
+        )
+
+
 def create_new_target_orphan_branches(
     auth_repo: AuthenticationRepository,
     target_repos: list,

--- a/taf/tests/test_updater/test_clone/test_clone_invalid.py
+++ b/taf/tests/test_updater/test_clone/test_clone_invalid.py
@@ -11,9 +11,12 @@ from taf.tests.test_updater.conftest import (
     WRONG_UPDATE_TYPE_TEST_REPO,
     SetupManager,
     SetupState,
+    add_unauthenticated_commit_to_target_repo,
     add_unauthenticated_commits_to_all_target_repos,
     add_valid_target_commits,
+    add_valid_unauthenticated_commits,
     clone_client_repo,
+    set_allow_unauthenticated_commits,
     swap_last_two_commits,
     update_expiration_dates,
     update_timestamp_metadata_invalid_signature,
@@ -70,6 +73,124 @@ def test_clone_invalid_target_repositories_contain_unsigned_commits(
     setup_manager = SetupManager(origin_auth_repo)
     setup_manager.add_task(add_unauthenticated_commits_to_all_target_repos)
     setup_manager.add_task(add_valid_target_commits)
+    setup_manager.execute_tasks()
+
+    update_invalid_repos_and_check_if_repos_exist(
+        OperationType.CLONE,
+        origin_auth_repo,
+        client_dir,
+        TARGET_MISSMATCH_PATTERN,
+        True,
+    )
+    client_auth_repo = AuthenticationRepository(client_dir, origin_auth_repo.name)
+    # make sure that the last validated commit does not exist
+    check_if_last_validated_commit_exists(client_auth_repo, True)
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [
+                {"name": "target1", "allow_unauthenticated_commits": True},
+                {"name": "target2"},
+            ],
+        },
+    ],
+    indirect=True,
+)
+def test_clone_invalid_unauthenticated_commits_after_disallowing(
+    origin_auth_repo, client_dir
+):
+    setup_manager = SetupManager(origin_auth_repo)
+    setup_manager.add_task(add_valid_target_commits)
+    setup_manager.add_task(
+        set_allow_unauthenticated_commits,
+        kwargs={"allow": False, "target_name": "target1"},
+    )
+    setup_manager.add_task(
+        add_unauthenticated_commit_to_target_repo, kwargs={"target_name": "target1"}
+    )
+    setup_manager.add_task(add_valid_target_commits)
+    setup_manager.execute_tasks()
+
+    update_invalid_repos_and_check_if_repos_exist(
+        OperationType.CLONE,
+        origin_auth_repo,
+        client_dir,
+        TARGET_MISSMATCH_PATTERN,
+        True,
+    )
+    client_auth_repo = AuthenticationRepository(client_dir, origin_auth_repo.name)
+    # make sure that the last validated commit does not exist
+    check_if_last_validated_commit_exists(client_auth_repo, True)
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [
+                {"name": "target1", "allow_unauthenticated_commits": True},
+                {"name": "target2"},
+            ],
+        },
+    ],
+    indirect=True,
+)
+def test_clone_invalid_unauthenticated_commits_after_removing_allow_key(
+    origin_auth_repo, client_dir
+):
+    setup_manager = SetupManager(origin_auth_repo)
+    setup_manager.add_task(add_valid_target_commits)
+    setup_manager.add_task(
+        set_allow_unauthenticated_commits,
+        kwargs={"allow": None, "target_name": "target1"},
+    )
+    setup_manager.add_task(
+        add_unauthenticated_commit_to_target_repo, kwargs={"target_name": "target1"}
+    )
+    setup_manager.add_task(add_valid_target_commits)
+    setup_manager.execute_tasks()
+
+    update_invalid_repos_and_check_if_repos_exist(
+        OperationType.CLONE,
+        origin_auth_repo,
+        client_dir,
+        TARGET_MISSMATCH_PATTERN,
+        True,
+    )
+    client_auth_repo = AuthenticationRepository(client_dir, origin_auth_repo.name)
+    # make sure that the last validated commit does not exist
+    check_if_last_validated_commit_exists(client_auth_repo, True)
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [
+                {"name": "target1", "allow_unauthenticated_commits": True},
+                {"name": "target2"},
+            ],
+        },
+    ],
+    indirect=True,
+)
+def test_clone_invalid_disallowing_unauthenticated_commits_with_pending_gap(
+    origin_auth_repo, client_dir
+):
+    setup_manager = SetupManager(origin_auth_repo)
+    setup_manager.add_task(add_valid_target_commits)
+    setup_manager.add_task(add_valid_unauthenticated_commits, kwargs={"repetitions": 2})
+    setup_manager.add_task(
+        set_allow_unauthenticated_commits,
+        kwargs={
+            "allow": False,
+            "target_name": "target1",
+            "sign_target_pointers": True,
+        },
+    )
     setup_manager.execute_tasks()
 
     update_invalid_repos_and_check_if_repos_exist(

--- a/taf/tests/test_updater/test_clone/test_clone_valid.py
+++ b/taf/tests/test_updater/test_clone/test_clone_valid.py
@@ -7,6 +7,7 @@ from taf.tests.test_updater.conftest import (
     add_valid_unauthenticated_commits,
     clone_client_repo,
     create_new_target_orphan_branches,
+    set_allow_unauthenticated_commits,
     update_and_sign_metadata_without_clean_check,
     update_expiration_dates,
     update_role_metadata_without_signing,
@@ -105,6 +106,74 @@ def test_clone_valid_with_unauthenticated_commits(origin_auth_repo, client_dir):
     setup_manager.add_task(add_valid_unauthenticated_commits)
     setup_manager.add_task(add_valid_target_commits)
     setup_manager.add_task(add_valid_unauthenticated_commits)
+    setup_manager.execute_tasks()
+
+    update_and_check_commit_shas(
+        OperationType.CLONE,
+        origin_auth_repo,
+        client_dir,
+        expected_repo_type=UpdateType.OFFICIAL,
+    )
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [
+                {"name": "target1", "allow_unauthenticated_commits": True},
+                {"name": "target2"},
+            ],
+        },
+    ],
+    indirect=True,
+)
+def test_clone_valid_after_disallowing_unauthenticated_commits(
+    origin_auth_repo, client_dir
+):
+    setup_manager = SetupManager(origin_auth_repo)
+    setup_manager.add_task(add_valid_target_commits)
+    setup_manager.add_task(add_valid_unauthenticated_commits)
+    setup_manager.add_task(add_valid_target_commits)
+    setup_manager.add_task(
+        set_allow_unauthenticated_commits,
+        kwargs={"allow": False, "target_name": "target1"},
+    )
+    setup_manager.add_task(add_valid_target_commits)
+    setup_manager.execute_tasks()
+
+    update_and_check_commit_shas(
+        OperationType.CLONE,
+        origin_auth_repo,
+        client_dir,
+        expected_repo_type=UpdateType.OFFICIAL,
+    )
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [
+                {"name": "target1", "allow_unauthenticated_commits": True},
+                {"name": "target2"},
+            ],
+        },
+    ],
+    indirect=True,
+)
+def test_clone_valid_after_removing_allow_unauthenticated_commits_key(
+    origin_auth_repo, client_dir
+):
+    setup_manager = SetupManager(origin_auth_repo)
+    setup_manager.add_task(add_valid_target_commits)
+    setup_manager.add_task(add_valid_unauthenticated_commits)
+    setup_manager.add_task(add_valid_target_commits)
+    setup_manager.add_task(
+        set_allow_unauthenticated_commits,
+        kwargs={"allow": None, "target_name": "target1"},
+    )
+    setup_manager.add_task(add_valid_target_commits)
     setup_manager.execute_tasks()
 
     update_and_check_commit_shas(

--- a/taf/tests/test_updater/test_update/test_update_valid.py
+++ b/taf/tests/test_updater/test_update/test_update_valid.py
@@ -12,6 +12,7 @@ from taf.tests.test_updater.conftest import (
     remove_last_validated_commit,
     remove_last_validated_data,
     revert_last_validated_commit,
+    set_allow_unauthenticated_commits,
     update_and_sign_metadata_without_clean_check,
     update_expiration_dates,
     update_role_metadata_without_signing,
@@ -107,6 +108,47 @@ def test_update_valid_when_unauthenticated_commits(origin_auth_repo, client_dir)
     setup_manager.add_task(add_valid_unauthenticated_commits)
     setup_manager.add_task(add_valid_target_commits)
     setup_manager.add_task(add_valid_unauthenticated_commits)
+    setup_manager.execute_tasks()
+
+    update_and_check_commit_shas(
+        OperationType.UPDATE,
+        origin_auth_repo,
+        client_dir,
+    )
+
+
+@pytest.mark.parametrize(
+    "origin_auth_repo",
+    [
+        {
+            "targets_config": [
+                {"name": "target1", "allow_unauthenticated_commits": True},
+                {"name": "target2"},
+            ],
+        },
+    ],
+    indirect=True,
+)
+def test_update_valid_after_disallowing_unauthenticated_commits(
+    origin_auth_repo, client_dir
+):
+    setup_manager = SetupManager(origin_auth_repo)
+    setup_manager.add_task(add_valid_target_commits)
+    setup_manager.add_task(add_valid_unauthenticated_commits)
+    setup_manager.add_task(add_valid_target_commits)
+    setup_manager.execute_tasks()
+
+    clone_repositories(
+        origin_auth_repo,
+        client_dir,
+    )
+
+    setup_manager = SetupManager(origin_auth_repo)
+    setup_manager.add_task(
+        set_allow_unauthenticated_commits,
+        kwargs={"allow": False, "target_name": "target1"},
+    )
+    setup_manager.add_task(add_valid_target_commits)
     setup_manager.execute_tasks()
 
     update_and_check_commit_shas(

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -459,6 +459,7 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
         self._output = None
         self.local_repos_consistent = True
         self.repos_synced_with_remote = False
+        self._repositories_json_cache: Dict[Commitish, Optional[Dict]] = {}
 
     @property
     def output(self):
@@ -1857,6 +1858,48 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
             self.state.event = Event.FAILED
             return UpdateStatus.FAILED
 
+    def _get_repositories_json_at(
+        self, auth_commit: Commitish
+    ) -> Optional[Dict[str, Any]]:
+        if auth_commit not in self._repositories_json_cache:
+            self._repositories_json_cache[auth_commit] = (
+                repositoriesdb.load_repositories_json(
+                    self.state.users_auth_repo, auth_commit
+                )
+            )
+        return self._repositories_json_cache[auth_commit]
+
+    def _is_unauthenticated_allowed_at(
+        self, repository, auth_commit: Commitish
+    ) -> bool:
+        """
+        Resolve allow-unauthenticated-commits as declared in repositories.json
+        at `auth_commit`, the authentication commit whose target file is being
+        validated, instead of using the newest repositories.json in the
+        validated range. This ensures that flipping the flag to False does not
+        retroactively invalidate unauthenticated commits that were made, and
+        signed over, while it was still True.
+        """
+        repositories_json = self._get_repositories_json_at(auth_commit)
+        if repositories_json is None:
+            return _is_unauthenticated_allowed(repository)
+
+        repositories = repositories_json.get("repositories") or {}
+        repo_data = repositories.get(repository.name)
+        if repo_data is None:
+            return _is_unauthenticated_allowed(repository)
+
+        custom = dict(repo_data.get("custom") or {})
+        target_custom = (
+            self.state.targets_data_by_auth_commits.get(repository.name, {})
+            .get(auth_commit, {})
+            .get("custom")
+        )
+        if target_custom:
+            custom.update(target_custom)
+
+        return custom.get("allow-unauthenticated-commits", False)
+
     def _validate_current_repo_commit(
         self,
         repository,
@@ -1894,7 +1937,7 @@ but commit not on branch {current_branch}"
 
         if current_commit == current_target_commit:
             return current_target_commit
-        if not _is_unauthenticated_allowed(repository):
+        if not self._is_unauthenticated_allowed_at(repository, current_auth_commit):
             commit_date = users_auth_repo.get_commit_date(current_auth_commit)
             raise UpdateFailedError(
                 f"Failure to validate {users_auth_repo.name} commit {current_auth_commit} committed on {commit_date}: \

--- a/taf/updater/updater_pipeline.py
+++ b/taf/updater/updater_pipeline.py
@@ -459,7 +459,6 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
         self._output = None
         self.local_repos_consistent = True
         self.repos_synced_with_remote = False
-        self._repositories_json_cache: Dict[Commitish, Optional[Dict]] = {}
 
     @property
     def output(self):
@@ -1858,46 +1857,19 @@ class AuthenticationRepositoryUpdatePipeline(Pipeline):
             self.state.event = Event.FAILED
             return UpdateStatus.FAILED
 
-    def _get_repositories_json_at(
-        self, auth_commit: Commitish
-    ) -> Optional[Dict[str, Any]]:
-        if auth_commit not in self._repositories_json_cache:
-            self._repositories_json_cache[auth_commit] = (
-                repositoriesdb.load_repositories_json(
-                    self.state.users_auth_repo, auth_commit
-                )
-            )
-        return self._repositories_json_cache[auth_commit]
-
     def _is_unauthenticated_allowed_at(
         self, repository, auth_commit: Commitish
     ) -> bool:
-        """
-        Resolve allow-unauthenticated-commits as declared in repositories.json
-        at `auth_commit`, the authentication commit whose target file is being
-        validated, instead of using the newest repositories.json in the
-        validated range. This ensures that flipping the flag to False does not
-        retroactively invalidate unauthenticated commits that were made, and
-        signed over, while it was still True.
-        """
-        repositories_json = self._get_repositories_json_at(auth_commit)
-        if repositories_json is None:
-            return _is_unauthenticated_allowed(repository)
-
-        repositories = repositories_json.get("repositories") or {}
-        repo_data = repositories.get(repository.name)
-        if repo_data is None:
-            return _is_unauthenticated_allowed(repository)
-
-        custom = dict(repo_data.get("custom") or {})
         target_custom = (
             self.state.targets_data_by_auth_commits.get(repository.name, {})
             .get(auth_commit, {})
             .get("custom")
         )
-        if target_custom:
-            custom.update(target_custom)
-
+        custom = repositoriesdb.get_repository_custom_at(
+            self.state.users_auth_repo, repository.name, auth_commit, target_custom
+        )
+        if custom is None:
+            return _is_unauthenticated_allowed(repository)
         return custom.get("allow-unauthenticated-commits", False)
 
     def _validate_current_repo_commit(


### PR DESCRIPTION
The updater resolved allow-unauthenticated-commits using only the newest repositories.json in the validated range, so flipping the flag from true to false retroactively invalidated unauthenticated commits that had already been signed over while it was still true, breaking every fresh clone or full-history validation of the repository.

Resolve the flag at the authentication commit that recorded each target advance instead, so older history stays valid and the change only applies going forward from the commit that disallows it.

## Description (e.g. "Related to ...", etc.)

Closes #768

## Code review checklist (for code reviewer to complete)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated, as appropriate
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
