### PR TITLE
feat(branch): add generic taf branch merge command

### DIFF
--- a/taf/api/merge.py
+++ b/taf/api/merge.py
@@ -304,12 +304,19 @@ def _mirrored_repos(source_branch, merge_plan, repos_by_name, qualifying_steps, 
     left to the post-merge repository validation instead. Otherwise an uneven
     count is left in and surfaces as a validation error - the ordinary signal
     that a repo's branch lost commits to a force push.
+
+    Materializes a local `source_branch` for each mirrored repo (mirroring
+    `create_local_branch_from_remote_tracking` already used for `destination`)
+    so downstream git operations that only look at local branches - a caller's
+    own tooling, not anything this function needs itself - see it too.
     """
     mirrored = [
         (name, destination)
         for name, (destination, _) in merge_plan.items()
         if repos_by_name[name].branch_exists(source_branch)
     ]
+    for name, _ in mirrored:
+        repos_by_name[name].create_local_branch_from_remote_tracking(source_branch)
     if not policy.allow_uneven_branch_lengths:
         return mirrored
     return [

--- a/taf/api/merge.py
+++ b/taf/api/merge.py
@@ -1,0 +1,471 @@
+"""
+Merges commits of a "batch" branch in an authentication repository - a
+branch whose commits each authenticate one commit of one or more target
+repositories, such as a speculative branch, a publication branch, or a
+single-commit update branch - into each repository's destination branch.
+
+Which target repositories participate, what commit each one merges to, its
+destination branch and any date gate are all read directly from the auth
+repo's signed target files at each unmerged commit (`taf.branches`); nothing
+about a specific repository needs to be configured. What is not in that data
+- branch name patterns, capstone role policy - comes from a `MergePolicy`
+(`taf.models.merge`).
+"""
+
+import datetime as dt
+from pathlib import Path
+from logging import ERROR, INFO
+from typing import Dict, Iterable, List, Optional, Set, Tuple
+
+from logdecorator import log_on_end, log_on_error, log_on_start
+
+import taf.repositoriesdb as repositoriesdb
+from taf.api.metadata import update_snapshot_and_timestamp
+from taf.auth_repo import AuthenticationRepository
+from taf.branches import (
+    BranchPattern,
+    find_unmerged_auth_commits,
+    select_branches,
+    updated_roles_at_commit,
+)
+from taf.exceptions import (
+    GitError,
+    InvalidBranchError,
+    MergeError,
+    RoleMetadataNotSameError,
+    TAFError,
+    ValidationFailedError,
+)
+from taf.git import GitRepository
+from taf.git_providers import get_git_provider
+from taf.log import taf_logger
+from taf.models.merge import MergePolicy
+from taf.models.types import Commitish
+from taf.updater.updater import validate_repository
+from taf.validation import validate_branch
+from taf.yubikey.yubikey_manager import PinManager
+
+
+class MergeStep:
+    def __init__(
+        self, auth_commit: Commitish, targets: Optional[Dict[str, Dict]] = None
+    ):
+        self.auth_commit = auth_commit
+        self.targets: Dict[str, Dict] = targets if targets is not None else {}
+
+
+def _sign_and_merge_commit(
+    auth_repo: AuthenticationRepository,
+    commit: Commitish,
+    roles: Iterable[str],
+    keystore: Optional[str],
+) -> None:
+    """
+    Checkout the changes made to `roles`' target files at `commit` onto the
+    currently checked out branch of `auth_repo`, then re-sign snapshot and
+    timestamp and commit.
+    """
+    roles = list(roles)
+    taf_logger.info(f"Merging commit {commit} into {auth_repo.name}")
+    changed_files = auth_repo.list_changed_files_at_revision(commit)
+    for changed_file in changed_files:
+        changed_file_path = Path(auth_repo.path, changed_file)
+        try:
+            changed_file_rel_path = changed_file_path.relative_to(
+                auth_repo.targets_path
+            )
+            if (
+                auth_repo.get_role_from_target_paths([str(changed_file_rel_path)])
+                not in roles
+            ):
+                continue
+        except ValueError:
+            pass
+        try:
+            auth_repo.checkout_paths(commit, changed_file)
+        except Exception:
+            pass
+
+    for role in roles:
+        auth_repo.delete_unregistered_target_files(role)
+
+    commit_msg = auth_repo.get_commit_message(commit)
+    update_snapshot_and_timestamp(
+        path=auth_repo.path,
+        pin_manager=auth_repo.pin_manager,
+        keystore=keystore,
+        commit_msg=commit_msg,
+        skip_clean_check=True,
+        roles_to_sync=roles,
+        push=False,
+        skip_remote_check=True,
+    )
+    taf_logger.info("Updated snapshot and timestamp")
+
+
+def _load_non_archived_repos(
+    auth_repo, library_dir, commit
+) -> Dict[str, GitRepository]:
+    repositoriesdb.load_repositories(
+        auth_repo, commits=[commit], library_dir=library_dir, only_load_targets=False
+    )
+    repos = repositoriesdb.get_repositories(auth_repo, commit)
+    return {
+        name: repo for name, repo in repos.items() if not repo.custom.get("archived")
+    }
+
+
+def _build_steps(auth_repo, unmerged_auth_commits, repo_names) -> List[MergeStep]:
+    steps = []
+    for commit in unmerged_auth_commits:
+        targets = {}
+        for name in repo_names:
+            target = auth_repo.get_target(name, commit)
+            if target is not None:
+                targets[name] = target
+        steps.append(MergeStep(auth_commit=commit, targets=targets))
+    return steps
+
+
+def _last_qualifying_step_index(steps: List[MergeStep], gate: Optional[str]) -> int:
+    """
+    Index of the last step whose gate value (if any) is today or earlier.
+    -1 if even the first step is gated into the future.
+    """
+    if gate is None:
+        return len(steps) - 1
+    today = dt.date.today().isoformat()
+    last = -1
+    for i, step in enumerate(steps):
+        gate_values = {t[gate] for t in step.targets.values() if gate in t}
+        if gate_values and max(gate_values) > today:
+            break
+        last = i
+    return last
+
+
+def _plan_merge(
+    repos_by_name, final_step: MergeStep
+) -> Dict[str, Tuple[str, Commitish]]:
+    """
+    For each repo with a target at `final_step`, decide whether its declared
+    commit is new work: it participates if that commit is not yet reachable
+    from its declared destination branch (a repo that was not touched by
+    this batch of commits already points there and drops out on its own).
+    """
+    plan = {}
+    for name, repo in repos_by_name.items():
+        target = final_step.targets.get(name)
+        if target is None:
+            continue
+        declared_commit = Commitish.from_hash(target["commit"])
+        destination = target.get("branch") or repo.default_branch
+        repo.create_local_branch_from_remote_tracking(destination)
+        if repo.is_commit_an_ancestor_of_a_commit_or_branch(
+            declared_commit, destination
+        ):
+            continue
+        plan[name] = (destination, declared_commit)
+    return plan
+
+
+def _check_no_force_push(source_branch, merge_plan, repos_by_name) -> None:
+    for name, (_, declared_commit) in merge_plan.items():
+        repo = repos_by_name[name]
+        if not repo.branches_containing_commit(declared_commit):
+            raise MergeError(
+                f"{source_branch}: declared commit {declared_commit} for {name} no "
+                "longer exists on any branch of that repository - check for a force push"
+            )
+
+
+def _validate_fully_participating_repos(
+    auth_repo,
+    source_branch,
+    default_branch,
+    policy,
+    merge_plan,
+    repos_by_name,
+    qualifying_steps,
+) -> None:
+    fully_participating = [
+        repos_by_name[name]
+        for name, (destination, _) in merge_plan.items()
+        if repos_by_name[name].branch_exists(source_branch)
+        and len(
+            repos_by_name[name].commits_on_branch_and_not_other(
+                source_branch, destination
+            )
+        )
+        == len(qualifying_steps)
+    ]
+    if not fully_participating:
+        return
+
+    updated_roles = sorted(
+        {
+            r
+            for step in qualifying_steps
+            for r in updated_roles_at_commit(auth_repo, step.auth_commit)
+        }
+    )
+    check_capstone_roles = [
+        r for r in updated_roles if r not in policy.no_capstone_roles
+    ]
+    check_branch_id_role_set = set(policy.check_branch_id_roles)
+    check_branch_roles = {
+        r: r in check_branch_id_role_set for r in check_capstone_roles
+    }
+    merge_branches = {repo: merge_plan[repo.name][0] for repo in fully_participating}
+    merge_branches[auth_repo] = default_branch
+    try:
+        validate_branch(
+            auth_repo,
+            fully_participating,
+            source_branch,
+            merge_branches,
+            updated_roles,
+            check_capstone_roles,
+            check_branch_roles,
+            check_branch_lengths_fun=lambda *_a, **_k: None,
+        )
+    except InvalidBranchError as e:
+        raise MergeError(f"{source_branch}: validation error: {e}")
+
+
+def _apply_merge_plan(source_branch, merge_plan, repos_by_name) -> None:
+    for name, (destination, declared_commit) in merge_plan.items():
+        repo = repos_by_name[name]
+        if repo.get_current_branch() == destination:
+            repo.checkout_commit(declared_commit)
+        if not repo.force_move_branch(destination, declared_commit):
+            raise MergeError(f"{source_branch}: could not move {name} to {destination}")
+        repo.checkout_branch(destination)
+        taf_logger.info(f"Merged {name} to {destination} at {declared_commit}")
+
+
+def _set_changed_default_branches(
+    merge_plan, repos_by_name, old_destinations, git_access_token
+) -> None:
+    for name, (destination, _) in merge_plan.items():
+        if destination == old_destinations[name]:
+            continue
+        repo = repos_by_name[name]
+        try:
+            git_provider = get_git_provider(repo, access_token=git_access_token)
+            git_provider.set_default_branch(destination)
+            taf_logger.warning(f"{destination} set as default branch in {repo.path}")
+        except Exception as e:
+            taf_logger.error(
+                f"Could not update default branch of {repo.path} due to error:\n{e}.\n"
+                "Please update default branch manually."
+            )
+
+
+def _merge_one_branch(
+    auth_repo: AuthenticationRepository,
+    source_branch: str,
+    policy: MergePolicy,
+    default_branch: str,
+    library_dir: Optional[str],
+    keystore: Optional[str],
+    git_access_token: Optional[str],
+) -> Tuple[bool, Set]:
+    auth_repo.checkout_branch(default_branch)
+    auth_repo.checkout_branch(source_branch)
+
+    try:
+        unmerged_auth_commits = find_unmerged_auth_commits(
+            auth_repo, source_branch, default_branch
+        )
+    except RoleMetadataNotSameError as e:
+        taf_logger.error(str(e))
+        return False, set()
+
+    if not unmerged_auth_commits:
+        taf_logger.info(f"{source_branch}: all commits already merged")
+        return False, set()
+
+    repos_by_name = _load_non_archived_repos(
+        auth_repo, library_dir, unmerged_auth_commits[-1]
+    )
+    steps = _build_steps(auth_repo, unmerged_auth_commits, repos_by_name)
+
+    last_index = _last_qualifying_step_index(steps, policy.gate)
+    if last_index < 0:
+        taf_logger.info(f"{source_branch}: no commits ready to merge yet")
+        return False, set()
+
+    qualifying_steps = steps[: last_index + 1]
+    final_step = qualifying_steps[-1]
+    merge_plan = _plan_merge(repos_by_name, final_step)
+
+    old_destinations = {
+        name: (
+            auth_repo.get_target(name, auth_repo.top_commit_of_branch(default_branch))
+            or {}
+        ).get("branch")
+        or repos_by_name[name].default_branch
+        for name in merge_plan
+    }
+
+    _check_no_force_push(source_branch, merge_plan, repos_by_name)
+    _validate_fully_participating_repos(
+        auth_repo,
+        source_branch,
+        default_branch,
+        policy,
+        merge_plan,
+        repos_by_name,
+        qualifying_steps,
+    )
+    _apply_merge_plan(source_branch, merge_plan, repos_by_name)
+
+    auth_repo.checkout_branch(default_branch)
+    for step in qualifying_steps:
+        commit_roles = updated_roles_at_commit(auth_repo, step.auth_commit)
+        _sign_and_merge_commit(auth_repo, step.auth_commit, commit_roles, keystore)
+
+    if policy.set_default_branch:
+        _set_changed_default_branches(
+            merge_plan, repos_by_name, old_destinations, git_access_token
+        )
+
+    return True, {repos_by_name[name] for name in merge_plan}
+
+
+def _rename_merged_branch(auth_repo: AuthenticationRepository, branch: str) -> None:
+    new_branch_name = f"merged/{branch}"
+    try:
+        auth_repo._git(f"checkout {branch}")
+        auth_repo._git(f"branch -m {new_branch_name}")
+        auth_repo._git(f"push origin {new_branch_name} --no-verify")
+        auth_repo._git(f"push origin --delete {branch} --no-verify")
+        auth_repo._git(
+            f"branch --set-upstream-to=origin/{new_branch_name} {new_branch_name}"
+        )
+        auth_repo._git(f"checkout {auth_repo.default_branch}")
+    except GitError as e:
+        taf_logger.warning(
+            f"Failed to rename merged branch {branch} due to error - {str(e)}"
+        )
+
+
+@log_on_start(INFO, "Merging branch commits", logger=taf_logger)
+@log_on_end(INFO, "Finished merging branch commits", logger=taf_logger)
+@log_on_error(
+    ERROR,
+    "An error occurred while merging branch commits: {e}",
+    logger=taf_logger,
+    on_exceptions=TAFError,
+    reraise=True,
+)
+def merge_branch_commits(
+    path: str,
+    pin_manager: PinManager,
+    policy: MergePolicy,
+    library_dir: Optional[str] = None,
+    pushed_branch: Optional[str] = None,
+    keystore: Optional[str] = None,
+    deploy: bool = False,
+    git_access_token: Optional[str] = None,
+) -> None:
+    """
+    Merge commits of the branch(es) matching `policy.branch_pattern` - the
+    newest overall, or the newest per `policy.group_by` group - into each
+    participating target repository's destination branch and the
+    authentication repository's default branch.
+
+    Arguments:
+        path: Path to the authentication repository.
+        policy: The merge policy to apply - see `taf.models.merge.MergePolicy`.
+        library_dir (optional): Directory containing the target repositories.
+        pushed_branch (optional): If given, this call is a no-op unless it matches
+            `policy.branch_pattern` (used to filter which CI trigger should act).
+        keystore (optional): Location of the keystore files.
+        deploy (optional): Push changes (and merged target repositories) to their remotes.
+        git_access_token (optional): Access token used to change a target repository's
+            default branch, when `policy.set_default_branch` is set.
+
+    Side Effects:
+        Force-moves destination branches of participating target repositories, re-signs
+        and commits snapshot/timestamp metadata of the authentication repository for each
+        merged commit, and (if `deploy`) pushes all of it, optionally renaming merged
+        branches.
+
+    Raises:
+        MergeError, RoleMetadataNotSameError
+
+    Returns:
+        None
+    """
+    pattern = BranchPattern(policy.branch_pattern)
+    if pushed_branch is not None and not pattern.matches(pushed_branch):
+        taf_logger.info(
+            f"Pushed branch {pushed_branch} does not match pattern "
+            f"'{policy.branch_pattern}', nothing to merge"
+        )
+        return
+
+    auth_repo = AuthenticationRepository(path=path, pin_manager=pin_manager)
+    default_branch = auth_repo.default_branch
+    if default_branch is None:
+        raise MergeError(f"Could not determine the default branch of {path}")
+    auth_repo.checkout_branch(default_branch)
+    try:
+        validate_from_commit = auth_repo.top_commit_of_branch(default_branch)
+    except GitError:
+        validate_from_commit = None
+
+    source_branches = select_branches(auth_repo, pattern, group_by=policy.group_by)
+    if not source_branches:
+        taf_logger.info(f"No branch matching pattern '{policy.branch_pattern}' found")
+        return
+
+    merged_branches = []
+    touched_repos: Set = set()
+    for source_branch in source_branches:
+        signed, repos = _merge_one_branch(
+            auth_repo,
+            source_branch,
+            policy,
+            default_branch,
+            library_dir,
+            keystore,
+            git_access_token,
+        )
+        if signed:
+            merged_branches.append(source_branch)
+            touched_repos.update(repos)
+
+    if not merged_branches:
+        return
+
+    try:
+        validate_repository(
+            path,
+            library_dir,
+            validate_from_commit=(
+                validate_from_commit.hash if validate_from_commit else None
+            ),
+        )
+    except ValidationFailedError as e:
+        raise MergeError(f"Could not merge branch commits due to validation error: {e}")
+    except Exception as e:
+        raise MergeError(
+            "An error occurred while validating repositories. This most likely means "
+            f"there is a problem with the TAF updater.\n{e}"
+        )
+
+    if not deploy:
+        taf_logger.info("deploy=False; skipping push")
+        return
+
+    taf_logger.info(f"Pushing {len(touched_repos)} target repo(s) and auth repo")
+    for repo in touched_repos:
+        repo.push()
+    auth_repo.push()
+
+    if policy.rename_merged:
+        for branch in merged_branches:
+            _rename_merged_branch(auth_repo, branch)

--- a/taf/api/merge.py
+++ b/taf/api/merge.py
@@ -266,6 +266,13 @@ def _verify_previously_merged_repos_intact(
     still be caught the next time this runs rather than only when new work for that
     repo happens to line up. Silently re-merging over a regressed destination would
     paper over the loss, so it is raised instead of healed.
+
+    Only a positively established regression is raised. If the declared commit is
+    not in the repo at all, or the destination branch is not there to compare
+    against, the ancestor check cannot answer the question - the target repo may
+    simply be one whose branch another system pushes and rewinds, as with a
+    single-commit update branch. Those are left to the post-merge repository
+    validation rather than reported as corruption here.
     """
     top_commit = auth_repo.top_commit_of_branch(default_branch)
     if top_commit is None:
@@ -281,6 +288,10 @@ def _verify_previously_merged_repos_intact(
         if destination is None:
             continue
         repo.create_local_branch_from_remote_tracking(destination)
+        if not repo.commit_exists(declared_commit):
+            continue
+        if not repo.branch_exists(destination, include_remotes=False):
+            continue
         if not repo.is_commit_an_ancestor_of_a_commit_or_branch(
             declared_commit, destination
         ):
@@ -422,7 +433,38 @@ def _merge_one_branch(
     git_access_token: Optional[str],
 ) -> Tuple[int, Set[GitRepository]]:
     """Returns the number of auth commits signed (0 if nothing was merged) and
-    the set of target repositories whose destination branch moved."""
+    the set of target repositories whose destination branch moved.
+
+    Leaves the authentication repository on its default branch when it returns, so
+    a branch that turns out to have nothing to merge does not leave the repo parked
+    on that source branch. A failure is left where it happened, for the caller to
+    inspect or repair.
+    """
+    result = _merge_source_branch(
+        auth_repo,
+        source_branch,
+        policy,
+        default_branch,
+        library_dir,
+        keystore,
+        git_access_token,
+    )
+    try:
+        auth_repo.checkout_branch(default_branch)
+    except GitError:
+        taf_logger.warning(f"Could not check out {default_branch} of {auth_repo.name}")
+    return result
+
+
+def _merge_source_branch(
+    auth_repo: AuthenticationRepository,
+    source_branch: str,
+    policy: MergePolicy,
+    default_branch: str,
+    library_dir: Optional[str],
+    keystore: Optional[str],
+    git_access_token: Optional[str],
+) -> Tuple[int, Set[GitRepository]]:
     auth_repo.checkout_branch(default_branch)
     auth_repo.checkout_branch(source_branch)
 
@@ -584,7 +626,8 @@ def merge_branch_commits(
     except GitError:
         validate_from_commit = None
 
-    _verify_previously_merged_repos_intact(auth_repo, default_branch, library_dir)
+    if policy.verify_merged_destinations:
+        _verify_previously_merged_repos_intact(auth_repo, default_branch, library_dir)
 
     source_branches = select_branches(auth_repo, pattern, group_by=policy.group_by)
     if not source_branches:

--- a/taf/api/merge.py
+++ b/taf/api/merge.py
@@ -146,6 +146,28 @@ def _load_non_archived_repos(
     }
 
 
+def _load_non_archived_repos_uncached(
+    auth_repo, library_dir, commit
+) -> Dict[str, GitRepository]:
+    """
+    Like `_load_non_archived_repos`, but bypasses repositoriesdb's process-wide cache.
+    That cache is keyed only by (auth repo path, commit): whichever caller loads a
+    commit first fixes the repo class for every later caller of that same commit, even
+    one that needs a different `repo_classes`. Used for a check that runs on every
+    `merge_branch_commits` call regardless of new work, so it must not be the one to
+    win that race against a caller (e.g. platform's own repo-class loading) that needs
+    a specific subclass for the same commit.
+    """
+    repos = repositoriesdb._load_repositories(
+        auth_repo, library_dir=library_dir, commits=[commit], only_load_targets=False
+    )
+    return {
+        name: repo
+        for name, repo in repos.get(commit, {}).items()
+        if not repo.custom.get("archived")
+    }
+
+
 def _build_steps(auth_repo, unmerged_auth_commits, repo_names) -> List[MergeStep]:
     steps = []
     for commit in unmerged_auth_commits:
@@ -200,14 +222,75 @@ def _plan_merge(
     return plan
 
 
-def _check_no_force_push(source_branch, merge_plan, repos_by_name) -> None:
-    for name, (_, declared_commit) in merge_plan.items():
+def _drop_or_reject_missing_commits(
+    source_branch, merge_plan, repos_by_name
+) -> Dict[str, Tuple[str, Commitish]]:
+    """
+    A repo whose local branch mirrors `source_branch` (speculative, rdf) moves in
+    lockstep with the auth branch, so a declared commit missing from all of its
+    branches is a corruption signal - typically a force push - and an error.
+
+    A repo that does not mirror it (a single-commit update branch, whose commit is
+    expected to already exist from a separate push) is not required to have that
+    commit yet; if it does not, the repo is just not ready to merge, so it is
+    dropped from the plan instead of raised.
+    """
+    filtered = {}
+    for name, (destination, declared_commit) in merge_plan.items():
         repo = repos_by_name[name]
-        if not repo.branches_containing_commit(declared_commit):
+        if repo.branches_containing_commit(declared_commit):
+            filtered[name] = (destination, declared_commit)
+            continue
+        if repo.branch_exists(source_branch):
             raise MergeError(
                 f"{source_branch}: declared commit {declared_commit} for {name} no "
                 "longer exists on any branch of that repository - check for a force push"
             )
+        taf_logger.warning(
+            f"{source_branch}: declared commit {declared_commit} for {name} not yet "
+            "found on any branch of that repository - skipping"
+        )
+    return filtered
+
+
+def _verify_previously_merged_repos_intact(
+    auth_repo: AuthenticationRepository, default_branch: str, library_dir: Optional[str]
+) -> None:
+    """
+    Every target repo already merged by a previous call must still contain, on its
+    declared destination branch, the commit the auth repo's current default-branch
+    state declares for it. This runs on every call, regardless of whether there is
+    any new work to merge: a target repo's destination branch can be rewritten
+    (a manual reset, or a force push straight to the destination rather than through
+    a batch branch) at a time when no new batch touches that repo, and it should
+    still be caught the next time this runs rather than only when new work for that
+    repo happens to line up. Silently re-merging over a regressed destination would
+    paper over the loss, so it is raised instead of healed.
+    """
+    top_commit = auth_repo.top_commit_of_branch(default_branch)
+    if top_commit is None:
+        return
+    repos = _load_non_archived_repos_uncached(auth_repo, library_dir, top_commit)
+    corrupted = []
+    for name, repo in sorted(repos.items()):
+        target = auth_repo.get_target(name, top_commit)
+        if target is None:
+            continue
+        declared_commit = Commitish.from_hash(target["commit"])
+        destination = target.get("branch") or repo.default_branch
+        if destination is None:
+            continue
+        repo.create_local_branch_from_remote_tracking(destination)
+        if not repo.is_commit_an_ancestor_of_a_commit_or_branch(
+            declared_commit, destination
+        ):
+            corrupted.append(
+                f"{name}: previously merged commit {declared_commit} is no longer an "
+                f"ancestor of {destination} - that branch may have been rewritten "
+                "since the last merge"
+            )
+    if corrupted:
+        raise MergeError("\n".join(corrupted))
 
 
 def _mirrored_repos(source_branch, merge_plan, repos_by_name, qualifying_steps, policy):
@@ -360,7 +443,17 @@ def _merge_one_branch(
 
     qualifying_steps = steps[: last_index + 1]
     final_step = qualifying_steps[-1]
-    merge_plan = _plan_merge(repos_by_name, final_step)
+    planned_merge_plan = _plan_merge(repos_by_name, final_step)
+    merge_plan = _drop_or_reject_missing_commits(
+        source_branch, planned_merge_plan, repos_by_name
+    )
+    if planned_merge_plan and not merge_plan:
+        # Every repo that had new work was not actually ready for it (the
+        # update-branch case) - unlike an empty `planned_merge_plan`, which just
+        # means all target repos already sit at their declared commit and the
+        # auth commit is signed on its own, this is nothing to merge at all.
+        taf_logger.info(f"{source_branch}: no target repository ready to merge yet")
+        return 0, set()
 
     old_destinations = {
         name: (
@@ -371,7 +464,6 @@ def _merge_one_branch(
         for name in merge_plan
     }
 
-    _check_no_force_push(source_branch, merge_plan, repos_by_name)
     _validate_fully_participating_repos(
         auth_repo,
         source_branch,
@@ -484,6 +576,8 @@ def merge_branch_commits(
         validate_from_commit = auth_repo.top_commit_of_branch(default_branch)
     except GitError:
         validate_from_commit = None
+
+    _verify_previously_merged_repos_intact(auth_repo, default_branch, library_dir)
 
     source_branches = select_branches(auth_repo, pattern, group_by=policy.group_by)
     if not source_branches:

--- a/taf/api/merge.py
+++ b/taf/api/merge.py
@@ -54,6 +54,37 @@ class MergeStep:
         self.targets: Dict[str, Dict] = targets if targets is not None else {}
 
 
+class MergeResult:
+    """
+    What `merge_branch_commits` did.
+
+    merged_branches
+        Names of the source branches that had at least one commit merged.
+    moved_repos
+        Names of the target repositories whose destination branch moved.
+    signed_commits
+        Total number of auth repo commits re-signed onto the default branch.
+    """
+
+    def __init__(
+        self,
+        merged_branches: Optional[List[str]] = None,
+        moved_repos: Optional[List[str]] = None,
+        signed_commits: int = 0,
+    ):
+        self.merged_branches: List[str] = (
+            list(merged_branches) if merged_branches else []
+        )
+        self.moved_repos: List[str] = list(moved_repos) if moved_repos else []
+        self.signed_commits: int = signed_commits
+
+    def __repr__(self) -> str:
+        return (
+            f"MergeResult(merged_branches={self.merged_branches!r}, "
+            f"moved_repos={self.moved_repos!r}, signed_commits={self.signed_commits})"
+        )
+
+
 def _sign_and_merge_commit(
     auth_repo: AuthenticationRepository,
     commit: Commitish,
@@ -179,6 +210,37 @@ def _check_no_force_push(source_branch, merge_plan, repos_by_name) -> None:
             )
 
 
+def _mirrored_repos(source_branch, merge_plan, repos_by_name, qualifying_steps, policy):
+    """
+    Repos whose local branch history actually mirrors `source_branch` -
+    `validate_branch` walks them commit-for-commit against the auth branch, which
+    only makes sense for a repo that carries one commit per qualifying step.
+
+    If `policy.allow_uneven_branch_lengths`, a repo whose count differs from the
+    step count (e.g. rdf carrying one extra rebuild commit) is excluded here and
+    left to the post-merge repository validation instead. Otherwise an uneven
+    count is left in and surfaces as a validation error - the ordinary signal
+    that a repo's branch lost commits to a force push.
+    """
+    mirrored = [
+        (name, destination)
+        for name, (destination, _) in merge_plan.items()
+        if repos_by_name[name].branch_exists(source_branch)
+    ]
+    if not policy.allow_uneven_branch_lengths:
+        return mirrored
+    return [
+        (name, destination)
+        for name, destination in mirrored
+        if len(
+            repos_by_name[name].commits_on_branch_and_not_other(
+                source_branch, destination
+            )
+        )
+        == len(qualifying_steps)
+    ]
+
+
 def _validate_fully_participating_repos(
     auth_repo,
     source_branch,
@@ -188,20 +250,13 @@ def _validate_fully_participating_repos(
     repos_by_name,
     qualifying_steps,
 ) -> None:
-    fully_participating = [
-        repos_by_name[name]
-        for name, (destination, _) in merge_plan.items()
-        if repos_by_name[name].branch_exists(source_branch)
-        and len(
-            repos_by_name[name].commits_on_branch_and_not_other(
-                source_branch, destination
-            )
-        )
-        == len(qualifying_steps)
-    ]
-    if not fully_participating:
+    mirrored = _mirrored_repos(
+        source_branch, merge_plan, repos_by_name, qualifying_steps, policy
+    )
+    if not mirrored:
         return
 
+    fully_participating = [repos_by_name[name] for name, _ in mirrored]
     updated_roles = sorted(
         {
             r
@@ -216,8 +271,13 @@ def _validate_fully_participating_repos(
     check_branch_roles = {
         r: r in check_branch_id_role_set for r in check_capstone_roles
     }
-    merge_branches = {repo: merge_plan[repo.name][0] for repo in fully_participating}
+    merge_branches = {
+        repos_by_name[name]: destination for name, destination in mirrored
+    }
     merge_branches[auth_repo] = default_branch
+    check_branch_lengths_fun = (
+        (lambda *_a, **_k: None) if policy.allow_uneven_branch_lengths else None
+    )
     try:
         validate_branch(
             auth_repo,
@@ -227,7 +287,7 @@ def _validate_fully_participating_repos(
             updated_roles,
             check_capstone_roles,
             check_branch_roles,
-            check_branch_lengths_fun=lambda *_a, **_k: None,
+            check_branch_lengths_fun=check_branch_lengths_fun,
         )
     except InvalidBranchError as e:
         raise MergeError(f"{source_branch}: validation error: {e}")
@@ -270,7 +330,9 @@ def _merge_one_branch(
     library_dir: Optional[str],
     keystore: Optional[str],
     git_access_token: Optional[str],
-) -> Tuple[bool, Set]:
+) -> Tuple[int, Set[GitRepository]]:
+    """Returns the number of auth commits signed (0 if nothing was merged) and
+    the set of target repositories whose destination branch moved."""
     auth_repo.checkout_branch(default_branch)
     auth_repo.checkout_branch(source_branch)
 
@@ -280,11 +342,11 @@ def _merge_one_branch(
         )
     except RoleMetadataNotSameError as e:
         taf_logger.error(str(e))
-        return False, set()
+        return 0, set()
 
     if not unmerged_auth_commits:
         taf_logger.info(f"{source_branch}: all commits already merged")
-        return False, set()
+        return 0, set()
 
     repos_by_name = _load_non_archived_repos(
         auth_repo, library_dir, unmerged_auth_commits[-1]
@@ -294,7 +356,7 @@ def _merge_one_branch(
     last_index = _last_qualifying_step_index(steps, policy.gate)
     if last_index < 0:
         taf_logger.info(f"{source_branch}: no commits ready to merge yet")
-        return False, set()
+        return 0, set()
 
     qualifying_steps = steps[: last_index + 1]
     final_step = qualifying_steps[-1]
@@ -331,7 +393,7 @@ def _merge_one_branch(
             merge_plan, repos_by_name, old_destinations, git_access_token
         )
 
-    return True, {repos_by_name[name] for name in merge_plan}
+    return len(qualifying_steps), {repos_by_name[name] for name in merge_plan}
 
 
 def _rename_merged_branch(auth_repo: AuthenticationRepository, branch: str) -> None:
@@ -362,14 +424,15 @@ def _rename_merged_branch(auth_repo: AuthenticationRepository, branch: str) -> N
 )
 def merge_branch_commits(
     path: str,
-    pin_manager: PinManager,
+    *,
     policy: MergePolicy,
+    pin_manager: Optional[PinManager] = None,
     library_dir: Optional[str] = None,
     pushed_branch: Optional[str] = None,
     keystore: Optional[str] = None,
     deploy: bool = False,
     git_access_token: Optional[str] = None,
-) -> None:
+) -> MergeResult:
     """
     Merge commits of the branch(es) matching `policy.branch_pattern` - the
     newest overall, or the newest per `policy.group_by` group - into each
@@ -379,6 +442,8 @@ def merge_branch_commits(
     Arguments:
         path: Path to the authentication repository.
         policy: The merge policy to apply - see `taf.models.merge.MergePolicy`.
+        pin_manager (optional): Reused across calls if the caller already has one (e.g.
+            `auth_repo.pin_manager`); a fresh one is created if not given.
         library_dir (optional): Directory containing the target repositories.
         pushed_branch (optional): If given, this call is a no-op unless it matches
             `policy.branch_pattern` (used to filter which CI trigger should act).
@@ -397,7 +462,7 @@ def merge_branch_commits(
         MergeError, RoleMetadataNotSameError
 
     Returns:
-        None
+        A `MergeResult` describing what was merged - empty if there was nothing to do.
     """
     pattern = BranchPattern(policy.branch_pattern)
     if pushed_branch is not None and not pattern.matches(pushed_branch):
@@ -405,7 +470,10 @@ def merge_branch_commits(
             f"Pushed branch {pushed_branch} does not match pattern "
             f"'{policy.branch_pattern}', nothing to merge"
         )
-        return
+        return MergeResult()
+
+    if pin_manager is None:
+        pin_manager = PinManager()
 
     auth_repo = AuthenticationRepository(path=path, pin_manager=pin_manager)
     default_branch = auth_repo.default_branch
@@ -420,12 +488,13 @@ def merge_branch_commits(
     source_branches = select_branches(auth_repo, pattern, group_by=policy.group_by)
     if not source_branches:
         taf_logger.info(f"No branch matching pattern '{policy.branch_pattern}' found")
-        return
+        return MergeResult()
 
-    merged_branches = []
-    touched_repos: Set = set()
+    merged_branches: List[str] = []
+    touched_repos: Set[GitRepository] = set()
+    signed_commits = 0
     for source_branch in source_branches:
-        signed, repos = _merge_one_branch(
+        branch_signed_commits, repos = _merge_one_branch(
             auth_repo,
             source_branch,
             policy,
@@ -434,12 +503,13 @@ def merge_branch_commits(
             keystore,
             git_access_token,
         )
-        if signed:
+        if branch_signed_commits:
             merged_branches.append(source_branch)
+            signed_commits += branch_signed_commits
             touched_repos.update(repos)
 
     if not merged_branches:
-        return
+        return MergeResult()
 
     try:
         validate_repository(
@@ -457,9 +527,15 @@ def merge_branch_commits(
             f"there is a problem with the TAF updater.\n{e}"
         )
 
+    result = MergeResult(
+        merged_branches=merged_branches,
+        moved_repos=sorted(repo.name for repo in touched_repos),
+        signed_commits=signed_commits,
+    )
+
     if not deploy:
         taf_logger.info("deploy=False; skipping push")
-        return
+        return result
 
     taf_logger.info(f"Pushing {len(touched_repos)} target repo(s) and auth repo")
     for repo in touched_repos:
@@ -469,3 +545,5 @@ def merge_branch_commits(
     if policy.rename_merged:
         for branch in merged_branches:
             _rename_merged_branch(auth_repo, branch)
+
+    return result

--- a/taf/branches.py
+++ b/taf/branches.py
@@ -1,0 +1,187 @@
+"""
+Generic helpers for recognizing, ordering and tracking "batch" branches -
+branches in an authentication repository whose commits each authenticate one
+commit of one or more target repositories (e.g. speculative branches,
+publication branches, or single-commit update branches).
+
+These helpers are pattern-driven rather than hardcoded to any particular
+naming convention: callers supply a `BranchPattern` built from a regular
+expression with named capture groups, and that pattern is used both to
+recognize matching branches and to order them (oldest/newest first) using
+the values of its named groups.
+"""
+
+import os
+from pathlib import Path
+import re
+from typing import List, Optional, Tuple
+
+from taf.exceptions import GitError, RoleMetadataNotSameError
+from taf.models.types import Commitish
+
+
+class BranchPattern:
+    """
+    Wraps a compiled regular expression used to recognize and order a family
+    of branch names (e.g. `^publication/(?P<pub_date>...)\\.(?P<spec_date>...)$`).
+
+    The pattern's named capture groups, in the order in which they are
+    defined, are used as the branch's sort key.
+    """
+
+    def __init__(self, pattern: str):
+        self.pattern = pattern
+        self._regex = re.compile(pattern)
+        self._group_names = sorted(
+            self._regex.groupindex, key=lambda name: self._regex.groupindex[name]
+        )
+
+    def has_group(self, name: str) -> bool:
+        return name in self._regex.groupindex
+
+    def matches(self, branch_name: str) -> bool:
+        return self._regex.match(branch_name) is not None
+
+    def group(self, branch_name: str, name: str) -> Optional[str]:
+        match = self._regex.match(branch_name)
+        if match is None:
+            return None
+        try:
+            return match.group(name)
+        except (IndexError, re.error):
+            return None
+
+    def sort_key(self, branch_name: str) -> Tuple[str, ...]:
+        match = self._regex.match(branch_name)
+        if match is None:
+            return tuple()
+        return tuple(match.group(name) or "" for name in self._group_names)
+
+    def __repr__(self):
+        return f"BranchPattern({self.pattern!r})"
+
+
+def select_branches(
+    repo,
+    pattern: BranchPattern,
+    group_by: Optional[str] = None,
+    traverse_branch: Optional[str] = None,
+    include_remotes: bool = True,
+) -> List[str]:
+    """
+    Select the newest branch of `repo` matching `pattern` that is reachable
+    from `traverse_branch` (the repository's default branch, if not given) -
+    one branch overall, or one per distinct value of the `group_by` named
+    group if given (e.g. one per role, for update branches).
+
+    "Newest" is judged first by how recently the branch diverged from
+    `traverse_branch`'s history, then by the pattern's sort key - this is
+    what keeps a same-day branch cut off an older commit from outranking one
+    cut off a more recent commit, regardless of name.
+    """
+    traverse_branch = traverse_branch or repo.default_branch
+
+    if group_by is None:
+        branch = repo.find_first_branch_matching_pattern(
+            traverse_branch,
+            pattern.matches,
+            include_remotes=include_remotes,
+            sort_key_func=pattern.sort_key,
+        )
+        return [branch] if branch else []
+
+    all_branches = repo.branches(all=include_remotes, strip_remote=True)
+    group_values: List[str] = sorted(
+        {
+            value
+            for branch in all_branches
+            if pattern.matches(branch)
+            for value in [pattern.group(branch, group_by)]
+            if value is not None
+        }
+    )
+
+    selected = []
+    for value in group_values:
+        branch = repo.find_first_branch_matching_pattern(
+            traverse_branch,
+            lambda b, v=value: pattern.matches(b) and pattern.group(b, group_by) == v,
+            include_remotes=include_remotes,
+            sort_key_func=pattern.sort_key,
+        )
+        if branch:
+            selected.append(branch)
+    return sorted(selected, key=pattern.sort_key, reverse=True)
+
+
+def role_metadata_version(auth_repo, role: str, commit: Optional[Commitish]) -> int:
+    """Read the version of `role`'s metadata file at `commit` (0 if it did not exist)."""
+    try:
+        role_metadata_path = os.path.join("metadata", f"{role}.json")
+        metadata = auth_repo.get_json(commit, role_metadata_path)
+        return metadata["signed"]["version"]
+    except (GitError, KeyError, TypeError):
+        return 0
+
+
+def updated_roles_at_commit(auth_repo, commit: Commitish) -> List[str]:
+    """Return the names of the roles whose metadata file changed at `commit`."""
+    updated_files = auth_repo.list_changed_files_at_revision(commit)
+    return [
+        Path(updated_file).stem
+        for updated_file in updated_files
+        if Path(updated_file).parent.name == "metadata"
+    ]
+
+
+def find_unmerged_auth_commits(
+    auth_repo, branch: str, default_branch: Optional[str] = None
+) -> List[Commitish]:
+    """
+    Return, oldest first, the commits of `branch` (an auth repo branch whose
+    commits authenticate commits of one or more target repositories) which
+    have not yet been merged into `default_branch`.
+
+    A commit is unmerged if any role it touches has a higher metadata
+    version on `branch` than on `default_branch` - auth commits are re-signed
+    onto the default branch rather than fast-forwarded, so branch commits
+    never become git-reachable from it, and metadata version is the only
+    reliable "already merged" watermark. No particular role needs to be
+    named: a commit's own changed metadata files say which roles it touched.
+
+    Raises RoleMetadataNotSameError if a touched role's metadata content
+    differs between `branch` and `default_branch` at the same version - that
+    means it was independently modified on `default_branch` since `branch`
+    was created, and none of `branch`'s commits can be safely merged.
+    """
+    default_branch = default_branch or auth_repo.default_branch
+    all_branch_commits = auth_repo.commits_on_branch_and_not_other(
+        branch, default_branch
+    )
+    if not len(all_branch_commits):
+        return []
+
+    default_commit = auth_repo.top_commit_of_branch(default_branch)
+    unmerged_commits = []
+
+    for commit in all_branch_commits:
+        is_unmerged = False
+        for role in updated_roles_at_commit(auth_repo, commit):
+            metadata_path = f"metadata/{role}.json"
+            default_version = role_metadata_version(auth_repo, role, default_commit)
+            commit_version = role_metadata_version(auth_repo, role, commit)
+            if commit_version > default_version:
+                is_unmerged = True
+            elif commit_version == default_version:
+                if auth_repo.get_json(
+                    default_commit, metadata_path
+                ) != auth_repo.get_json(commit, metadata_path):
+                    raise RoleMetadataNotSameError(
+                        f"{metadata_path} modified on {default_branch}! Commits of "
+                        f"branch {branch} cannot be merged"
+                    )
+        if not is_unmerged:
+            break
+        unmerged_commits.append(commit)
+
+    return unmerged_commits[::-1]

--- a/taf/exceptions.py
+++ b/taf/exceptions.py
@@ -234,6 +234,14 @@ class NoSpeculativeBranchError(TAFError):
     pass
 
 
+class MergeError(TAFError):
+    pass
+
+
+class RoleMetadataNotSameError(TAFError):
+    pass
+
+
 class RepositoriesNotFoundError(TAFError):
     pass
 

--- a/taf/git.py
+++ b/taf/git.py
@@ -1179,7 +1179,7 @@ class GitRepository:
     def create_local_branch_from_remote_tracking(self, branch, remote="origin"):
         repo = self.pygit_repo
         remote_branch_name = f"refs/remotes/{remote}/{branch}"
-        remote_branch = repo.lookup_reference(remote_branch_name)
+        remote_branch = repo.references.get(remote_branch_name)
         if remote_branch is not None:
             local_branch = repo.lookup_branch(branch, pygit2.GIT_BRANCH_LOCAL)
             if local_branch is None:
@@ -1682,7 +1682,7 @@ class GitRepository:
         if start_commit is not None:
             start_commit_id = repo.get(start_commit.hash).id
         elif branch:
-            branch_obj = repo.branches.get(branch)
+            branch_obj = repo.branches.get(self.get_branch_reference(branch))
             start_commit_id = branch_obj.target
         else:
             start_commit_id = repo[repo.head.target].id

--- a/taf/git.py
+++ b/taf/git.py
@@ -1186,6 +1186,7 @@ class GitRepository:
                 # Create a new local branch from the remote branch
                 target_commit = repo[remote_branch.target]
                 repo.create_branch(branch, target_commit)
+                self.set_tracking_branch(branch, remote=remote)
 
     def delete_local_branch(self, branch_name: str) -> None:
         """Deletes local branch."""

--- a/taf/git_providers.py
+++ b/taf/git_providers.py
@@ -1,0 +1,110 @@
+"""
+Minimal git hosting provider API, used to change a remote repository's
+default branch after a new declared (e.g. publication) branch is merged.
+Uses `urllib` rather than `requests` to avoid adding a dependency.
+"""
+
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from typing import Optional
+
+from taf.exceptions import TAFError
+
+GIT_URL_RE = re.compile(
+    r"(git|ssh|http(s)?)(@|:\/\/)?(?P<provider_owner_repo>[\w\.\:\/\-~]+)(\.git)(\/)?$"
+)
+
+
+class GitProviderError(TAFError):
+    pass
+
+
+def _extract_provider_owner_repo(git_remote_url: str):
+    """
+    Extract provider name, owner name and repository name from a remote
+    origin URL, e.g.:
+        https://github.com/some-org/some-repo.git
+        git@github.com:some-org/some-repo.git
+    """
+    git_remote_url = (
+        git_remote_url if git_remote_url.endswith(".git") else f"{git_remote_url}.git"
+    )
+
+    match = GIT_URL_RE.match(git_remote_url)
+    if match is None:
+        raise ValueError(
+            f"Git repository at {git_remote_url} does not have a valid remote origin url!"
+        )
+
+    provider, owner, repo_name = (
+        match.group("provider_owner_repo").replace(":", "/").split("/")
+    )
+    if provider is None or owner is None or repo_name is None:
+        raise ValueError(
+            "Cannot extract provider, owner and repo information from remote "
+            f"origin url: {git_remote_url}"
+        )
+
+    return provider, owner, repo_name
+
+
+class GitProvider:
+    """Base class representing a git hosting provider."""
+
+    API_BASE_URL: Optional[str] = None
+
+    def __init__(self, owner: str, repo_name: str, access_token: Optional[str] = None):
+        self.owner = owner
+        self.name = repo_name
+        self.access_token = access_token
+
+    def set_default_branch(self, branch_name: str) -> None:
+        raise NotImplementedError
+
+
+class GitHubProvider(GitProvider):
+    """Talks to the GitHub REST API."""
+
+    API_BASE_URL = "https://api.github.com"
+
+    def set_default_branch(self, branch_name: str) -> None:
+        url = f"{self.API_BASE_URL}/repos/{self.owner}/{self.name}"
+        data = json.dumps({"default_branch": branch_name}).encode("utf-8")
+        request = urllib.request.Request(
+            url,
+            data=data,
+            method="PATCH",
+            headers={
+                "Authorization": f"token {self.access_token}",
+                "Content-Type": "application/json",
+                "Accept": "application/vnd.github+json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request) as response:  # nosec B310
+                body = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            body = json.loads(e.read().decode("utf-8"))
+            err_msg = os.linesep.join(
+                err.get("message", "") for err in body.get("errors", [])
+            )
+            if not err_msg:
+                err_msg = body.get("message", "")
+            raise GitProviderError(err_msg)
+
+        if body.get("default_branch", "") != branch_name:
+            raise GitProviderError(
+                f"Could not set default branch of {self.owner}/{self.name} to {branch_name}"
+            )
+
+
+def get_git_provider(repo, access_token: Optional[str] = None) -> GitProvider:
+    """Return a `GitProvider` for `repo`, based on its remote origin URL."""
+    provider_name, owner_name, repo_name = _extract_provider_owner_repo(
+        repo.get_remote_url()
+    )
+    provider_class = {"github.com": GitHubProvider}.get(provider_name, GitProvider)
+    return provider_class(owner_name, repo_name, access_token)

--- a/taf/models/merge.py
+++ b/taf/models/merge.py
@@ -59,6 +59,13 @@ class MergePolicy:
         commit `validate_branch` check and left to the post-merge repository
         validation instead. If not set, an uneven count is an error - the ordinary
         signal that a repository's branch lost commits to a force push.
+    verify_merged_destinations
+        Before merging anything, check that every repository's destination branch
+        still descends from the commit the last merge declared for it, and refuse
+        to merge if one has been rewound. Turn this off for a policy whose target
+        repositories are pushed - and legitimately rewound - by another system
+        rather than moved by this merge, as with single-commit update branches;
+        the post-merge repository validation still reports the mismatch there.
     """
 
     branch_pattern: str
@@ -69,6 +76,7 @@ class MergePolicy:
     rename_merged: bool = False
     set_default_branch: bool = False
     allow_uneven_branch_lengths: bool = False
+    verify_merged_destinations: bool = True
 
     def __attrs_post_init__(self):
         if self.group_by and not _pattern_has_group(self.branch_pattern, self.group_by):

--- a/taf/models/merge.py
+++ b/taf/models/merge.py
@@ -52,6 +52,13 @@ class MergePolicy:
     set_default_branch
         If a repository's destination branch changed, set it as that repository's
         default branch on its git hosting provider.
+    allow_uneven_branch_lengths
+        Allow a participating repository's commit count on the source branch to
+        differ from the number of qualifying auth commits (e.g. an rdf repo carrying
+        one extra rebuild commit). Such a repository is excluded from the commit-by-
+        commit `validate_branch` check and left to the post-merge repository
+        validation instead. If not set, an uneven count is an error - the ordinary
+        signal that a repository's branch lost commits to a force push.
     """
 
     branch_pattern: str
@@ -61,6 +68,7 @@ class MergePolicy:
     check_branch_id_roles: List[str] = attrs.field(factory=list)
     rename_merged: bool = False
     set_default_branch: bool = False
+    allow_uneven_branch_lengths: bool = False
 
     def __attrs_post_init__(self):
         if self.group_by and not _pattern_has_group(self.branch_pattern, self.group_by):

--- a/taf/models/merge.py
+++ b/taf/models/merge.py
@@ -1,0 +1,229 @@
+"""
+Merge policy configuration - the small amount of merge behaviour that is not
+already carried in an authentication repository's signed target files
+(destination branch, commit and any date gate are read from there; see
+`taf.api.merge`). What is left - branch name patterns and capstone role
+policy - lives here.
+
+A policy file is signed JSON, normally at `targets/merge-policies.json` in a
+root authentication repository shared by several partner repositories, so
+changing it does not require re-signing every partner. Resolution order,
+first hit wins: an explicit `--config` file, the root repository's signed
+file, then the built-in defaults below.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional
+
+import attrs
+import cattrs
+
+from taf.exceptions import InvalidConfigError
+
+
+@attrs.define(slots=True, frozen=True, kw_only=True)
+class MergePolicy:
+    """
+    One named merge policy.
+
+    Attributes
+    ----------
+    branch_pattern
+        Regular expression, with named capture groups, identifying and ordering
+        source branches.
+    group_by
+        Name of a group in `branch_pattern` to select the newest branch per distinct
+        value of (e.g. "role", for update branches with one branch family per role).
+        If not given, the single newest matching branch is selected.
+    gate
+        Targets-metadata key holding an ISO date. Commits are merged up to the last one
+        whose value for this key is today or earlier. If not given, all unmerged commits
+        are merged.
+    no_capstone_roles
+        Roles exempt from the "branch ends with a capstone target file" check.
+    check_branch_id_roles
+        Roles whose branch ID should be validated across the whole branch.
+    rename_merged
+        Rename each merged branch to `merged/<branch>` and push the rename.
+    set_default_branch
+        If a repository's destination branch changed, set it as that repository's
+        default branch on its git hosting provider.
+    """
+
+    branch_pattern: str
+    group_by: Optional[str] = None
+    gate: Optional[str] = None
+    no_capstone_roles: List[str] = attrs.field(factory=list)
+    check_branch_id_roles: List[str] = attrs.field(factory=list)
+    rename_merged: bool = False
+    set_default_branch: bool = False
+
+    def __attrs_post_init__(self):
+        if self.group_by and not _pattern_has_group(self.branch_pattern, self.group_by):
+            raise InvalidConfigError(
+                f"group-by '{self.group_by}' is not a named group in "
+                f"branch-pattern '{self.branch_pattern}'"
+            )
+
+
+def _pattern_has_group(pattern: str, group: str) -> bool:
+    return group in re.compile(pattern).groupindex
+
+
+MERGE_POLICIES_TARGET_PATH = "merge-policies.json"
+
+_converter = cattrs.Converter(forbid_extra_keys=False)
+
+
+def _kebab_to_snake(data: Any) -> Any:
+    if isinstance(data, dict):
+        return {k.replace("-", "_"): _kebab_to_snake(v) for k, v in data.items()}
+    if isinstance(data, list):
+        return [_kebab_to_snake(v) for v in data]
+    return data
+
+
+def build_policy(**fields: Any) -> MergePolicy:
+    """Build a `MergePolicy` from snake_case fields, e.g. `build_policy(branch_pattern=...)`."""
+    try:
+        return _converter.structure(fields, MergePolicy)
+    except cattrs.ClassValidationError as e:
+        cause = e.exceptions[0]
+        if isinstance(cause, InvalidConfigError):
+            raise cause from e
+        raise
+
+
+DEFAULT_POLICIES: Dict[str, MergePolicy] = {
+    "speculative": build_policy(
+        branch_pattern=(
+            r"^publication/(?P<pub_date>\d{4}-\d{2}(-\d{2})?(-\d{2})?)"
+            r"\.(?P<spec_date>\d{4}-\d{2}-\d{2}(-\d{2})?)$"
+        ),
+        gate="codified-date",
+        no_capstone_roles=["docs", "assets"],
+    ),
+    "rdf": build_policy(
+        branch_pattern=(
+            r"^rdf/publication/(?P<pub_date>\d{4}-\d{2}(-\d{2})?(-\d{2})?)"
+            r"\.(?P<spec_date>\d{4}-\d{2}-\d{2}(-\d{2})?)$"
+        ),
+        gate="codified-date",
+    ),
+    "update": build_policy(
+        branch_pattern=r"^update/(?P<role>\w+)\.(?P<date>\d{4}-\d{2}-\d{2})(?P<idx>-\d{2})?$",
+        group_by="role",
+        rename_merged=True,
+    ),
+}
+
+
+@attrs.define(slots=True, frozen=True, kw_only=True)
+class MergePolicies:
+    """In-memory representation of a `merge-policies.json` file."""
+
+    policies: Dict[str, MergePolicy] = attrs.field(factory=dict)
+    partners: Dict[str, Dict[str, Dict[str, Any]]] = attrs.field(factory=dict)
+
+    @classmethod
+    def from_mapping(cls, mapping: Mapping[str, Any]) -> "MergePolicies":
+        try:
+            return _converter.structure(_kebab_to_snake(dict(mapping)), cls)
+        except cattrs.BaseValidationError as e:
+            messages = "; ".join(str(sub) for sub in e.exceptions)
+            raise InvalidConfigError(f"Invalid merge-policies.json: {messages}") from e
+
+    def resolve(self, name: str, partner_name: Optional[str] = None) -> MergePolicy:
+        base_policy = self.policies.get(name) or DEFAULT_POLICIES.get(name)
+        if base_policy is None:
+            raise InvalidConfigError(f"Unknown merge policy '{name}'")
+
+        overrides = (
+            self.partners.get(partner_name, {}).get(name) if partner_name else None
+        )
+        if not overrides:
+            return base_policy
+        return attrs.evolve(base_policy, **_kebab_to_snake(dict(overrides)))
+
+
+def resolve_policy(
+    name: str,
+    config_path: Optional[str] = None,
+    root_auth_repo: Optional[Any] = None,
+    partner_name: Optional[str] = None,
+) -> MergePolicy:
+    """
+    Resolve the merge policy named `name`, first hit wins:
+
+    1. `config_path` - a local `merge-policies.json`-shaped file.
+    2. `root_auth_repo`'s signed `targets/merge-policies.json`, if it has one.
+    3. The built-in default for `name`.
+    """
+    if config_path is not None:
+        data = json.loads(Path(config_path).read_text())
+        return MergePolicies.from_mapping(data).resolve(name, partner_name)
+
+    if root_auth_repo is not None:
+        commit = root_auth_repo.head_commit()
+        if commit is not None:
+            raw = root_auth_repo.safely_get_json(
+                commit, f"targets/{MERGE_POLICIES_TARGET_PATH}"
+            )
+            if raw is not None:
+                return MergePolicies.from_mapping(raw).resolve(name, partner_name)
+
+    if name not in DEFAULT_POLICIES:
+        raise InvalidConfigError(
+            f"Unknown merge policy '{name}' and no config was found to provide it"
+        )
+    return DEFAULT_POLICIES[name]
+
+
+def locate_root_auth_repo(
+    library_dir: Optional[str], root_auth_path: Optional[str] = None
+):
+    """
+    Locate the root authentication repository, either at `root_auth_path`
+    directly, or via the `[root]` table of `<library_dir>/.taf/config.toml`.
+    Returns None if neither is available.
+    """
+    from taf.auth_repo import AuthenticationRepository
+    from taf.config import load_config
+
+    if root_auth_path is not None:
+        return AuthenticationRepository(path=root_auth_path)
+
+    if library_dir is None:
+        return None
+
+    config_toml = Path(library_dir, ".taf", "config.toml")
+    if not config_toml.is_file():
+        return None
+
+    try:
+        cfg = load_config(str(config_toml))
+    except (FileNotFoundError, InvalidConfigError):
+        return None
+    if cfg.root is None:
+        return None
+
+    root_path = Path(library_dir, cfg.root.org, cfg.root.name)
+    if not root_path.is_dir():
+        return None
+    return AuthenticationRepository(path=root_path)
+
+
+def partner_name(auth_repo) -> Optional[str]:
+    """Return `<namespace>/<name>` for `auth_repo`, from its signed info.json, if set."""
+    info = auth_repo.get_info_json()
+    if not info:
+        return None
+    namespace = info.get("namespace")
+    name = info.get("name")
+    if namespace is None or name is None:
+        return None
+    return f"{namespace}/{name}"

--- a/taf/tests/test_branches/conftest.py
+++ b/taf/tests/test_branches/conftest.py
@@ -1,0 +1,5 @@
+from taf.tests.test_git.conftest import (  # noqa: F401
+    clone_repository,
+    origin_repo,
+    repository,
+)

--- a/taf/tests/test_branches/test_branch_patterns.py
+++ b/taf/tests/test_branches/test_branch_patterns.py
@@ -1,0 +1,151 @@
+import pytest
+
+from taf.branches import BranchPattern, select_branches
+
+SPECULATIVE_PATTERN = BranchPattern(
+    r"^publication\/(?P<pub_date>\d{4}-\d{2}(-\d{2})?(-\d{2})?)"
+    r"\.(?P<spec_date>\d{4}-\d{2}-\d{2}(-\d{2})?)$"
+)
+PUBLICATION_PATTERN = BranchPattern(
+    r"^publication\/(?P<pub_date>(\d{4}-\d{2}(-\d{2})?))(-\d{2})?$"
+)
+RDF_SPECULATIVE_PATTERN = BranchPattern(
+    r"^rdf\/publication\/(?P<pub_date>\d{4}-\d{2}(-\d{2})?(-\d{2})?)"
+    r"\.(?P<spec_date>\d{4}-\d{2}-\d{2}(-\d{2})?)$"
+)
+UPDATE_PATTERN = BranchPattern(
+    r"^update\/(?P<role>(\w+))\.(?P<date>(\d{4}-\d{2}-\d{2}))(?P<idx>(-\d{2}))?$"
+)
+
+
+@pytest.mark.parametrize(
+    "branch_name, expected",
+    [
+        ("publication/2019-10-01.2019-10-15", True),
+        ("publication/2019-10-01-01.2019-10-15-01", True),
+        ("publication/2019-10-11-02.2019-10-15-02", True),
+        ("publication/2019-10.2019-10-15-01", True),
+        ("rdf/publication/2019-10-01.2019-10-15", False),
+        ("2019-12-01", False),
+        ("publication/2019-10.2019-10-15-111", False),
+        ("publication/2019-10.2019-10-15-aa", False),
+        ("some random name", False),
+    ],
+)
+def test_speculative_pattern_matches(branch_name, expected):
+    assert SPECULATIVE_PATTERN.matches(branch_name) == expected
+
+
+@pytest.mark.parametrize(
+    "branch_name, expected",
+    [
+        ("rdf/publication/2019-10-01.2019-10-15", True),
+        ("rdf/publication/2019-10-01-01.2019-10-15-01", True),
+        ("rdf/publication/2019-10.2019-10-15-01", True),
+        ("publication/2019-10-01.2019-10-15", False),
+        ("rdf/publication/2019-10.2019-10-15-111", False),
+        ("rdf/2019-12-01", False),
+    ],
+)
+def test_rdf_speculative_pattern_matches(branch_name, expected):
+    assert RDF_SPECULATIVE_PATTERN.matches(branch_name) == expected
+
+
+@pytest.mark.parametrize(
+    "branch_name, expected",
+    [
+        ("publication/2019-10", True),
+        ("publication/2020-01", True),
+        ("publication/2020-01-01", True),
+        ("publication/2019-10-10-01", True),
+        ("publication/2019-101", False),
+        ("2019-10", False),
+    ],
+)
+def test_publication_pattern_matches(branch_name, expected):
+    assert PUBLICATION_PATTERN.matches(branch_name) == expected
+
+
+def test_speculative_sort_key_orders_by_named_groups():
+    branches = [
+        "publication/2019-11-02.2019-12-01-01",
+        "publication/2019-11-02.2019-12-01",
+        "publication/2019-11-01.2019-11-04",
+        "publication/2019-11.2019-11-04",
+    ]
+    ordered = sorted(branches, key=SPECULATIVE_PATTERN.sort_key, reverse=True)
+    assert ordered == [
+        "publication/2019-11-02.2019-12-01-01",
+        "publication/2019-11-02.2019-12-01",
+        "publication/2019-11-01.2019-11-04",
+        "publication/2019-11.2019-11-04",
+    ]
+
+
+def test_group_returns_named_group_value():
+    assert UPDATE_PATTERN.group("update/docs.2019-10-10-01", "role") == "docs"
+    assert UPDATE_PATTERN.group("update/docs.2019-10-10-01", "date") == "2019-10-10"
+    assert UPDATE_PATTERN.group("update/docs.2019-10-10-01", "idx") == "-01"
+    assert UPDATE_PATTERN.group("not-a-branch", "role") is None
+
+
+def test_has_group():
+    assert UPDATE_PATTERN.has_group("role")
+    assert not UPDATE_PATTERN.has_group("nonexistent")
+
+
+def test_select_branches_returns_empty_list_when_none_match(repository):
+    assert select_branches(repository, SPECULATIVE_PATTERN) == []
+
+
+def test_select_branches_ungrouped(repository):
+    initial_commit = repository.head_commit()
+
+    branch1 = "publication/2019-01-01.2019-01-01"
+    repository.create_branch(branch1)
+    assert select_branches(repository, SPECULATIVE_PATTERN) == [branch1]
+
+    repository.checkout_branch(branch1)
+    assert select_branches(repository, SPECULATIVE_PATTERN) == [branch1]
+
+    repository.checkout_branch(repository.default_branch)
+    repository.commit_empty("Commit 1")
+
+    branch2 = "publication/2019-01-01.2019-01-02"
+    repository.create_branch(branch2)
+    assert select_branches(repository, SPECULATIVE_PATTERN) == [branch2]
+
+    repository.commit_empty("Commit 2")
+
+    # branches off an older commit, even with a name that sorts later, do not win
+    branch3 = "publication/2019-01-01.2019-03-03"
+    repository.create_branch(branch3, initial_commit)
+    assert select_branches(repository, SPECULATIVE_PATTERN) == [branch2]
+
+    branch4 = "publication/2019-01-01.2019-01-04"
+    repository.create_branch(branch4)
+    assert select_branches(repository, SPECULATIVE_PATTERN) == [branch4]
+
+
+def test_select_branches_ungrouped_uses_remotes(repository, clone_repository):
+    branch = "publication/2019-01-01.2019-01-01"
+    repository.create_branch(branch)
+
+    clone_repository.clone_from_disk(repository.path, keep_remote=True)
+
+    assert select_branches(clone_repository, SPECULATIVE_PATTERN) == [branch]
+    assert (
+        select_branches(clone_repository, SPECULATIVE_PATTERN, include_remotes=False)
+        == []
+    )
+
+
+def test_select_branches_grouped_picks_newest_per_group(repository):
+    repository.create_branch("update/docs.2019-10-10")
+    repository.create_branch("update/docs.2019-10-10-01")
+    repository.create_branch("update/assets.2019-10-11")
+    repository.create_branch("unrelated")
+
+    branches = select_branches(repository, UPDATE_PATTERN, group_by="role")
+
+    assert branches == ["update/docs.2019-10-10-01", "update/assets.2019-10-11"]

--- a/taf/tests/test_merge/conftest.py
+++ b/taf/tests/test_merge/conftest.py
@@ -1,0 +1,96 @@
+import json
+import shutil
+import uuid
+
+import pytest
+
+from taf.api.repository import create_repository
+from taf.api.targets import register_target_files
+from taf.auth_repo import AuthenticationRepository
+from taf.git import GitRepository
+from taf.tests.conftest import NO_YUBIKEYS_INPUT
+from taf.utils import on_rm_error
+
+
+@pytest.fixture
+def merge_root(repo_dir):
+    root = repo_dir / f"test_merge_{uuid.uuid4()}"
+    root.mkdir(parents=True)
+    yield root
+    shutil.rmtree(root, onerror=on_rm_error)
+
+
+def _git_repo_with_origin(merge_root, name):
+    path = merge_root / "namespace" / name
+    path.mkdir(parents=True)
+    repo = GitRepository(path=path)
+    repo.init_repo()
+    repo.commit_empty("Initial commit")
+
+    origin_path = merge_root / "origin" / "namespace" / name
+    origin = GitRepository(path=origin_path)
+    origin.clone_from_disk(repo.path, is_bare=True)
+    repo.urls = [str(origin_path)]
+    repo._git("remote add origin {}", str(origin_path))
+    repo.push(repo.default_branch, set_upstream=True)
+    return repo
+
+
+@pytest.fixture
+def target1_repo(merge_root):
+    return _git_repo_with_origin(merge_root, "target1")
+
+
+@pytest.fixture
+def target2_repo(merge_root):
+    return _git_repo_with_origin(merge_root, "target2")
+
+
+@pytest.fixture
+def merge_auth_repo(
+    merge_root, target1_repo, target2_repo, keystore_delegations, pin_manager
+):
+    """An authentication repository with two non-delegated target repositories."""
+    auth_path = merge_root / "auth"
+    auth_path.mkdir(parents=True)
+
+    create_repository(
+        str(auth_path),
+        pin_manager,
+        roles_key_infos=str(NO_YUBIKEYS_INPUT),
+        keystore=keystore_delegations,
+        commit=True,
+        test=True,
+    )
+    auth_repo = AuthenticationRepository(path=auth_path, pin_manager=pin_manager)
+
+    targets_dir = auth_path / "targets"
+    (targets_dir / "repositories.json").write_text(
+        json.dumps(
+            {
+                "repositories": {
+                    "namespace/target1": {"custom": {"type": "targets"}},
+                    "namespace/target2": {"custom": {"type": "targets"}},
+                }
+            }
+        )
+    )
+    (targets_dir / "mirrors.json").write_text(
+        json.dumps({"mirrors": ["https://github.com/{org_name}/{repo_name}.git"]})
+    )
+    (targets_dir / "namespace").mkdir(parents=True)
+    for name, repo in (("target1", target1_repo), ("target2", target2_repo)):
+        (targets_dir / "namespace" / name).write_text(
+            json.dumps(
+                {"branch": repo.default_branch, "commit": repo.head_commit().value}
+            )
+        )
+    register_target_files(
+        path=auth_path,
+        pin_manager=pin_manager,
+        keystore=keystore_delegations,
+        commit=True,
+        push=False,
+        auth_repo=auth_repo,
+    )
+    return auth_repo

--- a/taf/tests/test_merge/test_merge_branch_commits.py
+++ b/taf/tests/test_merge/test_merge_branch_commits.py
@@ -1,0 +1,314 @@
+import json
+
+from freezegun import freeze_time
+
+from taf.api.merge import merge_branch_commits
+from taf.api.targets import register_target_files
+from taf.exceptions import MergeError
+from taf.models.merge import build_policy
+
+BRANCH_PATTERN = r"^spec/(?P<date>\d{4}-\d{2}-\d{2})(?P<idx>-\d{2})?$"
+SOURCE_BRANCH = "spec/2024-01-05"
+GATED_POLICY = build_policy(
+    branch_pattern=BRANCH_PATTERN, gate="codified-date", no_capstone_roles=["targets"]
+)
+UNGATED_POLICY = build_policy(
+    branch_pattern=BRANCH_PATTERN, no_capstone_roles=["targets"]
+)
+
+
+def _write_target(auth_repo, name, repo, gate_date=None, destination=None):
+    target_file = auth_repo.path / "targets" / "namespace" / name
+    data = {
+        "branch": destination or repo.default_branch,
+        "commit": repo.head_commit().value,
+    }
+    if gate_date is not None:
+        data["codified-date"] = gate_date
+    target_file.write_text(json.dumps(data))
+
+
+def _sign(merge_auth_repo, keystore_delegations, pin_manager):
+    register_target_files(
+        path=merge_auth_repo.path,
+        pin_manager=pin_manager,
+        keystore=keystore_delegations,
+        commit=True,
+        push=False,
+        auth_repo=merge_auth_repo,
+        update_snapshot_and_timestamp=False,
+    )
+
+
+def _build_source_branch(
+    merge_auth_repo,
+    target1_repo,
+    keystore_delegations,
+    pin_manager,
+    dates,
+    destination=None,
+):
+    default_branch = merge_auth_repo.default_branch
+    merge_auth_repo.checkout_branch(default_branch)
+    merge_auth_repo.create_and_checkout_branch(SOURCE_BRANCH)
+
+    target1_repo.checkout_branch(target1_repo.default_branch)
+    target1_repo.create_and_checkout_branch(SOURCE_BRANCH)
+
+    for i, gate_date in enumerate(dates):
+        target1_repo.commit_empty(f"target1 commit {i}")
+        _write_target(merge_auth_repo, "target1", target1_repo, gate_date, destination)
+        _sign(merge_auth_repo, keystore_delegations, pin_manager)
+
+    merge_auth_repo.checkout_branch(default_branch)
+
+
+def test_merge_branch_commits_gated_by_date(
+    merge_auth_repo, target1_repo, keystore_delegations, pin_manager, merge_root
+):
+    with freeze_time("2024-01-05"):
+        _build_source_branch(
+            merge_auth_repo,
+            target1_repo,
+            keystore_delegations,
+            pin_manager,
+            dates=["2024-01-05", "2024-01-10"],
+        )
+
+        default_branch = merge_auth_repo.default_branch
+        default_head_before = merge_auth_repo.top_commit_of_branch(default_branch)
+
+        merge_branch_commits(
+            path=str(merge_auth_repo.path),
+            pin_manager=pin_manager,
+            policy=GATED_POLICY,
+            library_dir=str(merge_root),
+            keystore=keystore_delegations,
+            deploy=False,
+        )
+
+        target1_default_commits = target1_repo.all_commits_on_branch(
+            branch=target1_repo.default_branch
+        )
+        assert len(target1_default_commits) == 2
+
+        default_head_after = merge_auth_repo.top_commit_of_branch(default_branch)
+        assert default_head_after != default_head_before
+
+    with freeze_time("2024-01-10"):
+        merge_branch_commits(
+            path=str(merge_auth_repo.path),
+            pin_manager=pin_manager,
+            policy=GATED_POLICY,
+            library_dir=str(merge_root),
+            keystore=keystore_delegations,
+            deploy=False,
+        )
+
+        target1_default_commits = target1_repo.all_commits_on_branch(
+            branch=target1_repo.default_branch
+        )
+        assert len(target1_default_commits) == 3
+
+
+def test_merge_branch_commits_is_idempotent(
+    merge_auth_repo, target1_repo, keystore_delegations, pin_manager, merge_root
+):
+    with freeze_time("2024-01-05"):
+        _build_source_branch(
+            merge_auth_repo,
+            target1_repo,
+            keystore_delegations,
+            pin_manager,
+            dates=["2024-01-05"],
+        )
+
+        merge_branch_commits(
+            path=str(merge_auth_repo.path),
+            pin_manager=pin_manager,
+            policy=GATED_POLICY,
+            library_dir=str(merge_root),
+            keystore=keystore_delegations,
+            deploy=False,
+        )
+
+        default_branch = merge_auth_repo.default_branch
+        head_after_first_merge = merge_auth_repo.top_commit_of_branch(default_branch)
+
+        merge_branch_commits(
+            path=str(merge_auth_repo.path),
+            pin_manager=pin_manager,
+            policy=GATED_POLICY,
+            library_dir=str(merge_root),
+            keystore=keystore_delegations,
+            deploy=False,
+        )
+
+        assert (
+            merge_auth_repo.top_commit_of_branch(default_branch)
+            == head_after_first_merge
+        )
+
+
+def test_merge_branch_commits_no_matching_branch_is_noop(
+    merge_auth_repo, pin_manager, keystore_delegations, merge_root
+):
+    default_branch = merge_auth_repo.default_branch
+    head_before = merge_auth_repo.top_commit_of_branch(default_branch)
+
+    merge_branch_commits(
+        path=str(merge_auth_repo.path),
+        pin_manager=pin_manager,
+        policy=UNGATED_POLICY,
+        library_dir=str(merge_root),
+        keystore=keystore_delegations,
+        deploy=False,
+    )
+
+    assert merge_auth_repo.top_commit_of_branch(default_branch) == head_before
+
+
+def test_merge_branch_commits_pushed_branch_filter_short_circuits(
+    merge_auth_repo, target1_repo, keystore_delegations, pin_manager, merge_root
+):
+    with freeze_time("2024-01-05"):
+        _build_source_branch(
+            merge_auth_repo,
+            target1_repo,
+            keystore_delegations,
+            pin_manager,
+            dates=["2024-01-05"],
+        )
+
+        default_branch = merge_auth_repo.default_branch
+        head_before = merge_auth_repo.top_commit_of_branch(default_branch)
+
+        merge_branch_commits(
+            path=str(merge_auth_repo.path),
+            pin_manager=pin_manager,
+            policy=GATED_POLICY,
+            library_dir=str(merge_root),
+            pushed_branch="unrelated-branch",
+            keystore=keystore_delegations,
+            deploy=False,
+        )
+
+        assert merge_auth_repo.top_commit_of_branch(default_branch) == head_before
+
+
+def test_merge_branch_commits_repo_not_touched_drops_out(
+    merge_auth_repo,
+    target1_repo,
+    target2_repo,
+    keystore_delegations,
+    pin_manager,
+    merge_root,
+):
+    """A repo whose declared commit does not change (e.g. rdf that was not
+    rebuilt) participates in signing but nothing moves for it."""
+    default_branch = merge_auth_repo.default_branch
+    merge_auth_repo.checkout_branch(default_branch)
+    merge_auth_repo.create_and_checkout_branch(SOURCE_BRANCH)
+
+    target1_repo.checkout_branch(target1_repo.default_branch)
+    target1_repo.create_and_checkout_branch(SOURCE_BRANCH)
+    target2_repo.checkout_branch(target2_repo.default_branch)
+    target2_repo.create_and_checkout_branch(SOURCE_BRANCH)
+
+    with freeze_time("2024-01-05"):
+        target1_repo.commit_empty("target1 commit 0")
+        target2_repo.commit_empty("target2 commit 0")
+        _write_target(merge_auth_repo, "target1", target1_repo)
+        _write_target(merge_auth_repo, "target2", target2_repo)
+        _sign(merge_auth_repo, keystore_delegations, pin_manager)
+
+        target1_repo.commit_empty("target1 commit 1")
+        _write_target(merge_auth_repo, "target1", target1_repo)
+        _sign(merge_auth_repo, keystore_delegations, pin_manager)
+
+        merge_auth_repo.checkout_branch(default_branch)
+
+        head_before = merge_auth_repo.top_commit_of_branch(default_branch)
+
+        merge_branch_commits(
+            path=str(merge_auth_repo.path),
+            pin_manager=pin_manager,
+            policy=UNGATED_POLICY,
+            library_dir=str(merge_root),
+            keystore=keystore_delegations,
+            deploy=False,
+        )
+
+        assert merge_auth_repo.top_commit_of_branch(default_branch) != head_before
+        assert (
+            len(target1_repo.all_commits_on_branch(branch=target1_repo.default_branch))
+            == 3
+        )
+        assert (
+            len(target2_repo.all_commits_on_branch(branch=target2_repo.default_branch))
+            == 2
+        )
+
+
+def test_merge_branch_commits_force_pushed_commit_raises(
+    merge_auth_repo, target1_repo, keystore_delegations, pin_manager, merge_root
+):
+    with freeze_time("2024-01-05"):
+        _build_source_branch(
+            merge_auth_repo,
+            target1_repo,
+            keystore_delegations,
+            pin_manager,
+            dates=["2024-01-05"],
+        )
+
+        target1_repo.checkout_branch(SOURCE_BRANCH)
+        target1_repo.reset_num_of_commits(1, hard=True)
+        target1_repo.checkout_branch(target1_repo.default_branch)
+
+        try:
+            merge_branch_commits(
+                path=str(merge_auth_repo.path),
+                pin_manager=pin_manager,
+                policy=UNGATED_POLICY,
+                library_dir=str(merge_root),
+                keystore=keystore_delegations,
+                deploy=False,
+            )
+            assert False, "expected MergeError"
+        except MergeError:
+            pass
+
+
+def test_merge_branch_commits_merges_commit_already_on_destination(
+    merge_auth_repo, target1_repo, keystore_delegations, pin_manager, merge_root
+):
+    """Update-branch shape: the target repo's commit is already on its
+    destination branch by the time the auth branch is built, so nothing
+    moves for it, but the auth commit is still merged."""
+    default_branch = merge_auth_repo.default_branch
+
+    target1_repo.checkout_branch(target1_repo.default_branch)
+    target1_repo.commit_empty("target1 commit 0")
+
+    merge_auth_repo.checkout_branch(default_branch)
+    merge_auth_repo.create_and_checkout_branch(SOURCE_BRANCH)
+    _write_target(merge_auth_repo, "target1", target1_repo)
+    _sign(merge_auth_repo, keystore_delegations, pin_manager)
+    merge_auth_repo.checkout_branch(default_branch)
+
+    head_before = merge_auth_repo.top_commit_of_branch(default_branch)
+
+    merge_branch_commits(
+        path=str(merge_auth_repo.path),
+        pin_manager=pin_manager,
+        policy=UNGATED_POLICY,
+        library_dir=str(merge_root),
+        keystore=keystore_delegations,
+        deploy=False,
+    )
+
+    assert merge_auth_repo.top_commit_of_branch(default_branch) != head_before
+    assert (
+        len(target1_repo.all_commits_on_branch(branch=target1_repo.default_branch)) == 2
+    )

--- a/taf/tests/test_merge/test_merge_branch_commits.py
+++ b/taf/tests/test_merge/test_merge_branch_commits.py
@@ -15,6 +15,11 @@ GATED_POLICY = build_policy(
 UNGATED_POLICY = build_policy(
     branch_pattern=BRANCH_PATTERN, no_capstone_roles=["targets"]
 )
+UNEVEN_LENGTHS_POLICY = build_policy(
+    branch_pattern=BRANCH_PATTERN,
+    no_capstone_roles=["targets"],
+    allow_uneven_branch_lengths=True,
+)
 
 
 def _write_target(auth_repo, name, repo, gate_date=None, destination=None):
@@ -233,7 +238,7 @@ def test_merge_branch_commits_repo_not_touched_drops_out(
         merge_branch_commits(
             path=str(merge_auth_repo.path),
             pin_manager=pin_manager,
-            policy=UNGATED_POLICY,
+            policy=UNEVEN_LENGTHS_POLICY,
             library_dir=str(merge_root),
             keystore=keystore_delegations,
             deploy=False,
@@ -248,6 +253,57 @@ def test_merge_branch_commits_repo_not_touched_drops_out(
             len(target2_repo.all_commits_on_branch(branch=target2_repo.default_branch))
             == 2
         )
+
+
+def test_merge_branch_commits_uneven_lengths_raises_by_default(
+    merge_auth_repo,
+    target1_repo,
+    target2_repo,
+    keystore_delegations,
+    pin_manager,
+    merge_root,
+):
+    """Without allow_uneven_branch_lengths, a repo whose commit count on the
+    source branch differs from the others is an error, not a silent drop-out -
+    the ordinary force-push signal that allow_uneven_branch_lengths is meant to
+    bypass only for a deliberately uneven case (e.g. rdf's rebuild commit)."""
+    default_branch = merge_auth_repo.default_branch
+    merge_auth_repo.checkout_branch(default_branch)
+    merge_auth_repo.create_and_checkout_branch(SOURCE_BRANCH)
+
+    target1_repo.checkout_branch(target1_repo.default_branch)
+    target1_repo.create_and_checkout_branch(SOURCE_BRANCH)
+    target2_repo.checkout_branch(target2_repo.default_branch)
+    target2_repo.create_and_checkout_branch(SOURCE_BRANCH)
+
+    with freeze_time("2024-01-05"):
+        target1_repo.commit_empty("target1 commit 0")
+        target2_repo.commit_empty("target2 commit 0")
+        _write_target(merge_auth_repo, "target1", target1_repo)
+        _write_target(merge_auth_repo, "target2", target2_repo)
+        _sign(merge_auth_repo, keystore_delegations, pin_manager)
+
+        target1_repo.commit_empty("target1 commit 1")
+        _write_target(merge_auth_repo, "target1", target1_repo)
+        _sign(merge_auth_repo, keystore_delegations, pin_manager)
+
+        merge_auth_repo.checkout_branch(default_branch)
+        head_before = merge_auth_repo.top_commit_of_branch(default_branch)
+
+        try:
+            merge_branch_commits(
+                path=str(merge_auth_repo.path),
+                pin_manager=pin_manager,
+                policy=UNGATED_POLICY,
+                library_dir=str(merge_root),
+                keystore=keystore_delegations,
+                deploy=False,
+            )
+            assert False, "expected MergeError"
+        except MergeError:
+            pass
+
+        assert merge_auth_repo.top_commit_of_branch(default_branch) == head_before
 
 
 def test_merge_branch_commits_force_pushed_commit_raises(

--- a/taf/tests/test_merge_policy.py
+++ b/taf/tests/test_merge_policy.py
@@ -25,6 +25,25 @@ def test_group_by_matching_a_real_group_is_accepted():
     assert policy.group_by == "role"
 
 
+def test_allow_uneven_branch_lengths_defaults_to_false():
+    policy = build_policy(branch_pattern=r"^rdf/publication/.*$")
+    assert policy.allow_uneven_branch_lengths is False
+
+
+def test_allow_uneven_branch_lengths_kebab_case_key():
+    policies = MergePolicies.from_mapping(
+        {
+            "policies": {
+                "rdf": {
+                    "branch-pattern": r"^rdf/publication/.*$",
+                    "allow-uneven-branch-lengths": True,
+                }
+            }
+        }
+    )
+    assert policies.resolve("rdf").allow_uneven_branch_lengths is True
+
+
 def test_from_mapping_converts_kebab_case_keys():
     policies = MergePolicies.from_mapping(
         {

--- a/taf/tests/test_merge_policy.py
+++ b/taf/tests/test_merge_policy.py
@@ -1,0 +1,92 @@
+import json
+
+import pytest
+
+from taf.exceptions import InvalidConfigError
+from taf.models.merge import (
+    DEFAULT_POLICIES,
+    MergePolicies,
+    build_policy,
+    resolve_policy,
+)
+
+
+def test_group_by_must_name_an_existing_group():
+    with pytest.raises(InvalidConfigError):
+        build_policy(
+            branch_pattern=r"^update/(?P<role>\w+)\.\w+$", group_by="nonexistent"
+        )
+
+
+def test_group_by_matching_a_real_group_is_accepted():
+    policy = build_policy(
+        branch_pattern=r"^update/(?P<role>\w+)\.\w+$", group_by="role"
+    )
+    assert policy.group_by == "role"
+
+
+def test_from_mapping_converts_kebab_case_keys():
+    policies = MergePolicies.from_mapping(
+        {
+            "policies": {
+                "speculative": {
+                    "branch-pattern": r"^publication/.*$",
+                    "gate": "codified-date",
+                    "no-capstone-roles": ["docs", "assets"],
+                }
+            }
+        }
+    )
+    policy = policies.resolve("speculative")
+    assert policy.branch_pattern == r"^publication/.*$"
+    assert policy.gate == "codified-date"
+    assert policy.no_capstone_roles == ["docs", "assets"]
+
+
+def test_resolve_falls_back_to_default_when_not_in_file():
+    policies = MergePolicies.from_mapping({"policies": {}})
+    assert policies.resolve("speculative") == DEFAULT_POLICIES["speculative"]
+
+
+def test_resolve_unknown_policy_raises():
+    policies = MergePolicies.from_mapping({"policies": {}})
+    with pytest.raises(InvalidConfigError):
+        policies.resolve("nonexistent")
+
+
+def test_partner_override_replaces_only_named_fields():
+    policies = MergePolicies.from_mapping(
+        {
+            "policies": {},
+            "partners": {"DCCouncil/law": {"speculative": {"gate": None}}},
+        }
+    )
+    policy = policies.resolve("speculative", partner_name="DCCouncil/law")
+    assert policy.gate is None
+    assert policy.branch_pattern == DEFAULT_POLICIES["speculative"].branch_pattern
+
+    assert (
+        policies.resolve("speculative", partner_name="other/law")
+        == DEFAULT_POLICIES["speculative"]
+    )
+
+
+def test_resolve_policy_prefers_config_path_over_defaults(tmp_path):
+    config_path = tmp_path / "merge-policies.json"
+    config_path.write_text(
+        json.dumps({"policies": {"speculative": {"branch-pattern": r"^custom/.*$"}}})
+    )
+
+    policy = resolve_policy("speculative", config_path=str(config_path))
+
+    assert policy.branch_pattern == r"^custom/.*$"
+
+
+def test_resolve_policy_uses_built_in_default_when_nothing_else_available():
+    policy = resolve_policy("update")
+    assert policy == DEFAULT_POLICIES["update"]
+
+
+def test_resolve_policy_unknown_name_without_config_raises():
+    with pytest.raises(InvalidConfigError):
+        resolve_policy("nonexistent")

--- a/taf/tools/branch/__init__.py
+++ b/taf/tools/branch/__init__.py
@@ -1,0 +1,135 @@
+import click
+
+from taf.api.merge import merge_branch_commits
+from taf.auth_repo import AuthenticationRepository
+from taf.exceptions import TAFError
+from taf.models.merge import (
+    build_policy,
+    locate_root_auth_repo,
+    partner_name,
+    resolve_policy,
+)
+from taf.tools.cli import catch_cli_exception, find_repository
+from taf.yubikey.yubikey_manager import pin_managed
+
+
+def merge_command():
+    @click.command(
+        name="merge",
+        help="""
+        Merge commits of a batch branch - a branch in the authentication repository
+        whose commits each authenticate one commit of one or more target repositories,
+        such as a speculative, publication or update branch - into each participating
+        target repository's destination branch.
+
+        Which repositories participate, what commit each merges to, its destination
+        branch and any date gate are read directly from the authentication repository's
+        signed target files. --policy selects a named policy (built in, or read from
+        --config or a root authentication repository's signed merge-policies.json) that
+        supplies the rest: the branch name pattern, and any capstone role rules.
+        --branch-pattern is a config-free escape hatch that runs with a policy of just
+        that pattern.
+        """,
+    )
+    @find_repository
+    @catch_cli_exception(handle=TAFError)
+    @click.option(
+        "--path",
+        default=".",
+        help="Authentication repository's location. If not specified, set to the current directory",
+    )
+    @click.option(
+        "--library-dir",
+        default=None,
+        help="Directory containing the target repositories. If not specified, calculated based on the authentication repository's path",
+    )
+    @click.option(
+        "--policy",
+        "policy_name",
+        default=None,
+        help="Name of the merge policy to apply (e.g. speculative, rdf, update)",
+    )
+    @click.option(
+        "--branch-pattern",
+        default=None,
+        help="Config-free escape hatch: run with a policy of just this branch pattern",
+    )
+    @click.option(
+        "--config",
+        "config_path",
+        default=None,
+        help="Path to a local merge-policies.json-shaped file",
+    )
+    @click.option(
+        "--root-auth",
+        "root_auth_path",
+        default=None,
+        help="Path to the root authentication repository whose signed targets/merge-policies.json should be used",
+    )
+    @click.option(
+        "--pushed-branch",
+        default=None,
+        help="If given, this call is a no-op unless it matches the policy's branch pattern",
+    )
+    @click.option("--keystore", default=None, help="Location of the keystore files")
+    @click.option(
+        "--deploy",
+        is_flag=True,
+        default=False,
+        help="Push changes to the remote after merging",
+    )
+    @click.option(
+        "--git-access-token",
+        default=None,
+        help="Access token used to change a target repository's default branch",
+    )
+    @pin_managed
+    def merge(
+        path,
+        library_dir,
+        policy_name,
+        branch_pattern,
+        config_path,
+        root_auth_path,
+        pushed_branch,
+        keystore,
+        deploy,
+        git_access_token,
+        pin_manager,
+    ):
+        if branch_pattern:
+            policy = build_policy(branch_pattern=branch_pattern)
+        else:
+            if not policy_name:
+                raise click.UsageError(
+                    "One of --policy or --branch-pattern is required"
+                )
+            root_auth_repo = None
+            partner = None
+            if config_path is None:
+                root_auth_repo = locate_root_auth_repo(library_dir, root_auth_path)
+                if root_auth_repo is not None:
+                    partner = partner_name(AuthenticationRepository(path=path))
+            policy = resolve_policy(
+                policy_name,
+                config_path=config_path,
+                root_auth_repo=root_auth_repo,
+                partner_name=partner,
+            )
+
+        merge_branch_commits(
+            path=path,
+            pin_manager=pin_manager,
+            policy=policy,
+            library_dir=library_dir,
+            pushed_branch=pushed_branch,
+            keystore=keystore,
+            deploy=deploy,
+            git_access_token=git_access_token,
+        )
+
+    return merge
+
+
+def attach_to_group(group):
+    group.add_command(merge_command())

--- a/taf/tools/cli/taf.py
+++ b/taf/tools/cli/taf.py
@@ -12,6 +12,7 @@ def taf_command_loader(name):
             "metadata",
             "roles",
             "repo",
+            "branch",
         ):
             return f"taf.tools.{name}.attach_to_group"
         else:
@@ -31,6 +32,7 @@ def taf_command_loader(name):
         "keystore": lambda: taf_command_loader("keystore"),
         "conf": lambda: taf_command_loader("conf"),
         "repo": lambda: taf_command_loader("repo"),
+        "branch": lambda: taf_command_loader("branch"),
         "targets": lambda: taf_command_loader("targets"),
         "metadata": lambda: taf_command_loader("metadata"),
         "roles": lambda: taf_command_loader("roles"),

--- a/taf/validation.py
+++ b/taf/validation.py
@@ -104,13 +104,21 @@ def validate_branch(
                     and commit_index == len(auth_commits) - 1,
                 )
 
-            for target, target_commits in targets_and_commits.items():
+            # targets' commits match the target commits specified in the authentication
+            # repository - checked for every target repo, in a fixed order, so that a
+            # step with multiple mismatching repos is reported deterministically and in full
+            mismatches = []
+            for target, target_commits in sorted(
+                targets_and_commits.items(), key=lambda item: item[0].name
+            ):
                 target_commit = target_commits[commit_index]
-
-                # targets' commits match the target commits specified in the authentication repository
-                _compare_commit_with_targets_metadata(
+                mismatch = _compare_commit_with_targets_metadata(
                     auth_repo, auth_commit, target, target_commit
                 )
+                if mismatch:
+                    mismatches.append(mismatch)
+            if mismatches:
+                raise InvalidBranchError("\n".join(mismatches))
 
 
 def _check_lengths_of_branches(targets_and_commits, branch_name):
@@ -216,23 +224,23 @@ def _compare_commit_with_targets_metadata(
 ):
     """
     Check if commit sha of a repository's speculative branch commit matches the
-    specified target value in its target file.
+    specified target value in its target file. Returns an error message describing
+    the mismatch, or None if the commit matches.
     """
     repo_name = f"{TARGETS_DIRECTORY_NAME}/{target_repo.name}"
     try:
         targets_head_sha = tuf_repo.get_json(tuf_commit, repo_name)["commit"]
     except GitError:
         if target_repo_commit is not None:
-            raise InvalidBranchError(
-                f"Target file {repo_name} does not exist in revision {tuf_commit}"
-            )
+            return f"Target file {repo_name} does not exist in revision {tuf_commit}"
         targets_head_sha = None
 
     if target_repo_commit != targets_head_sha:
-        raise InvalidBranchError(
+        return (
             f"Commit {target_repo_commit} of repository {target_repo.name} does "
             "not match the commit sha specified in its target file!"
         )
+    return None
 
 
 def _get_unchanged_targets_metadata(auth_repo, updated_roles):


### PR DESCRIPTION
CI's merge job reimplements, per branch type, work that belongs in taf: walking an authentication repository's unmerged commits by metadata version (git reachability alone can't tell what's merged, since auth commits are re-signed onto the default branch rather than fast-forwarded), fast-forwarding each target repository to its declared commit, and validating the result before push. Everything else - which repos participate, which branch each merges into, what date gates a commit - was hardcoded per branch type (publication vs rdf vs update) even though it's already present in the auth repo's signed target files: each target's commit, branch and gate date are recorded there per auth commit.

Add `taf branch merge`, driven by that data: a repo participates when its declared commit isn't yet reachable from its declared destination, so a repo untouched by a given commit (e.g. rdf not rebuilt) drops out on its own instead of needing a repo-type filter. The one thing not in that data - branch name patterns, capstone role policy - comes from a named MergePolicy, resolved from an explicit --config file, a root authentication repository's signed targets/merge-policies.json, or a built-in default, so per-repo behaviour can change without re-signing every partner repository. Update branches (single commit, no fan-out) fall out of the same model rather than needing a second command: their target commit is already on its destination by the time the branch is built, so nothing moves but the auth commit still gets signed.

branches.py gains select_branches, reusing the existing reachability-aware branch walk per group (e.g. one update branch per role) instead of a name-only sort, and find_unmerged_auth_commits drops its role parameter in favor of reading each commit's own changed metadata files.

## Description (e.g. "Related to ...", etc.)

_Please replace this description with a concise description of this Pull Request._

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
