### PR TITLE
fix: pass url as a {} arg in _get_default_branch_from_remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ### Fixed
 
+- Determine the default branch from a local (`--from-fs`) path containing a space, instead of failing ([780])
 - Fix YubiKey caching bugs that could skip a valid signing key for a delegated role ([775])
 - Disallowing unauthenticated commits no longer invalidates already-signed history ([774])
 - Allow `--key-pin` with multiple YubiKeys inserted ([770])
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning][semver].
 - Correct the clone access error that rendered as "Cannot None ..." and stop misattributing a local failure to an access/authentication problem ([762])
 
 
+[780]: https://github.com/openlawlibrary/taf/pull/780
 [775]: https://github.com/openlawlibrary/taf/pull/775
 [774]: https://github.com/openlawlibrary/taf/pull/774
 [771]: https://github.com/openlawlibrary/taf/pull/771

--- a/taf/git.py
+++ b/taf/git.py
@@ -430,8 +430,11 @@ class GitRepository:
                 self,
                 message="Could not get default branch from remote. Not a git repository",
             )
+        # url as a `{}` arg keeps it one token even with spaces (e.g. a
+        # --from-fs local path under a spaced home directory)
         branch = self._git(
-            f"ls-remote --symref {url} HEAD",
+            "ls-remote --symref {} HEAD",
+            url,
             log_error=True,
             log_error_msg="Unable to get default branch from remote",
             reraise_error=True,

--- a/taf/tests/test_git/test_clone_errors.py
+++ b/taf/tests/test_git/test_clone_errors.py
@@ -103,6 +103,16 @@ def test_clone_from_disk_with_spaced_source_path(repository: GitRepository, tmp_
     assert repo.is_git_repository
 
 
+def test_get_default_branch_from_remote_with_spaced_local_url(
+    repository: GitRepository, tmp_path
+):
+    spaced_origin = Path(tmp_path) / "Given Surname" / "origin"
+    GitRepository(path=spaced_origin).clone_from_disk(repository.path, is_bare=True)
+
+    branch = repository.get_default_branch(url=str(spaced_origin))
+    assert branch == repository.default_branch
+
+
 def test_git_subprocess_handles_spaced_repo_path(tmp_path):
     # A local git operation that actually shells out (via _git -> run) must
     # tolerate a repository path with spaces. The repo is initialised through


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

 fix: pass url as a {} arg in _get_default_branch_from_remote, so a local path with a space isn't split

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
