### PR TITLE
fix: retry os.replace on Windows PermissionError

### DIFF
--- a/taf/__init__.py
+++ b/taf/__init__.py
@@ -2,6 +2,10 @@
 
 import sys
 
+from taf.utils import patch_os_replace_with_windows_retry
+
+patch_os_replace_with_windows_retry()
+
 
 class YubikeyMissingLibrary:
     """If `yubikey-manager` is not installed and we try to use any function from `taf.yubikey`

--- a/taf/tests/test_utils.py
+++ b/taf/tests/test_utils.py
@@ -3,11 +3,13 @@ import os
 import pytest
 from pathlib import Path
 
+import taf.utils as taf_utils
 from taf.utils import (
     TempPartition,
     _background_cleanup_threads,
     format_command_args,
     normalize_line_endings,
+    patch_os_replace_with_windows_retry,
     safely_save_json_to_disk,
     safely_move_file,
 )
@@ -26,6 +28,64 @@ def test_format_command_args_drops_empty_args():
 def test_format_command_args_fills_multiple_placeholders_in_one_token():
     tokens = format_command_args("update-ref refs/heads/{}/{} {}", "a", "b", "c")
     assert tokens == ["update-ref", "refs/heads/a/b", "c"]
+
+
+@pytest.fixture
+def windows(monkeypatch):
+    monkeypatch.setattr(taf_utils.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(taf_utils, "_os_replace_patched", False)
+
+
+def _counting_replace(fail_times):
+    calls = {"n": 0}
+
+    def replace(src, dst, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] <= fail_times:
+            raise PermissionError
+        return "ok"
+
+    return replace, calls
+
+
+def test_patch_os_replace_with_windows_retry_is_noop_off_windows(monkeypatch):
+    monkeypatch.setattr(taf_utils.platform, "system", lambda: "Linux")
+    original = os.replace
+
+    patch_os_replace_with_windows_retry()
+
+    assert os.replace is original
+
+
+def test_patch_os_replace_with_windows_retry_retries_transient_failure(
+    windows, monkeypatch
+):
+    replace, calls = _counting_replace(fail_times=2)
+    monkeypatch.setattr(os, "replace", replace)
+    patch_os_replace_with_windows_retry(retries=5, delay=0)
+
+    assert os.replace("a", "b") == "ok"
+    assert calls["n"] == 3
+
+
+def test_patch_os_replace_with_windows_retry_reraises_persistent_failure(
+    windows, monkeypatch
+):
+    replace, calls = _counting_replace(fail_times=float("inf"))
+    monkeypatch.setattr(os, "replace", replace)
+    patch_os_replace_with_windows_retry(retries=3, delay=0)
+
+    with pytest.raises(PermissionError):
+        os.replace("a", "b")
+    assert calls["n"] == 3
+
+
+def test_patch_os_replace_with_windows_retry_is_idempotent(windows):
+    patch_os_replace_with_windows_retry()
+    wrapped = os.replace
+    patch_os_replace_with_windows_retry()
+
+    assert os.replace is wrapped
 
 
 def test_normalize_line_ending_extra_lines():

--- a/taf/utils.py
+++ b/taf/utils.py
@@ -319,6 +319,39 @@ def normalize_line_endings(file_content):
     return replaced_content
 
 
+_os_replace_patched = False
+
+
+def patch_os_replace_with_windows_retry(retries: int = 5, delay: float = 0.1) -> None:
+    """On Windows, os.replace() can transiently fail with WinError 5 (Access
+    is denied) when another process (commonly antivirus) briefly holds a
+    handle on the source or destination file. python-tuf's own atomic
+    metadata writes (tuf.ngclient.updater) call os.replace() with no retry
+    of their own, so this failure surfaces as a validation error instead of
+    the transient hiccup it usually is. Wraps the stdlib os.replace with a
+    short retry so that case recovers on its own. No-op on non-Windows
+    platforms, and idempotent - calling this more than once won't stack
+    multiple retry wrappers.
+    """
+    global _os_replace_patched
+    if platform.system() != "Windows" or _os_replace_patched:
+        return
+
+    original_replace = os.replace
+
+    def _replace_with_retry(src, dst, *args, **kwargs):
+        for attempt in range(retries):
+            try:
+                return original_replace(src, dst, *args, **kwargs)
+            except PermissionError:
+                if attempt == retries - 1:
+                    raise
+                time.sleep(delay * (attempt + 1))
+
+    os.replace = _replace_with_retry
+    _os_replace_patched = True
+
+
 def on_rm_error(_func, path, _exc_info):
     """Used by when calling rmtree to ensure that readonly files and folders
     are deleted.


### PR DESCRIPTION
## Description (e.g. "Related to ...", etc.)

fix: retry os.replace on Windows PermissionError to survive transient file locks (e.g. antivirus)

## Code review checklist (for code reviewer to complete)

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated, as appropriate
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Changelog has been updated, as needed (see [CHANGELOG.md][changelog])

[changelog]: https://github.com/openlawlibrary/taf/blob/master/CHANGELOG.md
[commit messages]: https://chris.beams.io/posts/git-commit/
