### PR TITLE
test(yubikey): add regression coverage for multi-YubiKey delegated-ro…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ and this project adheres to [Semantic Versioning][semver].
 ### Fixed
 
 - Disallowing unauthenticated commits no longer invalidates already-signed history ([774])
-- - Allow `--key-pin` with multiple YubiKeys inserted ([770])
+- Fix YubiKey caching bugs that could skip a valid signing key for a delegated role
+- Allow `--key-pin` with multiple YubiKeys inserted ([770])
 - Detect signing scheme from key material instead of assuming RSA ([757])
 - Clone no longer fails when the repository path contains a space (e.g. a Windows home directory with a space in the user name) ([762])
 - Surface the underlying git error when a clone fails, instead of hiding it behind a generic access message ([762])

--- a/taf/keys.py
+++ b/taf/keys.py
@@ -357,7 +357,8 @@ def load_signers(
                 use_yubikeys_to_sign = True
                 num_of_loaded_keys = len(loaded_keys)
                 for loaded_key in loaded_keys:
-                    key_names.remove(loaded_key)
+                    if loaded_key in key_names:
+                        key_names.remove(loaded_key)
 
                 if num_of_loaded_keys:
                     num_of_signatures += num_of_loaded_keys

--- a/taf/tests/tuf/test_keys/conftest.py
+++ b/taf/tests/tuf/test_keys/conftest.py
@@ -42,13 +42,19 @@ def make_fake_yubikey(monkeypatch, keystore):
         device = make_fake_yubikey(
             "snapshot", extra_slots={SLOT.AUTHENTICATION: "timestamp"}
         )
+        # flash from a different keystore directory (e.g. one that has
+        # delegated roles' keys):
+        device = make_fake_yubikey("delegated_role1", keystore_path=keystore_delegations)
     """
     monkeypatch.setattr(yk, "_yk_piv_ctrl", _yk_piv_ctrl_mock)
     created = []
 
-    def _make(key_name, extra_slots=None):
+    def _make(key_name, extra_slots=None, keystore_path=None):
+        source_keystore = keystore_path if keystore_path is not None else keystore
         device = FakeYubiKey(
-            keystore / key_name, keystore / f"{key_name}.pub", scheme=None
+            source_keystore / key_name,
+            source_keystore / f"{key_name}.pub",
+            scheme=None,
         )
         device.insert()
         for slot, other_key_name in (extra_slots or {}).items():
@@ -56,7 +62,7 @@ def make_fake_yubikey(monkeypatch, keystore):
                 pin=device.pin,
                 serial=device.serial,
                 cert_cn=f"{other_key_name} key",
-                private_key_pem=(keystore / other_key_name).read_bytes(),
+                private_key_pem=(source_keystore / other_key_name).read_bytes(),
                 slot=slot,
             )
         created.append(device)
@@ -84,6 +90,30 @@ def create_auth_repo(repo_path, keystore, keystore_no_yubikeys_path):
             keystore_no_yubikeys_path,
             is_test_repo=True,
             keystore=keystore,
+        )
+
+    return _create
+
+
+@pytest.fixture
+def create_delegated_auth_repo(
+    repo_path, keystore_delegations, with_delegations_no_yubikeys_path
+):
+    """Factory wrapping create_authentication_repository: builds a repo with
+    delegations (targets -> delegated_role -> inner_role), signed entirely
+    with keys already present in the keystore_delegations fixture, so
+    nothing needs generating or writing. Built under the test's own
+    repo_path, cleaned up with it.
+    """
+
+    def _create(pin_manager=None):
+        return create_authentication_repository(
+            repo_path,
+            pin_manager if pin_manager is not None else PinManager(),
+            "test/auth",
+            with_delegations_no_yubikeys_path,
+            is_test_repo=True,
+            keystore=keystore_delegations,
         )
 
     return _create

--- a/taf/tests/tuf/test_keys/conftest.py
+++ b/taf/tests/tuf/test_keys/conftest.py
@@ -1,6 +1,8 @@
 import pytest
 import shutil
 
+from yubikit.piv import SLOT
+
 import taf.yubikey.yubikey as yk
 from taf.tests.conftest import create_authentication_repository
 from taf.tools.yubikey.yubikey_utils import FakeYubiKey, _yk_piv_ctrl_mock
@@ -128,3 +130,61 @@ def tuf_repo(
     repo.create(roles_keys_data, signers_with_delegations)
     yield repo
     shutil.rmtree(tuf_repo_path, onerror=on_rm_error)
+
+
+@pytest.fixture
+def delegated_role_device(make_fake_yubikey, keystore_delegations):
+    """A fake YubiKey holding both of delegated_role's keys (SIGNATURE +
+    AUTHENTICATION), from keystore_delegations."""
+    return make_fake_yubikey(
+        "delegated_role1",
+        extra_slots={SLOT.AUTHENTICATION: "delegated_role2"},
+        keystore_path=keystore_delegations,
+    )
+
+
+@pytest.fixture
+def unauthorized_device(make_fake_yubikey, keystore_delegations):
+    """A fake YubiKey valid for 'targets', not for 'delegated_role'."""
+    return make_fake_yubikey("targets1", keystore_path=keystore_delegations)
+
+
+@pytest.fixture
+def block_reprompt(monkeypatch):
+    """Fail loudly instead of hanging if yubikey_prompt retries - guards
+    against yubikey_prompt's unbounded retry loop turning a real bug into a
+    hang instead of a clean assertion failure."""
+
+    def _unexpected_reprompt(*_args, **_kwargs):
+        raise AssertionError(
+            "unexpected re-prompt: yubikey_prompt retried instead of finding "
+            "the authorized YubiKey among the inserted devices"
+        )
+
+    monkeypatch.setattr(yk, "getpass", _unexpected_reprompt)
+
+
+def insert_in_order(*devices):
+    """Remove and re-insert devices in the given order, so get_serial_nums()
+    (which reflects INSERTED_YUBIKEYS' insertion order) enumerates them in
+    that order."""
+    for device in devices:
+        device.remove()
+    for device in devices:
+        device.insert()
+
+
+def write_target(path, text="hello"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def write_signing_keystore(tmp_path, source_keystore, names=("snapshot", "timestamp")):
+    signing_keystore = tmp_path / "signing_keystore"
+    signing_keystore.mkdir()
+    for name in names:
+        (signing_keystore / name).write_bytes((source_keystore / name).read_bytes())
+        (signing_keystore / f"{name}.pub").write_bytes(
+            (source_keystore / f"{name}.pub").read_bytes()
+        )
+    return signing_keystore

--- a/taf/tests/tuf/test_keys/test_yubikey_delegated_signing.py
+++ b/taf/tests/tuf/test_keys/test_yubikey_delegated_signing.py
@@ -1,0 +1,222 @@
+"""Regression coverage for a reported multi-YubiKey bug: with two YubiKeys
+inserted, where only one of them holds a key with authority over a
+delegated role, signing was reported to fail depending on which key got
+checked first."""
+
+import pytest
+from tuf.api.metadata import Metadata
+from yubikit.piv import SLOT
+
+from taf.api.targets import register_target_files
+from taf.auth_repo import AuthenticationRepository
+from taf.tuf.keys import load_signer_from_file
+from taf.yubikey.yubikey_manager import PinManager
+import taf.yubikey.yubikey as yk
+
+
+def _pin_manager(*devices) -> PinManager:
+    pin_manager = PinManager()
+    for device in devices:
+        pin_manager.add_pin(device.serial, device.pin)
+    return pin_manager
+
+
+@pytest.mark.parametrize("authorized_inserted_first", [True, False])
+def test_read_and_check_yubikeys_skips_unauthorized_device_for_delegated_role(
+    make_fake_yubikey,
+    keystore_delegations,
+    create_delegated_auth_repo,
+    authorized_inserted_first,
+):
+    if authorized_inserted_first:
+        authorized = make_fake_yubikey(
+            "delegated_role1",
+            extra_slots={SLOT.AUTHENTICATION: "delegated_role2"},
+            keystore_path=keystore_delegations,
+        )
+        unauthorized = make_fake_yubikey("targets1", keystore_path=keystore_delegations)
+    else:
+        unauthorized = make_fake_yubikey("targets1", keystore_path=keystore_delegations)
+        authorized = make_fake_yubikey(
+            "delegated_role1",
+            extra_slots={SLOT.AUTHENTICATION: "delegated_role2"},
+            keystore_path=keystore_delegations,
+        )
+
+    taf_repo = create_delegated_auth_repo()
+
+    result = yk._read_and_check_yubikeys(
+        role="delegated_role",
+        taf_repo=taf_repo,
+        pin_manager=_pin_manager(authorized, unauthorized),
+        pin_confirm=False,
+        pin_repeat=False,
+        prompt_message=None,
+        key_names=["delegated_role1", "delegated_role2"],
+        retrying=False,
+        hide_already_loaded_message=True,
+        hide_threshold_message=True,
+        key_id_pins=None,
+    )
+
+    assert result is not None
+    role1_key = load_signer_from_file(
+        keystore_delegations / "delegated_role1"
+    ).public_key
+    role2_key = load_signer_from_file(
+        keystore_delegations / "delegated_role2"
+    ).public_key
+    found_keyids = {entry[0].keyid for entry in result}
+    assert found_keyids == {role1_key.keyid, role2_key.keyid}
+    assert all(entry[1] == authorized.serial for entry in result)
+
+
+@pytest.mark.parametrize("authorized_inserted_first", [True, False])
+def test_sign_delegated_role_with_unauthorized_yubikey_inserted(
+    make_fake_yubikey,
+    keystore_delegations,
+    create_delegated_auth_repo,
+    tmp_path,
+    monkeypatch,
+    authorized_inserted_first,
+):
+    def _unexpected_reprompt(*_args, **_kwargs):
+        raise AssertionError(
+            "unexpected re-prompt: yubikey_prompt retried instead of finding "
+            "the authorized YubiKey among the inserted devices"
+        )
+
+    monkeypatch.setattr(yk, "getpass", _unexpected_reprompt)
+
+    if authorized_inserted_first:
+        authorized = make_fake_yubikey(
+            "delegated_role1",
+            extra_slots={SLOT.AUTHENTICATION: "delegated_role2"},
+            keystore_path=keystore_delegations,
+        )
+        unauthorized = make_fake_yubikey("targets1", keystore_path=keystore_delegations)
+    else:
+        unauthorized = make_fake_yubikey("targets1", keystore_path=keystore_delegations)
+        authorized = make_fake_yubikey(
+            "delegated_role1",
+            extra_slots={SLOT.AUTHENTICATION: "delegated_role2"},
+            keystore_path=keystore_delegations,
+        )
+
+    pin_manager = _pin_manager(authorized, unauthorized)
+    taf_repo = create_delegated_auth_repo(pin_manager)
+
+    metadata_path = taf_repo.path / "metadata"
+    delegated_md_before = Metadata.from_file(str(metadata_path / "delegated_role.json"))
+    version_before = delegated_md_before.signed.version
+
+    target_file = taf_repo.targets_path / "dir1" / "a-new-target.txt"
+    target_file.parent.mkdir(parents=True, exist_ok=True)
+    target_file.write_text("hello")
+
+    signing_keystore = tmp_path / "signing_keystore"
+    signing_keystore.mkdir()
+    for name in ("snapshot", "timestamp"):
+        (signing_keystore / name).write_bytes(
+            (keystore_delegations / name).read_bytes()
+        )
+        (signing_keystore / f"{name}.pub").write_bytes(
+            (keystore_delegations / f"{name}.pub").read_bytes()
+        )
+
+    auth_repo = AuthenticationRepository(
+        path=str(taf_repo.path), pin_manager=pin_manager
+    )
+
+    register_target_files(
+        str(taf_repo.path),
+        pin_manager,
+        keystore=str(signing_keystore),
+        update_snapshot_and_timestamp=True,
+        push=False,
+    )
+
+    assert "dir1/a-new-target.txt" in auth_repo.get_signed_target_files()
+
+    targets_md = Metadata.from_file(str(metadata_path / "targets.json"))
+    delegated_md_after = Metadata.from_file(str(metadata_path / "delegated_role.json"))
+    targets_md.verify_delegate("delegated_role", delegated_md_after)
+    assert delegated_md_after.signed.version > version_before
+
+
+@pytest.mark.parametrize("device_a_inserted_first", [True, False])
+def test_sign_two_delegated_roles_each_with_its_own_yubikey_in_one_command(
+    make_fake_yubikey,
+    keystore_delegations,
+    create_delegated_auth_repo,
+    tmp_path,
+    monkeypatch,
+    device_a_inserted_first,
+):
+    def _unexpected_reprompt(*_args, **_kwargs):
+        raise AssertionError(
+            "unexpected re-prompt: yubikey_prompt retried instead of finding "
+            "the authorized YubiKey among the inserted devices"
+        )
+
+    monkeypatch.setattr(yk, "getpass", _unexpected_reprompt)
+
+    device_delegated = make_fake_yubikey(
+        "delegated_role1",
+        extra_slots={SLOT.AUTHENTICATION: "delegated_role2"},
+        keystore_path=keystore_delegations,
+    )
+    device_inner = make_fake_yubikey("inner_role", keystore_path=keystore_delegations)
+    if not device_a_inserted_first:
+        device_delegated.remove()
+        device_inner.remove()
+        device_inner.insert()
+        device_delegated.insert()
+
+    pin_manager = _pin_manager(device_delegated, device_inner)
+    taf_repo = create_delegated_auth_repo(pin_manager)
+
+    metadata_path = taf_repo.path / "metadata"
+    versions_before = {
+        role: Metadata.from_file(str(metadata_path / f"{role}.json")).signed.version
+        for role in ("delegated_role", "inner_role")
+    }
+
+    (taf_repo.targets_path / "dir1").mkdir(parents=True, exist_ok=True)
+    (taf_repo.targets_path / "dir1" / "a-new-target.txt").write_text("hello")
+    (taf_repo.targets_path / "dir2").mkdir(parents=True, exist_ok=True)
+    (taf_repo.targets_path / "dir2" / "path2").write_text("hello")
+
+    signing_keystore = tmp_path / "signing_keystore"
+    signing_keystore.mkdir()
+    for name in ("snapshot", "timestamp"):
+        (signing_keystore / name).write_bytes(
+            (keystore_delegations / name).read_bytes()
+        )
+        (signing_keystore / f"{name}.pub").write_bytes(
+            (keystore_delegations / f"{name}.pub").read_bytes()
+        )
+
+    auth_repo = AuthenticationRepository(
+        path=str(taf_repo.path), pin_manager=pin_manager
+    )
+
+    register_target_files(
+        str(taf_repo.path),
+        pin_manager,
+        keystore=str(signing_keystore),
+        update_snapshot_and_timestamp=True,
+        push=False,
+    )
+
+    signed_targets = auth_repo.get_signed_target_files()
+    assert "dir1/a-new-target.txt" in signed_targets
+    assert "dir2/path2" in signed_targets
+
+    targets_md = Metadata.from_file(str(metadata_path / "targets.json"))
+    delegated_md = Metadata.from_file(str(metadata_path / "delegated_role.json"))
+    inner_md = Metadata.from_file(str(metadata_path / "inner_role.json"))
+    targets_md.verify_delegate("delegated_role", delegated_md)
+    delegated_md.verify_delegate("inner_role", inner_md)
+    assert delegated_md.signed.version > versions_before["delegated_role"]
+    assert inner_md.signed.version > versions_before["inner_role"]

--- a/taf/tests/tuf/test_keys/test_yubikey_delegated_signing.py
+++ b/taf/tests/tuf/test_keys/test_yubikey_delegated_signing.py
@@ -5,10 +5,14 @@ checked first."""
 
 import pytest
 from tuf.api.metadata import Metadata
-from yubikit.piv import SLOT
 
 from taf.api.targets import register_target_files
 from taf.auth_repo import AuthenticationRepository
+from taf.tests.tuf.test_keys.conftest import (
+    insert_in_order,
+    write_signing_keystore,
+    write_target,
+)
 from taf.tuf.keys import load_signer_from_file
 from taf.yubikey.yubikey_manager import PinManager
 import taf.yubikey.yubikey as yk
@@ -21,69 +25,23 @@ def _pin_manager(*devices) -> PinManager:
     return pin_manager
 
 
-def _block_reprompt(monkeypatch):
-    def _unexpected_reprompt(*_args, **_kwargs):
-        raise AssertionError(
-            "unexpected re-prompt: yubikey_prompt retried instead of finding "
-            "the authorized YubiKey among the inserted devices"
-        )
-
-    monkeypatch.setattr(yk, "getpass", _unexpected_reprompt)
-
-
-def _make_delegated_role_device(make_fake_yubikey, keystore_delegations):
-    return make_fake_yubikey(
-        "delegated_role1",
-        extra_slots={SLOT.AUTHENTICATION: "delegated_role2"},
-        keystore_path=keystore_delegations,
-    )
-
-
-def _make_unauthorized_device(make_fake_yubikey, keystore_delegations):
-    return make_fake_yubikey("targets1", keystore_path=keystore_delegations)
-
-
-def _insert_in_order(*devices):
-    for device in devices:
-        device.remove()
-    for device in devices:
-        device.insert()
-
-
-def _write_target(path, text="hello"):
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(text)
-
-
-def _write_signing_keystore(tmp_path, source_keystore, names=("snapshot", "timestamp")):
-    signing_keystore = tmp_path / "signing_keystore"
-    signing_keystore.mkdir()
-    for name in names:
-        (signing_keystore / name).write_bytes((source_keystore / name).read_bytes())
-        (signing_keystore / f"{name}.pub").write_bytes(
-            (source_keystore / f"{name}.pub").read_bytes()
-        )
-    return signing_keystore
-
-
 @pytest.mark.parametrize("authorized_inserted_first", [True, False])
 def test_read_and_check_yubikeys_skips_unauthorized_device_for_delegated_role(
-    make_fake_yubikey,
+    delegated_role_device,
+    unauthorized_device,
     keystore_delegations,
     create_delegated_auth_repo,
     authorized_inserted_first,
 ):
-    authorized = _make_delegated_role_device(make_fake_yubikey, keystore_delegations)
-    unauthorized = _make_unauthorized_device(make_fake_yubikey, keystore_delegations)
     if not authorized_inserted_first:
-        _insert_in_order(unauthorized, authorized)
+        insert_in_order(unauthorized_device, delegated_role_device)
 
     taf_repo = create_delegated_auth_repo()
 
     result = yk._read_and_check_yubikeys(
         role="delegated_role",
         taf_repo=taf_repo,
-        pin_manager=_pin_manager(authorized, unauthorized),
+        pin_manager=_pin_manager(delegated_role_device, unauthorized_device),
         pin_confirm=False,
         pin_repeat=False,
         prompt_message=None,
@@ -103,34 +61,31 @@ def test_read_and_check_yubikeys_skips_unauthorized_device_for_delegated_role(
     ).public_key
     found_keyids = {entry[0].keyid for entry in result}
     assert found_keyids == {role1_key.keyid, role2_key.keyid}
-    assert all(entry[1] == authorized.serial for entry in result)
+    assert all(entry[1] == delegated_role_device.serial for entry in result)
 
 
 @pytest.mark.parametrize("authorized_inserted_first", [True, False])
 def test_sign_delegated_role_with_unauthorized_yubikey_inserted(
-    make_fake_yubikey,
+    delegated_role_device,
+    unauthorized_device,
     keystore_delegations,
     create_delegated_auth_repo,
     tmp_path,
-    monkeypatch,
+    block_reprompt,
     authorized_inserted_first,
 ):
-    _block_reprompt(monkeypatch)
-
-    authorized = _make_delegated_role_device(make_fake_yubikey, keystore_delegations)
-    unauthorized = _make_unauthorized_device(make_fake_yubikey, keystore_delegations)
     if not authorized_inserted_first:
-        _insert_in_order(unauthorized, authorized)
+        insert_in_order(unauthorized_device, delegated_role_device)
 
-    pin_manager = _pin_manager(authorized, unauthorized)
+    pin_manager = _pin_manager(delegated_role_device, unauthorized_device)
     taf_repo = create_delegated_auth_repo(pin_manager)
 
     metadata_path = taf_repo.path / "metadata"
     delegated_md_before = Metadata.from_file(str(metadata_path / "delegated_role.json"))
     version_before = delegated_md_before.signed.version
 
-    _write_target(taf_repo.targets_path / "dir1" / "a-new-target.txt")
-    signing_keystore = _write_signing_keystore(tmp_path, keystore_delegations)
+    write_target(taf_repo.targets_path / "dir1" / "a-new-target.txt")
+    signing_keystore = write_signing_keystore(tmp_path, keystore_delegations)
 
     auth_repo = AuthenticationRepository(
         path=str(taf_repo.path), pin_manager=pin_manager
@@ -154,23 +109,19 @@ def test_sign_delegated_role_with_unauthorized_yubikey_inserted(
 
 @pytest.mark.parametrize("device_a_inserted_first", [True, False])
 def test_sign_two_delegated_roles_each_with_its_own_yubikey_in_one_command(
+    delegated_role_device,
     make_fake_yubikey,
     keystore_delegations,
     create_delegated_auth_repo,
     tmp_path,
-    monkeypatch,
+    block_reprompt,
     device_a_inserted_first,
 ):
-    _block_reprompt(monkeypatch)
-
-    device_delegated = _make_delegated_role_device(
-        make_fake_yubikey, keystore_delegations
-    )
     device_inner = make_fake_yubikey("inner_role", keystore_path=keystore_delegations)
     if not device_a_inserted_first:
-        _insert_in_order(device_inner, device_delegated)
+        insert_in_order(device_inner, delegated_role_device)
 
-    pin_manager = _pin_manager(device_delegated, device_inner)
+    pin_manager = _pin_manager(delegated_role_device, device_inner)
     taf_repo = create_delegated_auth_repo(pin_manager)
 
     metadata_path = taf_repo.path / "metadata"
@@ -179,9 +130,9 @@ def test_sign_two_delegated_roles_each_with_its_own_yubikey_in_one_command(
         for role in ("delegated_role", "inner_role")
     }
 
-    _write_target(taf_repo.targets_path / "dir1" / "a-new-target.txt")
-    _write_target(taf_repo.targets_path / "dir2" / "path2")
-    signing_keystore = _write_signing_keystore(tmp_path, keystore_delegations)
+    write_target(taf_repo.targets_path / "dir1" / "a-new-target.txt")
+    write_target(taf_repo.targets_path / "dir2" / "path2")
+    signing_keystore = write_signing_keystore(tmp_path, keystore_delegations)
 
     auth_repo = AuthenticationRepository(
         path=str(taf_repo.path), pin_manager=pin_manager

--- a/taf/tests/tuf/test_keys/test_yubikey_delegated_signing.py
+++ b/taf/tests/tuf/test_keys/test_yubikey_delegated_signing.py
@@ -21,6 +21,51 @@ def _pin_manager(*devices) -> PinManager:
     return pin_manager
 
 
+def _block_reprompt(monkeypatch):
+    def _unexpected_reprompt(*_args, **_kwargs):
+        raise AssertionError(
+            "unexpected re-prompt: yubikey_prompt retried instead of finding "
+            "the authorized YubiKey among the inserted devices"
+        )
+
+    monkeypatch.setattr(yk, "getpass", _unexpected_reprompt)
+
+
+def _make_delegated_role_device(make_fake_yubikey, keystore_delegations):
+    return make_fake_yubikey(
+        "delegated_role1",
+        extra_slots={SLOT.AUTHENTICATION: "delegated_role2"},
+        keystore_path=keystore_delegations,
+    )
+
+
+def _make_unauthorized_device(make_fake_yubikey, keystore_delegations):
+    return make_fake_yubikey("targets1", keystore_path=keystore_delegations)
+
+
+def _insert_in_order(*devices):
+    for device in devices:
+        device.remove()
+    for device in devices:
+        device.insert()
+
+
+def _write_target(path, text="hello"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def _write_signing_keystore(tmp_path, source_keystore, names=("snapshot", "timestamp")):
+    signing_keystore = tmp_path / "signing_keystore"
+    signing_keystore.mkdir()
+    for name in names:
+        (signing_keystore / name).write_bytes((source_keystore / name).read_bytes())
+        (signing_keystore / f"{name}.pub").write_bytes(
+            (source_keystore / f"{name}.pub").read_bytes()
+        )
+    return signing_keystore
+
+
 @pytest.mark.parametrize("authorized_inserted_first", [True, False])
 def test_read_and_check_yubikeys_skips_unauthorized_device_for_delegated_role(
     make_fake_yubikey,
@@ -28,20 +73,10 @@ def test_read_and_check_yubikeys_skips_unauthorized_device_for_delegated_role(
     create_delegated_auth_repo,
     authorized_inserted_first,
 ):
-    if authorized_inserted_first:
-        authorized = make_fake_yubikey(
-            "delegated_role1",
-            extra_slots={SLOT.AUTHENTICATION: "delegated_role2"},
-            keystore_path=keystore_delegations,
-        )
-        unauthorized = make_fake_yubikey("targets1", keystore_path=keystore_delegations)
-    else:
-        unauthorized = make_fake_yubikey("targets1", keystore_path=keystore_delegations)
-        authorized = make_fake_yubikey(
-            "delegated_role1",
-            extra_slots={SLOT.AUTHENTICATION: "delegated_role2"},
-            keystore_path=keystore_delegations,
-        )
+    authorized = _make_delegated_role_device(make_fake_yubikey, keystore_delegations)
+    unauthorized = _make_unauthorized_device(make_fake_yubikey, keystore_delegations)
+    if not authorized_inserted_first:
+        _insert_in_order(unauthorized, authorized)
 
     taf_repo = create_delegated_auth_repo()
 
@@ -80,28 +115,12 @@ def test_sign_delegated_role_with_unauthorized_yubikey_inserted(
     monkeypatch,
     authorized_inserted_first,
 ):
-    def _unexpected_reprompt(*_args, **_kwargs):
-        raise AssertionError(
-            "unexpected re-prompt: yubikey_prompt retried instead of finding "
-            "the authorized YubiKey among the inserted devices"
-        )
+    _block_reprompt(monkeypatch)
 
-    monkeypatch.setattr(yk, "getpass", _unexpected_reprompt)
-
-    if authorized_inserted_first:
-        authorized = make_fake_yubikey(
-            "delegated_role1",
-            extra_slots={SLOT.AUTHENTICATION: "delegated_role2"},
-            keystore_path=keystore_delegations,
-        )
-        unauthorized = make_fake_yubikey("targets1", keystore_path=keystore_delegations)
-    else:
-        unauthorized = make_fake_yubikey("targets1", keystore_path=keystore_delegations)
-        authorized = make_fake_yubikey(
-            "delegated_role1",
-            extra_slots={SLOT.AUTHENTICATION: "delegated_role2"},
-            keystore_path=keystore_delegations,
-        )
+    authorized = _make_delegated_role_device(make_fake_yubikey, keystore_delegations)
+    unauthorized = _make_unauthorized_device(make_fake_yubikey, keystore_delegations)
+    if not authorized_inserted_first:
+        _insert_in_order(unauthorized, authorized)
 
     pin_manager = _pin_manager(authorized, unauthorized)
     taf_repo = create_delegated_auth_repo(pin_manager)
@@ -110,19 +129,8 @@ def test_sign_delegated_role_with_unauthorized_yubikey_inserted(
     delegated_md_before = Metadata.from_file(str(metadata_path / "delegated_role.json"))
     version_before = delegated_md_before.signed.version
 
-    target_file = taf_repo.targets_path / "dir1" / "a-new-target.txt"
-    target_file.parent.mkdir(parents=True, exist_ok=True)
-    target_file.write_text("hello")
-
-    signing_keystore = tmp_path / "signing_keystore"
-    signing_keystore.mkdir()
-    for name in ("snapshot", "timestamp"):
-        (signing_keystore / name).write_bytes(
-            (keystore_delegations / name).read_bytes()
-        )
-        (signing_keystore / f"{name}.pub").write_bytes(
-            (keystore_delegations / f"{name}.pub").read_bytes()
-        )
+    _write_target(taf_repo.targets_path / "dir1" / "a-new-target.txt")
+    signing_keystore = _write_signing_keystore(tmp_path, keystore_delegations)
 
     auth_repo = AuthenticationRepository(
         path=str(taf_repo.path), pin_manager=pin_manager
@@ -153,25 +161,14 @@ def test_sign_two_delegated_roles_each_with_its_own_yubikey_in_one_command(
     monkeypatch,
     device_a_inserted_first,
 ):
-    def _unexpected_reprompt(*_args, **_kwargs):
-        raise AssertionError(
-            "unexpected re-prompt: yubikey_prompt retried instead of finding "
-            "the authorized YubiKey among the inserted devices"
-        )
+    _block_reprompt(monkeypatch)
 
-    monkeypatch.setattr(yk, "getpass", _unexpected_reprompt)
-
-    device_delegated = make_fake_yubikey(
-        "delegated_role1",
-        extra_slots={SLOT.AUTHENTICATION: "delegated_role2"},
-        keystore_path=keystore_delegations,
+    device_delegated = _make_delegated_role_device(
+        make_fake_yubikey, keystore_delegations
     )
     device_inner = make_fake_yubikey("inner_role", keystore_path=keystore_delegations)
     if not device_a_inserted_first:
-        device_delegated.remove()
-        device_inner.remove()
-        device_inner.insert()
-        device_delegated.insert()
+        _insert_in_order(device_inner, device_delegated)
 
     pin_manager = _pin_manager(device_delegated, device_inner)
     taf_repo = create_delegated_auth_repo(pin_manager)
@@ -182,20 +179,9 @@ def test_sign_two_delegated_roles_each_with_its_own_yubikey_in_one_command(
         for role in ("delegated_role", "inner_role")
     }
 
-    (taf_repo.targets_path / "dir1").mkdir(parents=True, exist_ok=True)
-    (taf_repo.targets_path / "dir1" / "a-new-target.txt").write_text("hello")
-    (taf_repo.targets_path / "dir2").mkdir(parents=True, exist_ok=True)
-    (taf_repo.targets_path / "dir2" / "path2").write_text("hello")
-
-    signing_keystore = tmp_path / "signing_keystore"
-    signing_keystore.mkdir()
-    for name in ("snapshot", "timestamp"):
-        (signing_keystore / name).write_bytes(
-            (keystore_delegations / name).read_bytes()
-        )
-        (signing_keystore / f"{name}.pub").write_bytes(
-            (keystore_delegations / f"{name}.pub").read_bytes()
-        )
+    _write_target(taf_repo.targets_path / "dir1" / "a-new-target.txt")
+    _write_target(taf_repo.targets_path / "dir2" / "path2")
+    signing_keystore = _write_signing_keystore(tmp_path, keystore_delegations)
 
     auth_repo = AuthenticationRepository(
         path=str(taf_repo.path), pin_manager=pin_manager

--- a/taf/tuf/repository.py
+++ b/taf/tuf/repository.py
@@ -239,9 +239,13 @@ class MetadataRepository(Repository):
             self._keys_name_mappings[key_id] = key_name
 
     def add_default_names_of_role(self, role_name):
-        key_names = self.get_key_names_of_role(role_name)
+        keys_name_mapping = self.keys_name_mappings
         key_ids = self.get_keyids_of_role(role_name)
-        for key_name, key_id in zip(key_names, key_ids):
+        number = len(key_ids)
+        for index, key_id in enumerate(key_ids):
+            if keys_name_mapping and key_id in keys_name_mapping:
+                continue
+            key_name = role_name if number == 1 else f"{role_name}{index + 1}"
             self.add_key_name(key_name, key_id)
 
     def all_target_files(self) -> Set:
@@ -1418,7 +1422,12 @@ class MetadataRepository(Repository):
         """
 
         if public_key is None:
-            public_key = yk.get_piv_public_key_tuf()
+            for serial in yk.get_serial_nums():
+                device_keys = yk.get_piv_public_keys_tuf(serial=serial).get(serial, {})
+                for candidate_key in device_keys.values():
+                    if self.is_valid_metadata_key(role, candidate_key):
+                        return True
+            return False
 
         return self.is_valid_metadata_key(role, public_key)
 

--- a/taf/yubikey/yubikey.py
+++ b/taf/yubikey/yubikey.py
@@ -732,7 +732,8 @@ def _read_and_check_yubikeys(
         taf_logger.log(
             "NOTICE",
             f"YubiKey(s) with serial(s) {', '.join(str(s) for s in invalid_keys)} "
-            f"are not valid signing keys for role '{role}' and were skipped.",
+            f"do not hold a signing key for role '{role}' and were skipped for this "
+            "role - they may still be used to sign other roles in this run.",
         )
 
     return yubikeys

--- a/taf/yubikey/yubikey.py
+++ b/taf/yubikey/yubikey.py
@@ -693,7 +693,10 @@ def _read_and_check_yubikeys(
                 slot = candidate_slot
                 found_valid_key = True
 
-                key_name = taf_repo.keys_name_mappings.get(public_key.keyid)
+                key_name = (
+                    taf_repo.keys_name_mappings.get(public_key.keyid)
+                    or f"{serial_num}-{slot.name}"
+                )
                 taf_logger.debug(
                     f"Potential YubiKey with serial={serial_num}, associated key_name='{key_name}', slot={slot}."
                 )
@@ -723,6 +726,13 @@ def _read_and_check_yubikeys(
         print("All inserted YubiKeys already loaded")
         taf_logger.debug(
             f"All YubiKeys inserted were already loaded for role='{role}'."
+        )
+
+    if invalid_keys:
+        taf_logger.log(
+            "NOTICE",
+            f"YubiKey(s) with serial(s) {', '.join(str(s) for s in invalid_keys)} "
+            f"are not valid signing keys for role '{role}' and were skipped.",
         )
 
     return yubikeys


### PR DESCRIPTION
…le signing

Add tests reproducing a reported bug: signing a delegated role while an unauthorized YubiKey is also inserted, in both insertion orders and across single- and multi-role signing commands. The scenario didn't reproduce as originally described, but reading the surrounding code turned up genuine order-dependent defects, fixed here:

- add_default_names_of_role zipped two independently-ordered lists, mis-pairing a key name with the wrong keyid when only some of a role's keys already had a name
- YubiKeyStore collided on key_name=None, letting two unnamed YubiKeys clobber each other's cached serial/public key/roles
- rejected YubiKeys were silently dropped instead of logged
- is_valid_metadata_yubikey(role) with no public_key only ever checked one device's SIGNATURE slot

## Description (e.g. "Related to ...", etc.)

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
